### PR TITLE
🐛 fix: pin docker host for exec

### DIFF
--- a/crates/applications/cli/tests/common/container_runtime.rs
+++ b/crates/applications/cli/tests/common/container_runtime.rs
@@ -22,3 +22,22 @@ pub fn runtime_binary() -> &'static str {
         }
     })
 }
+
+/// Create a runtime command pre-configured to target the same Docker daemon
+/// that the `gfs` compute adapter uses.
+///
+/// On some Linux setups, the Docker CLI context (e.g. Docker Desktop) may point
+/// to a different socket than the default `/var/run/docker.sock` used by the API client.
+pub fn runtime_command() -> Command {
+    let bin = runtime_binary();
+    let mut cmd = Command::new(bin);
+
+    #[cfg(unix)]
+    {
+        if bin == "docker" && std::path::Path::new("/var/run/docker.sock").exists() {
+            cmd.env("DOCKER_HOST", "unix:///var/run/docker.sock");
+        }
+    }
+
+    cmd
+}

--- a/crates/applications/cli/tests/common/postgres.rs
+++ b/crates/applications/cli/tests/common/postgres.rs
@@ -5,7 +5,6 @@
 #![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
@@ -23,9 +22,12 @@ struct ContainerCleanupGuard(String);
 
 impl Drop for ContainerCleanupGuard {
     fn drop(&mut self) {
-        let runtime = super::container_runtime::runtime_binary();
-        let _ = Command::new(runtime).args(["stop", &self.0]).output();
-        let _ = Command::new(runtime).args(["rm", "-f", &self.0]).output();
+        let _ = super::container_runtime::runtime_command()
+            .args(["stop", &self.0])
+            .output();
+        let _ = super::container_runtime::runtime_command()
+            .args(["rm", "-f", &self.0])
+            .output();
     }
 }
 
