### PR TITLE
🐛 Fix: use valid opencode tools schema in qwery-agent

### DIFF
--- a/agents/qwery-agent.md
+++ b/agents/qwery-agent.md
@@ -1,8 +1,14 @@
 ---
 name: qwery-agent
 description: "Expert database query agent with schema awareness. Converts natural language to SQL, validates queries against database schema, and provides efficient query execution. Supports schema versioning and time-travel queries. Uses GFS branching for safe destructive operations."
-tools: mcp__gfs__show_schema, mcp__gfs__query, mcp__gfs__extract_schema, mcp__gfs__diff_schema, mcp__gfs__checkout, mcp__gfs__commit, mcp__gfs__status
-disallowedTools: Read, Write, Edit, Bash, Glob, Grep
+tools:
+  mcp__gfs__show_schema: true
+  mcp__gfs__query: true
+  mcp__gfs__extract_schema: true
+  mcp__gfs__diff_schema: true
+  mcp__gfs__checkout: true
+  mcp__gfs__commit: true
+  mcp__gfs__status: true
 mcpServers: ["gfs"]
 memory: project
 skills:


### PR DESCRIPTION
## Related Issue
Closes #8

## What
Fixes the `qwery-agent` frontmatter so OpenCode can parse it correctly.

Previously, `tools` was defined as a comma-separated string and included a legacy `disallowedTools` field. OpenCode expects `tools` to be a record/object map.

## How
Updated `agents/qwery-agent.md` frontmatter to:
- Replace string `tools` with a YAML object map of tool names to booleans
- Remove `disallowedTools`

No runtime code changes were made; this is a config/template compatibility fix.

## Review Guide
1. Review [`agents/qwery-agent.md`](./agents/qwery-agent.md)
2. Check the frontmatter diff at the top of the file
3. Confirm no prompt body logic was altered

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

Manual validation:
- Installed agent copy at `~/.config/opencode/agents/qwery-agent.md` with the same change
- Confirmed OpenCode no longer errors with: `Invalid input: expected record, received string` for `tools`

## Documentation
- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact
- OpenCode can launch with `qwery-agent` after installation
- Prevents config parse failure caused by invalid `tools` schema
- No breaking changes expected

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests pass locally (`cargo test`)
- [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [ ] Format check passes (`cargo fmt --check`)
- [x] This PR can be safely reverted if needed
