### PR TITLE
feat(cli): visual overhaul — retro ASCII art, Unicode box-drawing, polished output

### DIFF
--- a/crates/applications/cli/src/commands/cmd_checkout.rs
+++ b/crates/applications/cli/src/commands/cmd_checkout.rs
@@ -55,13 +55,15 @@ pub async fn checkout(
     let short_hash = &commit_hash[..7.min(commit_hash.len())];
     if let Some(ref name) = create_branch {
         println!(
-            "Switched to new branch '{}' ({})",
+            "{} Switched to new branch '{}' ({})",
+            green("✓"),
             green(name.trim()),
             dimmed(short_hash)
         );
     } else {
         println!(
-            "Switched to {} ({})",
+            "{} Switched to {} ({})",
+            green("✓"),
             cyan(revision.trim()),
             dimmed(short_hash)
         );

--- a/crates/applications/cli/src/commands/cmd_commit.rs
+++ b/crates/applications/cli/src/commands/cmd_commit.rs
@@ -12,7 +12,7 @@ use gfs_domain::ports::storage::StoragePort;
 use gfs_domain::usecases::repository::commit_repo_usecase::CommitRepoUseCase;
 
 use crate::cli_utils::get_repo_dir;
-use crate::output::{cyan, dimmed};
+use crate::output::{cyan, dimmed, green};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
@@ -85,5 +85,5 @@ async fn run(
 
 fn print_commit_result(branch: &str, hash: &str, message: &str) {
     let short = &hash[..7.min(hash.len())];
-    println!("[{}] {}  {}", cyan(branch), dimmed(short), message);
+    println!("{} [{}] {}  {}", green("✓"), cyan(branch), dimmed(short), message);
 }

--- a/crates/applications/cli/src/commands/cmd_compute.rs
+++ b/crates/applications/cli/src/commands/cmd_compute.rs
@@ -14,7 +14,7 @@ use gfs_domain::utils::current_user;
 
 use crate::ComputeAction;
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
-use crate::output::{dimmed, green, red, yellow};
+use crate::output::{bold, box_bottom, box_row, box_top, dimmed, green, red, yellow};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
@@ -75,7 +75,11 @@ fn handle_config(path: Option<PathBuf>, key: &str, value: &str) -> Result<()> {
                 );
             }
             config.save(&repo_path).context("failed to save config")?;
-            println!("database_port updated to {port}. Run 'gfs compute restart' to apply.");
+            println!(
+                "{} database_port updated to {}. Run 'gfs compute restart' to apply.",
+                green("✓"),
+                port
+            );
             Ok(())
         }
         _ => anyhow::bail!("unknown config key '{}'; supported keys: db.port", key),
@@ -100,23 +104,16 @@ async fn dispatch(
                 .status(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
-            if let Some(ref dir) = container_data_dir(compute, &instance_id, path.clone()).await {
-                let repo_path = path.clone().unwrap_or_else(get_repo_dir);
-                let rel = relativize_to_repo(&repo_path, dir);
-                println!("Container data dir : {rel}");
-            }
+            let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
         ComputeAction::Start { .. } => {
             let repo_path = path.clone().unwrap_or_else(get_repo_dir);
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, false).await?;
-            print_status(&status);
-            if let Some(ref dir) = container_data_dir(compute, &instance_id, path).await {
-                let rel = relativize_to_repo(&repo_path, dir);
-                println!("Container data dir : {rel}");
-            }
+            let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
         ComputeAction::Stop { .. } => {
@@ -124,18 +121,15 @@ async fn dispatch(
                 .stop(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
+            print_status(&status, None, path.as_ref());
         }
 
         ComputeAction::Restart { .. } => {
             let repo_path = path.clone().unwrap_or_else(get_repo_dir);
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, true).await?;
-            print_status(&status);
-            if let Some(ref dir) = container_data_dir(compute, &instance_id, path).await {
-                let rel = relativize_to_repo(&repo_path, dir);
-                println!("Container data dir : {rel}");
-            }
+            let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
         ComputeAction::Pause { .. } => {
@@ -143,7 +137,7 @@ async fn dispatch(
                 .pause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
+            print_status(&status, None, path.as_ref());
         }
 
         ComputeAction::Unpause { .. } => {
@@ -151,7 +145,7 @@ async fn dispatch(
                 .unpause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
+            print_status(&status, None, path.as_ref());
         }
 
         ComputeAction::Config { .. } => unreachable!("Config is handled before dispatch"),
@@ -202,21 +196,77 @@ async fn dispatch(
 }
 
 // ---------------------------------------------------------------------------
-// Display helper
+// Display helper — boxed status
 // ---------------------------------------------------------------------------
 
-fn print_status(s: &InstanceStatus) {
-    println!("id          : {}", dimmed(&s.id.0));
-    println!("state       : {}", format_state_colored(&s.state));
+const BOX_W: usize = 40;
+const LABEL_W: usize = 18;
+
+fn fmt_row(label: &str, value: &str) -> String {
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let padded_value = format!("{:<w$}", value, w = value_w);
+    format!("{} {}", dimmed(&padded_label), padded_value)
+}
+
+fn fmt_row_colored(label: &str, colored_value: &str, raw_value: &str) -> String {
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let remaining = value_w.saturating_sub(raw_value.chars().count());
+    format!(
+        "{} {}{}",
+        dimmed(&padded_label),
+        colored_value,
+        " ".repeat(remaining)
+    )
+}
+
+fn print_status(s: &InstanceStatus, data_dir: Option<&str>, path: Option<&PathBuf>) {
+    println!("{}", box_top(&bold("Compute"), BOX_W));
+
+    // ID
+    let truncated_id = truncate_id(&s.id.0);
+    let row = fmt_row_colored("id", &dimmed(&truncated_id), &truncated_id);
+    println!("{}", box_row(&row, BOX_W));
+
+    // State with dot indicator
+    let state_str = format_state(&s.state);
+    let dot = status_indicator_colored(&s.state);
+    let colored_state = format!("{} {}", dot, format_state_colored_text(&s.state));
+    let raw_state = format!("{} {}", status_indicator_raw(&s.state), state_str);
+    let row = fmt_row_colored("state", &colored_state, &raw_state);
+    println!("{}", box_row(&row, BOX_W));
+
+    // PID
     if let Some(pid) = s.pid {
-        println!("pid         : {pid}");
+        let pid_str = pid.to_string();
+        let row = fmt_row("pid", &pid_str);
+        println!("{}", box_row(&row, BOX_W));
     }
+
+    // Started at
     if let Some(started_at) = s.started_at {
-        println!("started_at  : {}", started_at.format("%Y-%m-%dT%H:%M:%SZ"));
+        let ts = started_at.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let row = fmt_row("started_at", &ts);
+        println!("{}", box_row(&row, BOX_W));
     }
+
+    // Exit code
     if let Some(code) = s.exit_code {
-        println!("exit_code   : {code}");
+        let code_str = code.to_string();
+        let row = fmt_row("exit_code", &code_str);
+        println!("{}", box_row(&row, BOX_W));
     }
+
+    // Container data dir
+    if let Some(dir) = data_dir {
+        let repo_path = path.cloned().unwrap_or_else(get_repo_dir);
+        let rel = relativize_to_repo(&repo_path, dir);
+        let row = fmt_row("data dir", &rel);
+        println!("{}", box_row(&row, BOX_W));
+    }
+
+    println!("{}", box_bottom(BOX_W));
 }
 
 fn format_state(state: &InstanceState) -> &'static str {
@@ -232,15 +282,40 @@ fn format_state(state: &InstanceState) -> &'static str {
     }
 }
 
-fn format_state_colored(state: &InstanceState) -> String {
+fn status_indicator_raw(state: &InstanceState) -> &'static str {
+    match state {
+        InstanceState::Running => "●",
+        InstanceState::Starting | InstanceState::Restarting => "◐",
+        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => "○",
+        InstanceState::Failed | InstanceState::Unknown => "✕",
+    }
+}
+
+fn status_indicator_colored(state: &InstanceState) -> String {
+    let dot = status_indicator_raw(state);
+    match state {
+        InstanceState::Running => green(dot),
+        InstanceState::Starting | InstanceState::Restarting => yellow(dot),
+        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => dimmed(dot),
+        InstanceState::Failed | InstanceState::Unknown => red(dot),
+    }
+}
+
+fn format_state_colored_text(state: &InstanceState) -> String {
     let s = format_state(state);
     match state {
-        InstanceState::Running => green(s).to_string(),
-        InstanceState::Starting | InstanceState::Restarting => yellow(s).to_string(),
-        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => {
-            dimmed(s).to_string()
-        }
-        InstanceState::Failed | InstanceState::Unknown => red(s).to_string(),
+        InstanceState::Running => green(s),
+        InstanceState::Starting | InstanceState::Restarting => yellow(s),
+        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => dimmed(s),
+        InstanceState::Failed | InstanceState::Unknown => red(s),
+    }
+}
+
+fn truncate_id(id: &str) -> String {
+    if id.len() <= 16 {
+        id.to_string()
+    } else {
+        format!("{}…", &id[..12])
     }
 }
 

--- a/crates/applications/cli/src/commands/cmd_export.rs
+++ b/crates/applications/cli/src/commands/cmd_export.rs
@@ -40,8 +40,8 @@ pub async fn run(
         .context("export failed")?;
 
     println!(
-        "{} {}",
-        green("Exported to"),
+        "{} Exported to {}",
+        green("✓"),
         cyan(output.file_path.display().to_string())
     );
     if !output.stderr.is_empty() {

--- a/crates/applications/cli/src/commands/cmd_import.rs
+++ b/crates/applications/cli/src/commands/cmd_import.rs
@@ -38,8 +38,8 @@ pub async fn run(
         .context("import failed")?;
 
     println!(
-        "{} {}",
-        green("Imported from"),
+        "{} Imported from {}",
+        green("✓"),
         cyan(output.imported_from.display().to_string())
     );
     if !output.stderr.is_empty() {

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -10,6 +10,7 @@ use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::init_repo_usecase::InitRepositoryUseCase;
 
 use crate::cli_utils::get_repo_dir;
+use crate::output::{cyan, dimmed, green};
 
 pub async fn init(
     path: Option<PathBuf>,
@@ -20,6 +21,7 @@ pub async fn init(
     tracing::trace!("Initializing Guepard environment at: {:?}", path);
 
     let target_path = path.unwrap_or_else(get_repo_dir);
+    let provider_display = database_provider.clone();
 
     let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
     let compute: Arc<dyn Compute> = Arc::new(DockerCompute::new()?);
@@ -30,13 +32,38 @@ pub async fn init(
     let use_case = InitRepositoryUseCase::new(repository, compute, registry);
     use_case
         .run(
-            target_path,
+            target_path.clone(),
             None,
             database_provider,
             database_version,
             database_port,
         )
         .await?;
+
+    // Success feedback
+    println!(
+        "  {} Initialized GFS repository at {}",
+        green("✓"),
+        cyan(target_path.display().to_string())
+    );
+    println!();
+    println!(
+        "    {:<16} {}",
+        dimmed("Branch"),
+        cyan("main")
+    );
+    println!(
+        "    {:<16} {}",
+        dimmed("Config"),
+        ".gfs/config.toml"
+    );
+    if let Some(ref provider) = provider_display {
+        println!(
+            "    {:<16} {}",
+            dimmed("Provider"),
+            cyan(provider)
+        );
+    }
 
     Ok(())
 }

--- a/crates/applications/cli/src/commands/cmd_log.rs
+++ b/crates/applications/cli/src/commands/cmd_log.rs
@@ -7,7 +7,7 @@ use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::log_repo_usecase::LogRepoUseCase;
 
 use crate::cli_utils::get_repo_dir;
-use crate::output::{dimmed, green};
+use crate::output::{dimmed, gold, green};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
@@ -44,7 +44,7 @@ pub async fn log(
 }
 
 // ---------------------------------------------------------------------------
-// Display (git-style format)
+// Display (graph-style format with ● dots and │ connector lines)
 // ---------------------------------------------------------------------------
 
 fn print_commit_block(cwr: &gfs_domain::model::commit::CommitWithRefs, full_hash: bool) {
@@ -54,45 +54,52 @@ fn print_commit_block(cwr: &gfs_domain::model::commit::CommitWithRefs, full_hash
         .as_deref()
         .unwrap_or("0000000000000000000000000000000000000000000000000000000000000000");
 
-    // Display short or full hash based on flag
     let hash_display =
         gfs_domain::repo_utils::repo_layout::format_commit_hash(hash_full, full_hash);
 
     let refs_str = if cwr.refs.is_empty() {
         String::new()
     } else {
-        format!(" ({})", cwr.refs.join(", "))
+        format!("  ({})", cwr.refs.join(", "))
     };
+
+    // Graph dot + hash + refs
     println!(
-        "{} {}{}",
-        dimmed("commit"),
+        "  {} {}{}",
+        gold("●"),
         dimmed(hash_display),
         green(refs_str)
     );
 
+    // Author line
+    let pipe = dimmed("│");
     let author = &cwr.commit.author;
     let author_email = cwr.commit.author_email.as_deref().unwrap_or("");
-    let author_line = if author_email.is_empty() {
-        format!("{} {}", dimmed("Author:"), author)
+    if author_email.is_empty() {
+        println!("  {} {} {}", pipe, dimmed("Author:"), author);
     } else {
-        format!(
-            "{} {} <{}>",
+        println!(
+            "  {} {} {} <{}>",
+            pipe,
             dimmed("Author:"),
             author,
             dimmed(author_email)
-        )
-    };
-    println!("{}", author_line);
+        );
+    }
 
+    // Date line
     let date_str = cwr.commit.author_date.format("%a %b %e %H:%M:%S %Y %z");
-    println!("{}   {}", dimmed("Date:"), date_str);
+    println!("  {} {}   {}", pipe, dimmed("Date:"), date_str);
 
-    println!();
+    // Blank separator
+    println!("  {}", pipe);
+
+    // Message body (indented)
     for line in cwr.commit.message.lines() {
-        println!("    {}", line);
+        println!("  {}     {}", pipe, line);
     }
     if !cwr.commit.message.ends_with('\n') && !cwr.commit.message.is_empty() {
-        println!();
+        println!("  {}", pipe);
     }
-    println!();
+    println!("  {}", pipe);
 }

--- a/crates/applications/cli/src/commands/cmd_providers.rs
+++ b/crates/applications/cli/src/commands/cmd_providers.rs
@@ -7,7 +7,10 @@ use gfs_domain::ports::database_provider::{
     DatabaseProviderRegistry, InMemoryDatabaseProviderRegistry, SupportedFeature,
 };
 
-use crate::output::{bold, cyan};
+use crate::output::{
+    bold, cyan, tbl_rule, TBL_BL, TBL_BR, TBL_T_DOWN, TBL_T_LEFT, TBL_T_RIGHT, TBL_T_UP,
+    TBL_TL, TBL_TR, TBL_V,
+};
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -70,84 +73,109 @@ fn print_provider_detail(registry: &impl DatabaseProviderRegistry, name: &str) -
 }
 
 // ---------------------------------------------------------------------------
-// Output
+// Output — Unicode box tables
 // ---------------------------------------------------------------------------
 
-/// Print providers table. Columns: database_provider | version | features
+const COL_PROVIDER: usize = 20;
+const COL_VERSION: usize = 30;
+const COL_FEATURES: usize = 30;
+
 fn print_providers_table(rows: &[(String, String, String)]) {
-    const COL_PROVIDER: usize = 20;
-    const COL_VERSION: usize = 30;
-    const COL_FEATURES: usize = 50;
+    let cols = [COL_PROVIDER, COL_VERSION, COL_FEATURES];
 
+    // Top border: ┌──────┬──────┬──────┐
+    println!("{}", tbl_rule(&cols, TBL_TL, TBL_T_DOWN, TBL_TR));
+
+    // Header row
+    let h_provider = format!("{:<w$}", "database_provider", w = COL_PROVIDER);
+    let h_version = format!("{:<w$}", "version", w = COL_VERSION);
+    let h_features = format!("{:<w$}", "features", w = COL_FEATURES);
     println!(
-        "  {:<provider$} | {:<version$} | {:<features$}",
-        bold("database_provider"),
-        bold("version"),
-        bold("features"),
-        provider = COL_PROVIDER,
-        version = COL_VERSION,
-        features = COL_FEATURES
-    );
-    println!(
-        "  {:<provider$}-+-{:<version$}-+-{:<features$}",
-        "-".repeat(COL_PROVIDER),
-        "-".repeat(COL_VERSION),
-        "-".repeat(COL_FEATURES),
-        provider = COL_PROVIDER,
-        version = COL_VERSION,
-        features = COL_FEATURES
+        "  {} {} {} {} {} {} {}",
+        TBL_V,
+        bold(&h_provider),
+        TBL_V,
+        bold(&h_version),
+        TBL_V,
+        bold(&h_features),
+        TBL_V
     );
 
+    // Separator: ├──────┼──────┼──────┤
+    println!(
+        "{}",
+        tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT)
+    );
+
+    // Data rows
     for (name, versions, features) in rows {
-        let version_trunc = truncate(versions, COL_VERSION);
-        let features_trunc = truncate(features, COL_FEATURES);
+        let p = format!("{:<w$}", name, w = COL_PROVIDER);
+        let v = format!("{:<w$}", truncate(versions, COL_VERSION), w = COL_VERSION);
+        let f = format!("{:<w$}", truncate(features, COL_FEATURES), w = COL_FEATURES);
         println!(
-            "  {:<provider$} | {:<version$} | {:<features$}",
-            cyan(name),
-            version_trunc,
-            features_trunc,
-            provider = COL_PROVIDER,
-            version = COL_VERSION,
-            features = COL_FEATURES
+            "  {} {} {} {} {} {} {}",
+            TBL_V,
+            cyan(&p),
+            TBL_V,
+            v,
+            TBL_V,
+            f,
+            TBL_V
         );
     }
+
+    // Bottom border: └──────┴──────┴──────┘
+    println!("{}", tbl_rule(&cols, TBL_BL, TBL_T_UP, TBL_BR));
 
     println!();
     println!("  Images are pulled from Docker Hub by default.");
 }
 
-/// Print features table. Columns: feature | description
+const COL_FEATURE: usize = 25;
+const COL_DESC: usize = 45;
+
 fn print_features_table(features: &[SupportedFeature]) {
-    const COL_FEATURE: usize = 25;
-    const COL_DESC: usize = 55;
+    let cols = [COL_FEATURE, COL_DESC];
 
     println!("  {}", bold("Features"));
-    println!("  {}", "─".repeat(COL_FEATURE + COL_DESC + 5));
+
+    // Top border
+    println!("{}", tbl_rule(&cols, TBL_TL, TBL_T_DOWN, TBL_TR));
+
+    // Header
+    let h_feat = format!("{:<w$}", "feature", w = COL_FEATURE);
+    let h_desc = format!("{:<w$}", "description", w = COL_DESC);
     println!(
-        "  {:<feature$} | {:<desc$}",
-        bold("feature"),
-        bold("description"),
-        feature = COL_FEATURE,
-        desc = COL_DESC
-    );
-    println!(
-        "  {:<feature$}-+-{:<desc$}",
-        "-".repeat(COL_FEATURE),
-        "-".repeat(COL_DESC),
-        feature = COL_FEATURE,
-        desc = COL_DESC
+        "  {} {} {} {} {}",
+        TBL_V,
+        bold(&h_feat),
+        TBL_V,
+        bold(&h_desc),
+        TBL_V
     );
 
+    // Separator
+    println!(
+        "{}",
+        tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT)
+    );
+
+    // Rows
     for f in features {
-        let desc_trunc = truncate(&f.description, COL_DESC);
+        let feat = format!("{:<w$}", f.id, w = COL_FEATURE);
+        let desc = format!(
+            "{:<w$}",
+            truncate(&f.description, COL_DESC),
+            w = COL_DESC
+        );
         println!(
-            "  {:<feature$} | {:<desc$}",
-            f.id,
-            desc_trunc,
-            feature = COL_FEATURE,
-            desc = COL_DESC
+            "  {} {} {} {} {}",
+            TBL_V, feat, TBL_V, desc, TBL_V
         );
     }
+
+    // Bottom
+    println!("{}", tbl_rule(&cols, TBL_BL, TBL_T_UP, TBL_BR));
 }
 
 fn truncate(s: impl AsRef<str>, max_len: usize) -> String {
@@ -155,6 +183,6 @@ fn truncate(s: impl AsRef<str>, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
+        format!("{}…", &s[..max_len.saturating_sub(1)])
     }
 }

--- a/crates/applications/cli/src/commands/cmd_schema.rs
+++ b/crates/applications/cli/src/commands/cmd_schema.rs
@@ -14,7 +14,7 @@ use gfs_domain::repo_utils::repo_layout;
 use gfs_domain::usecases::repository::extract_schema_usecase::ExtractSchemaUseCase;
 
 use crate::cli_utils::get_repo_dir;
-use crate::output::{bold, cyan, dimmed, green};
+use crate::output::{cyan, dimmed, green, header};
 
 /// Extract schema from the running database instance.
 pub async fn run_extract(
@@ -52,8 +52,8 @@ pub async fn run_extract(
         std::fs::write(&output_path, &json)
             .with_context(|| format!("failed to write schema to {}", output_path.display()))?;
         println!(
-            "{} {}",
-            green("Schema extracted to"),
+            "{} Schema extracted to {}",
+            green("✓"),
             cyan(output_path.display().to_string())
         );
     } else {
@@ -101,18 +101,22 @@ pub async fn run_show(
         println!("{}", json);
     } else {
         // Show both metadata and DDL with colors
-        println!("{} {}", dimmed("Schema Hash:"), cyan(schema_hash));
+        println!("  {} {}", dimmed("Schema Hash:"), cyan(schema_hash));
         println!(
-            "{} {} {}",
+            "  {} {} {}",
             dimmed("Driver:"),
             metadata.driver,
             metadata.version
         );
-        println!("\n{}", bold("=== Metadata (JSON) ==="));
+        println!();
+        println!("  {}", header("Metadata (JSON)"));
+        println!();
         let json = serde_json::to_string_pretty(&metadata)
             .context("failed to serialize schema metadata")?;
         println!("{}", json);
-        println!("\n{}", bold("=== DDL (SQL) ==="));
+        println!();
+        println!("  {}", header("DDL (SQL)"));
+        println!();
         println!("{}", ddl);
     }
 

--- a/crates/applications/cli/src/commands/cmd_status.rs
+++ b/crates/applications/cli/src/commands/cmd_status.rs
@@ -12,7 +12,9 @@ use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::status_repo_usecase::StatusRepoUseCase;
 
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
-use crate::output::{bold, cyan, dimmed, green, red, yellow};
+use crate::output::{
+    bold, box_bottom, box_row, box_top, cyan, dimmed, green, red, yellow, BOX_V,
+};
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -47,72 +49,85 @@ pub async fn run(path: Option<PathBuf>, output: String) -> Result<()> {
 // Output formats
 // ---------------------------------------------------------------------------
 
-const LABEL_WIDTH: usize = 20;
+const LABEL_W: usize = 20;
+const BOX_W: usize = 40;
+
+fn fmt_row(label: &str, value: &str) -> String {
+    // Pad label first (plain text), then apply dimmed.
+    // Pad value to fill the box width.
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let padded_value = format!("{:<w$}", value, w = value_w);
+    format!("{} {}", dimmed(&padded_label), padded_value)
+}
+
+fn fmt_row_colored(label: &str, colored_value: &str, raw_value: &str) -> String {
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let remaining = value_w.saturating_sub(raw_value.chars().count());
+    format!(
+        "{} {}{}",
+        dimmed(&padded_label),
+        colored_value,
+        " ".repeat(remaining)
+    )
+}
 
 fn print_table(s: &StatusResponse, repo_path: &Path) {
     // Repository section
-    println!("  {}", bold("Repository"));
-    println!("  {}", "─".repeat(40));
-    println!(
-        "  {:<width$} {}",
-        "Branch",
-        cyan(&s.current_branch),
-        width = LABEL_WIDTH
-    );
+    println!("{}", box_top(&bold("Repository"), BOX_W));
+
+    let branch_row = fmt_row_colored("Branch", &cyan(&s.current_branch), &s.current_branch);
+    println!("{}", box_row(&branch_row, BOX_W));
+
     if let Some(ref active) = s.active_workspace_data_dir {
-        println!(
-            "  {:<width$} {}",
-            "Active workspace",
-            relativize_to_repo(repo_path, active),
-            width = LABEL_WIDTH
-        );
+        let rel = relativize_to_repo(repo_path, active);
+        let row = fmt_row("Active workspace", &rel);
+        println!("{}", box_row(&row, BOX_W));
     }
+    println!("{}", box_bottom(BOX_W));
+
     println!();
 
     if let Some(ref c) = s.compute {
         let status_dot = status_indicator_colored(&c.container_status);
-        println!("  {}", bold("Compute"));
-        println!("  {}", "─".repeat(40));
-        println!(
-            "  {:<width$} {}",
-            "Provider",
-            c.provider,
-            width = LABEL_WIDTH
+        let status_raw = format!(
+            "{} {}",
+            status_indicator(&c.container_status),
+            c.container_status
         );
-        println!("  {:<width$} {}", "Version", c.version, width = LABEL_WIDTH);
-        println!(
-            "  {:<width$} {} {}",
-            "Status",
-            status_dot,
-            c.container_status,
-            width = LABEL_WIDTH
-        );
-        println!(
-            "  {:<width$} {}",
-            "Container ID",
-            dimmed(truncate_id(&c.container_id)),
-            width = LABEL_WIDTH
-        );
+
+        println!("{}", box_top(&bold("Compute"), BOX_W));
+
+        let row = fmt_row("Provider", &c.provider);
+        println!("{}", box_row(&row, BOX_W));
+
+        let row = fmt_row("Version", &c.version);
+        println!("{}", box_row(&row, BOX_W));
+
+        let status_colored = format!("{} {}", status_dot, c.container_status);
+        let row = fmt_row_colored("Status", &status_colored, &status_raw);
+        println!("{}", box_row(&row, BOX_W));
+
+        let truncated = truncate_id(&c.container_id);
+        let row = fmt_row_colored("Container ID", &dimmed(&truncated), &truncated);
+        println!("{}", box_row(&row, BOX_W));
+
         if let Some(ref bind) = c.data_bind_host_path {
-            println!(
-                "  {:<width$} {}",
-                "Container data dir",
-                relativize_to_repo(repo_path, bind),
-                width = LABEL_WIDTH
-            );
+            let rel = relativize_to_repo(repo_path, bind);
+            let row = fmt_row("Container data dir", &rel);
+            println!("{}", box_row(&row, BOX_W));
         }
         if !c.connection_string.is_empty() {
-            println!(
-                "  {:<width$} {}",
-                "Connection",
-                c.connection_string,
-                width = LABEL_WIDTH
-            );
+            let row = fmt_row("Connection", &c.connection_string);
+            println!("{}", box_row(&row, BOX_W));
         }
+        println!("{}", box_bottom(BOX_W));
     } else {
-        println!("  {}", bold("Compute"));
-        println!("  {}", "─".repeat(40));
-        println!("  (no compute instance configured)");
+        println!("{}", box_top(&bold("Compute"), BOX_W));
+        let msg = format!("{:<w$}", "(no compute instance configured)", w = BOX_W);
+        println!("  {} {} {}", BOX_V, dimmed(&msg), BOX_V);
+        println!("{}", box_bottom(BOX_W));
     }
 
     if let Some(ref warning) = s.bind_mismatch_warning {

--- a/crates/applications/cli/src/commands/cmd_version.rs
+++ b/crates/applications/cli/src/commands/cmd_version.rs
@@ -1,6 +1,90 @@
-//! `gfs version` — print the CLI version.
+//! `gfs version` — print the CLI version with retro arcade-style ASCII art.
 
-/// Print the current gfs CLI version.
+use crate::output::{bold, dimmed, gold};
+
+/// Print the current gfs CLI version inside a retro branded box.
 pub fn run() {
-    println!("gfs {}", env!("CARGO_PKG_VERSION"));
+    let version = env!("CARGO_PKG_VERSION");
+    let target = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+
+    // Double-line box (DOS/retro style)
+    let tl = "╔";
+    let tr = "╗";
+    let bl = "╚";
+    let br = "╝";
+    let h = "═";
+    let v = "║";
+
+    let w: usize = 39; // inner visible width
+
+    let art = [
+        " ██████  ███████ ███████",
+        "██       ██      ██     ",
+        "██  ███  █████   ███████",
+        "██   ██  ██           ██",
+        " ██████  ██      ███████",
+    ];
+
+    let tagline = "Git For database Systems";
+    let meta = format!("v{} · rust · {}", version, target);
+
+    // Top border
+    println!("  {}{}{}", tl, h.repeat(w + 2), tr);
+
+    // Empty line
+    println!("  {} {} {}", v, " ".repeat(w), v);
+
+    // ASCII art lines (gold-colored block letters)
+    for line in &art {
+        let indent = "    ";
+        let plain_len = indent.len() + line.chars().count();
+        let remaining = w.saturating_sub(plain_len);
+        println!(
+            "  {} {}{}{} {}",
+            v,
+            indent,
+            gold(line),
+            " ".repeat(remaining),
+            v
+        );
+    }
+
+    // Empty line
+    println!("  {} {} {}", v, " ".repeat(w), v);
+
+    // Tagline (bold)
+    {
+        let indent = "    ";
+        let plain_len = indent.len() + tagline.chars().count();
+        let remaining = w.saturating_sub(plain_len);
+        println!(
+            "  {} {}{}{} {}",
+            v,
+            indent,
+            bold(tagline),
+            " ".repeat(remaining),
+            v
+        );
+    }
+
+    // Version + platform (dimmed)
+    {
+        let indent = "    ";
+        let plain_len = indent.len() + meta.chars().count();
+        let remaining = w.saturating_sub(plain_len);
+        println!(
+            "  {} {}{}{} {}",
+            v,
+            indent,
+            dimmed(&meta),
+            " ".repeat(remaining),
+            v
+        );
+    }
+
+    // Empty line
+    println!("  {} {} {}", v, " ".repeat(w), v);
+
+    // Bottom border
+    println!("  {}{}{}", bl, h.repeat(w + 2), br);
 }

--- a/crates/applications/cli/src/output.rs
+++ b/crates/applications/cli/src/output.rs
@@ -79,3 +79,91 @@ pub fn bold(s: impl AsRef<str>) -> String {
     let s = s.as_ref().to_string();
     format!("{}", s.if_supports_color(Stream::Stdout, |t| t.bold()))
 }
+
+/// Brand accent: bright yellow (GFS gold #ffcb51 mapped to ANSI).
+pub fn gold(s: impl AsRef<str>) -> String {
+    let s = s.as_ref().to_string();
+    format!(
+        "{}",
+        s.if_supports_color(Stream::Stdout, |t| t.bright_yellow())
+    )
+}
+
+/// Section header: bold + underline.
+pub fn header(s: impl AsRef<str>) -> String {
+    // Apply bold and underline separately to avoid chained-temporary issues.
+    let s = s.as_ref().to_string();
+    let bolded = format!("{}", s.if_supports_color(Stream::Stdout, |t| t.bold()));
+    format!(
+        "{}",
+        bolded.if_supports_color(Stream::Stdout, |t| t.underline())
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Unicode box-drawing characters
+// ---------------------------------------------------------------------------
+
+// Rounded corners for info panels / status boxes
+pub const BOX_TL: &str = "╭";
+pub const BOX_TR: &str = "╮";
+pub const BOX_BL: &str = "╰";
+pub const BOX_BR: &str = "╯";
+pub const BOX_H: &str = "─";
+pub const BOX_V: &str = "│";
+
+// Sharp corners for data tables
+pub const TBL_TL: &str = "┌";
+pub const TBL_TR: &str = "┐";
+pub const TBL_BL: &str = "└";
+pub const TBL_BR: &str = "┘";
+pub const TBL_V: &str = "│";
+pub const TBL_H: &str = "─";
+pub const TBL_CROSS: &str = "┼";
+pub const TBL_T_DOWN: &str = "┬";
+pub const TBL_T_UP: &str = "┴";
+pub const TBL_T_RIGHT: &str = "├";
+pub const TBL_T_LEFT: &str = "┤";
+
+// ---------------------------------------------------------------------------
+// Box-drawing helpers (rounded panels)
+// ---------------------------------------------------------------------------
+
+/// Top edge of a rounded box with an optional inline title.
+/// Example: `╭─ Repository ──────────────────╮`
+pub fn box_top(title: &str, width: usize) -> String {
+    if title.is_empty() {
+        format!("  {}{}{}", BOX_TL, BOX_H.repeat(width + 2), BOX_TR)
+    } else {
+        let label = format!("{} {} ", BOX_H, title);
+        let fill = width + 2 - label.chars().count().min(width + 2);
+        format!("  {}{}{}{}", BOX_TL, label, BOX_H.repeat(fill), BOX_TR)
+    }
+}
+
+/// A row inside a rounded box. `content` should be pre-padded to `width` visible chars.
+/// Example: `│ Branch               main     │`
+pub fn box_row(content: &str, width: usize) -> String {
+    // NOTE: content may contain ANSI escapes. Callers must ensure
+    // the *visible* portion is exactly `width` characters wide
+    // (pad raw text first, then apply color).
+    let _ = width; // used by callers for formatting
+    format!("  {} {} {}", BOX_V, content, BOX_V)
+}
+
+/// Bottom edge of a rounded box.
+/// Example: `╰──────────────────────────────╯`
+pub fn box_bottom(width: usize) -> String {
+    format!("  {}{}{}", BOX_BL, BOX_H.repeat(width + 2), BOX_BR)
+}
+
+// ---------------------------------------------------------------------------
+// Table-drawing helpers (sharp-cornered data tables)
+// ---------------------------------------------------------------------------
+
+/// Build a horizontal table rule from column widths.
+/// `left`, `mid`, `right` are the corner/junction characters.
+pub fn tbl_rule(cols: &[usize], left: &str, mid: &str, right: &str) -> String {
+    let segments: Vec<String> = cols.iter().map(|&w| TBL_H.repeat(w + 2)).collect();
+    format!("  {}{}{}", left, segments.join(mid), right)
+}


### PR DESCRIPTION
## Summary

- **Retro arcade-style ASCII art** banner on `gfs version` with block-letter GFS logo in gold and double-line `╔═╗` border
- **Unicode box panels** (`╭─��╰─╯`) replace plain `��` dividers in `gfs status` and `gfs compute status`
- **Unicode box tables** (`┌┬┐├┼┤└┴┘`) replace ASCII pipe tables in `gfs providers`
- **Graph-style commit log** with gold `●` dots and dimmed `│` connectors in `gfs log`
- **Green `✓` success prefix** on all action commands: `commit`, `checkout`, `export`, `import`, `schema extract`
- **`gfs init` now speaks** — was completely silent, now shows repo path, branch, config, and provider
- **Bold+underline section headers** replace `=== Metadata ===` in `gfs schema show`
- **Expanded `output.rs`** with `gold()`, `header()`, box-drawing constants, and layout helpers

## Design decisions

- **Zero new dependencies** — all visuals use Unicode characters + the existing `owo-colors` crate
- **Agent-safe** — all output remains plain stdout text lines, fully parseable by AI agents (Claude Code, Cursor, Cline)
- **Pipe-friendly** — `gfs log | grep`, `gfs status > file`, and `jq` workflows unaffected
- **Graceful degradation** — `NO_COLOR=1` and `--color never` disable ANSI codes, Unicode box chars remain readable

## Before / After

### `gfs version`
```
Before:  gfs 0.2.1

After:
  ╔═════════════════════════════════════════╗
  ║                                         ║
  ║      ██████  ███████ ███████            ║
  ║     ██       ██      ██                 ║
  ║     ██  ███  █████   ███████            ║
  ║     ██   ██  ██           ██            ║
  ║      ██████  ██      ███████            ║
  ║                                         ║
  ║     Git For database Systems            ║
  ║     v0.2.1 · rust · macos-aarch64       ║
  ║                                         ║
  ╚═════════════════════════════════════════╝
```

### `gfs log`
```
Before:                          After:
commit f7b9847 (HEAD -> main)      ● f7b9847  (HEAD -> main)
Author: user                       │ Author: user
Date:   Sun Apr 5 23:59:13         │ Date:   Sun Apr 5 23:59:13
                                   │
    Initial schema setup           │     Initial schema setup
                                   │
```

### `gfs status`
```
Before:                            After:
  Repository                         ╭─ Repository ──────────────────╮
  ────────────────────                │ Branch               main     │
  Branch               main          │ Active workspace     .gfs/... │
                                     ╰──────────────────────────────╯
```

### `gfs commit`
```
Before:  [main] f7b9847  Initial schema setup
After:   ✓ [main] f7b9847  Initial schema setup
```

### `gfs init`
```
Before:  (completely silent)
After:   ✓ Initialized GFS repository at ./my-project

           Branch           main
           Config           .gfs/config.toml
```

## Test plan

- [x] `cargo build -p gfs-cli` — compiles clean
- [x] `cargo test -p gfs-cli --lib` — all 3 unit tests pass
- [x] `gfs version` — retro banner renders correctly
- [x] `gfs init` / `commit` / `checkout` / `log` / `status` / `providers` — verified in live workflow
- [ ] `NO_COLOR=1 gfs version` — graceful degradation (no ANSI, Unicode preserved)
- [ ] `gfs version | cat` — auto-detects non-TTY, disables colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)