@@ -97,7 +99,7 @@ where
 
     // 4. Wait for Postgres before commit (commit runs CHECKPOINT)
     for _ in 0..30 {
-        let ok = Command::new(super::container_runtime::runtime_binary())
+        let ok = super::container_runtime::runtime_command()
             .args([
                 "exec",
                 &container_id,
@@ -134,7 +136,7 @@ pub fn gfs_import(repo_path: &Path, file: &Path, format: Option<&str>) -> (bool,
 }
 
 pub fn run_psql_select(container_id: &str, query: &str) -> String {
-    let out = Command::new(super::container_runtime::runtime_binary())
+    let out = super::container_runtime::runtime_command()
         .args([
             "exec",
             container_id,

--- a/crates/applications/cli/tests/e2e_checkout_postgres.rs
+++ b/crates/applications/cli/tests/e2e_checkout_postgres.rs
@@ -46,7 +46,7 @@ struct OneOffContainerGuard(String);
 
 impl Drop for OneOffContainerGuard {
     fn drop(&mut self) {
-        let _ = Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["rm", "-f", &self.0])
             .output();
     }
@@ -71,10 +71,10 @@ impl Drop for MainContainerCleanup {
         if let Ok(mut id) = self.0.lock()
             && let Some(container_id) = id.take()
         {
-            let _ = Command::new(common::container_runtime::runtime_binary())
+            let _ = common::container_runtime::runtime_command()
                 .args(["stop", &container_id])
                 .output();
-            let _ = Command::new(common::container_runtime::runtime_binary())
+            let _ = common::container_runtime::runtime_command()
                 .args(["rm", "-f", &container_id])
                 .output();
         }
@@ -110,10 +110,10 @@ fn cleanup_main_container(repo_path: &Path) {
         .take_container_id()
         .or_else(|| get_container_id(repo_path));
     if let Some(id) = container_id {
-        let _ = Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["stop", &id])
             .output();
-        let _ = Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["rm", "-f", &id])
             .output();
     }
@@ -127,7 +127,7 @@ fn get_container_id(repo_path: &Path) -> Option<String> {
 
 fn wait_for_postgres(container_id: &str) -> bool {
     for _ in 0..30 {
-        let ok = Command::new(common::container_runtime::runtime_binary())
+        let ok = common::container_runtime::runtime_command()
             .args([
                 "exec",
                 container_id,
@@ -150,7 +150,7 @@ fn wait_for_postgres(container_id: &str) -> bool {
 
 fn run_pgbench_init(container_id: &str) -> (Duration, String) {
     let start = Instant::now();
-    let out = Command::new(common::container_runtime::runtime_binary())
+    let out = common::container_runtime::runtime_command()
         .args([
             "exec",
             container_id,
@@ -175,7 +175,7 @@ fn run_pgbench_init(container_id: &str) -> (Duration, String) {
 
 #[allow(dead_code)]
 fn run_psql_list_tables(container_id: &str) -> String {
-    let out = Command::new(common::container_runtime::runtime_binary())
+    let out = common::container_runtime::runtime_command()
         .args([
             "exec",
             container_id,
@@ -268,20 +268,20 @@ fn run_one_off_postgres_list_tables_inner(
         args.push("--user");
         args.push(u);
     }
-    let create = Command::new(common::container_runtime::runtime_binary())
+    let create = common::container_runtime::runtime_command()
         .args(args)
         .output()
         .expect("run one-off postgres");
     if !create.status.success() {
         let stderr = String::from_utf8_lossy(&create.stderr);
-        let _ = Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["rm", "-f", &name])
             .output();
         panic!("failed to create one-off container: {}", stderr);
     }
     let _guard = OneOffContainerGuard(name.clone());
     for _ in 0..30 {
-        let ok = Command::new(common::container_runtime::runtime_binary())
+        let ok = common::container_runtime::runtime_command()
             .args([
                 "exec", &name, "psql", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1",
             ])
@@ -294,7 +294,7 @@ fn run_one_off_postgres_list_tables_inner(
         thread::sleep(Duration::from_secs(1));
     }
     thread::sleep(Duration::from_secs(2));
-    let out = Command::new(common::container_runtime::runtime_binary())
+    let out = common::container_runtime::runtime_command()
         .args([
             "exec", &name, "psql", "-U", "postgres", "-d", "postgres", "-c", "\\dt",
         ])

--- a/crates/applications/cli/tests/e2e_commit.rs
+++ b/crates/applications/cli/tests/e2e_commit.rs
@@ -27,7 +27,7 @@ fn get_container_id(repo_path: &Path) -> Option<String> {
 /// Wait for Postgres in the container to accept connections. Retries up to 30 times with 1s delay.
 fn wait_for_postgres(container_id: &str) -> bool {
     for _ in 0..30 {
-        let ok = std::process::Command::new(common::container_runtime::runtime_binary())
+        let ok = common::container_runtime::runtime_command()
             .args([
                 "exec",
                 container_id,
@@ -53,10 +53,10 @@ struct ContainerCleanupGuard(String);
 
 impl Drop for ContainerCleanupGuard {
     fn drop(&mut self) {
-        let _ = std::process::Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["stop", &self.0])
             .output();
-        let _ = std::process::Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["rm", "-f", &self.0])
             .output();
     }

--- a/crates/applications/cli/tests/e2e_short_hash.rs
+++ b/crates/applications/cli/tests/e2e_short_hash.rs
@@ -25,7 +25,7 @@ fn get_container_id(repo_path: &Path) -> Option<String> {
 /// Wait for Postgres in the container to accept connections. Retries up to 30 times with 1s delay.
 fn wait_for_postgres(container_id: &str) -> bool {
     for _ in 0..30 {
-        let ok = std::process::Command::new(common::container_runtime::runtime_binary())
+        let ok = common::container_runtime::runtime_command()
             .args([
                 "exec",
                 container_id,
@@ -51,10 +51,10 @@ struct ContainerCleanupGuard(String);
 
 impl Drop for ContainerCleanupGuard {
     fn drop(&mut self) {
-        let _ = std::process::Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["stop", &self.0])
             .output();
-        let _ = std::process::Command::new(common::container_runtime::runtime_binary())
+        let _ = common::container_runtime::runtime_command()
             .args(["rm", "-f", &self.0])
             .output();
     }


### PR DESCRIPTION
## Related Issue
N/A (test infrastructure fix; no issue filed)

## What
Fixes Postgres integration tests failing with `No such container` even though `gfs init --database-provider postgres` succeeded.

Root cause: on some Linux setups the Docker CLI context (e.g. Docker Desktop `desktop-linux`) targets a different daemon/socket than the one used by the compute adapter. The tests were using `docker exec` against the CLI’s context daemon, while the container was created/managed by the compute adapter’s daemon, so the CREATE TABLE never executed and schema extraction returned `tables: []`.

## How
- Introduce a shared test helper `runtime_command()` that pins Docker CLI invocations to `unix:///var/run/docker.sock` when available.
- Update Docker calls in the Postgres test helpers and e2e tests to use `runtime_command()` so `docker exec` talks to the same daemon as the compute adapter.

## Review Guide
1. `crates/applications/cli/tests/common/container_runtime.rs` — `runtime_command()` helper
2. `crates/applications/cli/tests/common/postgres.rs` — exec/cleanup use `runtime_command()`
3. `crates/applications/cli/tests/e2e_checkout_postgres.rs` — runtime calls use `runtime_command()`
4. `crates/applications/cli/tests/e2e_commit.rs`, `crates/applications/cli/tests/e2e_short_hash.rs` — same change for consistency (macOS-only)

## Testing
- [x] Manual testing performed
- [x] Unit tests added/updated (test helpers updated)
- [x] E2E tests added/updated

Commands:
- `cargo test -p gfs-cli --test schema_extract_postgres -- --nocapture --test-threads=1`
- `cargo test --verbose`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`

## Documentation
- [x] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated

## User Impact
- More reliable CI/local test execution on Docker Desktop + Linux (no false failures from mismatched Docker daemons).
- No runtime/product behavior changes (tests only).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`cargo test`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Format check passes (`cargo fmt --check`)
- [x] This PR can be safely reverted if needed