### PR TITLE
feat: add --port flag to gfs init and gfs compute config db.port

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ cargo build
 Run commands using cargo:
 
 ```bash
-cargo run --bin gfs init --database-provider postgres --database-version 17
+cargo run --bin gfs init --database-provider postgres --database-version 17 [--port 65432]
 cargo run --bin gfs commit -m "v1"
 cargo run --bin gfs log
 cargo run --bin gfs status

--- a/crates/applications/cli/src/commands/cmd_compute.rs
+++ b/crates/applications/cli/src/commands/cmd_compute.rs
@@ -30,6 +30,7 @@ fn resolve_id(path: Option<PathBuf>, action: &ComputeAction) -> Result<String> {
         ComputeAction::Pause { id } => id.as_deref(),
         ComputeAction::Unpause { id } => id.as_deref(),
         ComputeAction::Logs { id, .. } => id.as_deref(),
+        ComputeAction::Config { .. } => return Ok(String::new()),
     };
     if let Some(id) = id_from_action {
         return Ok(id.to_string());
@@ -47,10 +48,37 @@ fn resolve_id(path: Option<PathBuf>, action: &ComputeAction) -> Result<String> {
 }
 
 pub async fn run(path: Option<PathBuf>, action: ComputeAction) -> Result<()> {
+    if let ComputeAction::Config { ref key, ref value } = action {
+        return handle_config(path, key, value);
+    }
     let compute = DockerCompute::new()
         .map_err(|e| anyhow::anyhow!("failed to connect to Docker/Podman daemon: {e}"))?;
     let id = resolve_id(path.clone(), &action)?;
     dispatch(&compute, &id, action, path).await
+}
+
+fn handle_config(path: Option<PathBuf>, key: &str, value: &str) -> Result<()> {
+    match key {
+        "db.port" => {
+            let port: u16 = value
+                .parse()
+                .map_err(|_| anyhow::anyhow!("'{}' is not a valid port number (1-65535)", value))?;
+            let repo_path = path.unwrap_or_else(get_repo_dir);
+            let mut config = GfsConfig::load(&repo_path)
+                .context("not a gfs repository (use --path <repo> or run from a repo)")?;
+            if let Some(ref mut env) = config.environment {
+                env.database_port = Some(port);
+            } else {
+                anyhow::bail!(
+                    "no environment config found; run 'gfs init --database-provider ...' first"
+                );
+            }
+            config.save(&repo_path).context("failed to save config")?;
+            println!("database_port updated to {port}. Run 'gfs compute restart' to apply.");
+            Ok(())
+        }
+        _ => anyhow::bail!("unknown config key '{}'; supported keys: db.port", key),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -124,6 +152,8 @@ async fn dispatch(
                 .map_err(anyhow::Error::from)?;
             print_status(&status);
         }
+
+        ComputeAction::Config { .. } => unreachable!("Config is handled before dispatch"),
 
         ComputeAction::Logs {
             tail,

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -15,6 +15,7 @@ pub async fn init(
     path: Option<PathBuf>,
     database_provider: Option<String>,
     database_version: Option<String>,
+    database_port: Option<u16>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing::trace!("Initializing Guepard environment at: {:?}", path);
 
@@ -28,7 +29,13 @@ pub async fn init(
 
     let use_case = InitRepositoryUseCase::new(repository, compute, registry);
     use_case
-        .run(target_path, None, database_provider, database_version)
+        .run(
+            target_path,
+            None,
+            database_provider,
+            database_version,
+            database_port,
+        )
         .await?;
 
     Ok(())

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -106,6 +106,13 @@ pub enum ComputeAction {
         #[arg(long, default_missing_value = "true", num_args = 0..=1)]
         stderr: Option<bool>,
     },
+    /// Read or write a compute config value (e.g. db.port)
+    Config {
+        /// Config key (currently only `db.port` is supported)
+        key: String,
+        /// Value to set
+        value: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +167,10 @@ enum TopLevel {
         /// Database version (e.g. 17 for postgres). Required when --database-provider is set.
         #[arg(long)]
         database_version: Option<String>,
+
+        /// Host port to bind for the database container (e.g. 5432). Default: Docker auto-assigns.
+        #[arg(long)]
+        port: Option<u16>,
     },
 
     /// Record a commit of the current repository state
@@ -449,8 +460,9 @@ where
                 path,
                 database_provider,
                 database_version,
+                port,
             } => {
-                commands::cmd_init::init(path, database_provider, database_version)
+                commands::cmd_init::init(path, database_provider, database_version, port)
                     .await
                     .map_err(|e| anyhow::anyhow!("{}", e))?;
                 Ok(0)

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -760,6 +760,7 @@ async fn do_init(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
             None,
             database_provider.clone(),
             database_version.clone(),
+            None,
         )
         .await
         .map_err(|e| to_error_data(e.to_string()))?;

--- a/crates/domain/src/model/config.rs
+++ b/crates/domain/src/model/config.rs
@@ -23,6 +23,8 @@ pub struct UserConfig {
 pub struct EnvironmentConfig {
     pub database_provider: String,
     pub database_version: String,
+    #[serde(default)]
+    pub database_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -152,6 +154,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 database_provider: "postgres".into(),
                 database_version: "17".into(),
+                database_port: Some(5432),
             }),
             runtime: Some(RuntimeConfig {
                 runtime_provider: "docker".into(),
@@ -167,6 +170,10 @@ mod tests {
         assert_eq!(
             loaded.environment.as_ref().unwrap().database_provider,
             "postgres"
+        );
+        assert_eq!(
+            loaded.environment.as_ref().unwrap().database_port,
+            Some(5432)
         );
         assert_eq!(loaded.runtime.as_ref().unwrap().container_name, "c1");
     }

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -904,6 +904,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 database_provider: "mock-db".into(),
                 database_version: "16".into(),
+                database_port: None,
             }),
             ..Default::default()
         };

--- a/crates/domain/src/usecases/repository/export_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/export_repo_usecase.rs
@@ -112,9 +112,15 @@ impl<R: DatabaseProviderRegistry> ExportRepoUseCase<R> {
                     )));
                 }
             } else {
-                // For non-existent paths, check that resolved path is within repo
-                // by ensuring it starts with the canonical repo path
-                if !resolved_output.starts_with(&canonical_path) {
+                // For non-existent paths the path can't be canonicalized directly.
+                // Canonicalize the nearest existing ancestor (usually the repo root itself)
+                // to resolve symlinks (e.g. /tmp → /private/tmp on macOS) before comparing.
+                let canonical_output = resolved_output
+                    .parent()
+                    .and_then(|p| std::fs::canonicalize(p).ok())
+                    .map(|p| p.join(resolved_output.file_name().unwrap_or_default()))
+                    .unwrap_or(resolved_output.clone());
+                if !canonical_output.starts_with(&canonical_path) {
                     return Err(ExportRepoError::Config(format!(
                         "output directory must be within repository: {}",
                         dir.display()
@@ -479,6 +485,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "postgres".into(),
             database_version: "17".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),
@@ -507,6 +514,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "postgres".into(),
             database_version: "17".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),
@@ -564,6 +572,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 database_provider: "postgres".into(),
                 database_version: "17".into(),
+                database_port: None,
             }),
             runtime: Some(RuntimeConfig {
                 runtime_provider: "docker".into(),
@@ -589,6 +598,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "mysql".into(),
             database_version: "8".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),
@@ -613,6 +623,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "postgres".into(),
             database_version: "17".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),

--- a/crates/domain/src/usecases/repository/extract_schema_usecase.rs
+++ b/crates/domain/src/usecases/repository/extract_schema_usecase.rs
@@ -745,6 +745,7 @@ GFS_SCHEMA_COLUMNS
             Some(EnvironmentConfig {
                 database_provider: "unknown-provider".into(),
                 database_version: "17".into(),
+                database_port: None,
             }),
             Some(RuntimeConfig {
                 runtime_provider: "docker".into(),
@@ -778,6 +779,7 @@ GFS_SCHEMA_COLUMNS
             Some(EnvironmentConfig {
                 database_provider: "mock-schema".into(),
                 database_version: "17".into(),
+                database_port: None,
             }),
             Some(RuntimeConfig {
                 runtime_provider: "docker".into(),
@@ -817,6 +819,7 @@ GFS_SCHEMA_COLUMNS
             Some(EnvironmentConfig {
                 database_provider: "mock-schema".into(),
                 database_version: "17".into(),
+                database_port: None,
             }),
             Some(RuntimeConfig {
                 runtime_provider: "docker".into(),
@@ -881,6 +884,7 @@ GFS_SCHEMA_COLUMNS
             Some(EnvironmentConfig {
                 database_provider: "mock-schema".into(),
                 database_version: "17".into(),
+                database_port: None,
             }),
             Some(RuntimeConfig {
                 runtime_provider: "docker".into(),

--- a/crates/domain/src/usecases/repository/import_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/import_repo_usecase.rs
@@ -547,6 +547,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "postgres".into(),
             database_version: "17".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),
@@ -575,6 +576,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "postgres".into(),
             database_version: "17".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),
@@ -601,6 +603,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "postgres".into(),
             database_version: "17".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),
@@ -625,6 +628,7 @@ mod tests {
         let env = EnvironmentConfig {
             database_provider: "postgres".into(),
             database_version: "17".into(),
+            database_port: None,
         };
         let runtime = RuntimeConfig {
             runtime_provider: "docker".into(),

--- a/crates/domain/src/usecases/repository/init_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/init_repo_usecase.rs
@@ -65,6 +65,7 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
         mount_point: Option<String>,
         database_provider: Option<String>,
         database_version: Option<String>,
+        database_port: Option<u16>,
     ) -> std::result::Result<(), InitRepoError> {
         self.repository.init(&path, mount_point).await?;
 
@@ -72,7 +73,8 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
             let version = database_version
                 .filter(|v| !v.is_empty())
                 .ok_or(InitRepoError::DatabaseVersionRequired)?;
-            self.deploy_database(&path, provider, version).await?;
+            self.deploy_database(&path, provider, version, database_port)
+                .await?;
         }
 
         Ok(())
@@ -83,6 +85,7 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
         repo_path: &std::path::Path,
         provider_name: String,
         database_version: String,
+        database_port: Option<u16>,
     ) -> std::result::Result<(), InitRepoError> {
         let list = self.registry.list();
         let matched_name = list
@@ -108,6 +111,14 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
             .unwrap_or(&definition.image);
         definition.image = format!("{}:{}", base, database_version);
 
+        if let Some(port) = database_port {
+            for mapping in &mut definition.ports {
+                if mapping.compute_port == provider.default_port() {
+                    mapping.host_port = Some(port);
+                }
+            }
+        }
+
         let workspace_data_dir = self
             .repository
             .get_workspace_data_dir_for_head(repo_path)
@@ -129,6 +140,7 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
         let environment = EnvironmentConfig {
             database_provider: provider_name,
             database_version,
+            database_port,
         };
         self.repository
             .update_environment_config(repo_path, environment)
@@ -528,7 +540,7 @@ mod tests {
         );
         let dir = tempfile::tempdir().unwrap();
         let result = usecase
-            .run(dir.path().to_path_buf(), None, None, None)
+            .run(dir.path().to_path_buf(), None, None, None, None)
             .await;
         assert!(result.is_ok());
     }
@@ -547,6 +559,7 @@ mod tests {
                 None,
                 Some("postgres".into()),
                 Some("17".into()),
+                None,
             )
             .await;
         assert!(result.is_ok());
@@ -565,6 +578,7 @@ mod tests {
                 dir.path().to_path_buf(),
                 None,
                 Some("postgres".into()),
+                None,
                 None,
             )
             .await;
@@ -588,6 +602,7 @@ mod tests {
                 None,
                 Some("mysql".into()),
                 Some("8".into()),
+                None,
             )
             .await;
         assert!(matches!(
@@ -607,11 +622,11 @@ mod tests {
         let path = dir.path().to_path_buf();
 
         // First init succeeds
-        let first = usecase.run(path.clone(), None, None, None).await;
+        let first = usecase.run(path.clone(), None, None, None, None).await;
         assert!(first.is_ok(), "first init should succeed: {:?}", first);
 
         // Second init fails with AlreadyInitialized
-        let second = usecase.run(path, None, None, None).await;
+        let second = usecase.run(path, None, None, None, None).await;
         assert!(
             matches!(
                 second,

--- a/crates/domain/src/usecases/repository/status_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/status_repo_usecase.rs
@@ -603,6 +603,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 database_provider: "postgres".into(),
                 database_version: "17".into(),
+                database_port: None,
             }),
             runtime: Some(RuntimeConfig {
                 runtime_provider: "docker".into(),


### PR DESCRIPTION
  - Add `database_port: Option<u16>` to `EnvironmentConfig` (serde default for backward compat)
  - `gfs init --port <N>` pins the Docker host port at provision time
  - `gfs compute config db.port <N>` updates the persisted port post-init
  - Fix macOS symlink bug in export output-dir validation (/tmp → /private/tmp)

<!--
Thank you for contributing to GFS!

Please follow the PR title conventions:
🎉 New Database Support: [name]
✨ Feature: add [description]
🐛 Fix: [description]
📝 Documentation update
🚨 Breaking change
-->

## Related Issue
<!-- 
Link the issue this PR addresses. If no issue exists, consider creating one first.
Closes #(issue number)
-->

## What
<!--
Describe what problem this change solves and why it's needed.
Provide background context for reviewers unfamiliar with this area.
-->

## How
<!--
Explain how your code changes achieve the solution.
Highlight key implementation decisions and any trade-offs made.
-->

## Review Guide
<!--
Help reviewers navigate your changes:
1. Start with `src/main.rs` - main logic changes
2. `src/lib.rs` - supporting changes
3. Skip `tests/integration.rs` - just test updates
-->

## Testing
<!--
How was this tested? What scenarios were covered?
- [ ] Manual testing performed
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
-->

## Documentation
<!--
- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)
-->

## User Impact
<!--
What's the end result for users?
- What improves?
- Are there any breaking changes or side effects?
-->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests pass locally (`cargo test`)
- [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [ ] Format check passes (`cargo fmt --check`)
- [ ] This PR can be safely reverted if needed