### PR TITLE
✨ Feature: CLI visual overhaul + json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ name = "gfs-cli"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-compute-docker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bollard",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-domain"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-storage-apfs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-storage-file"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-telemetry"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "gfs-domain",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "gfs-website"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "console_error_panic_hook",
  "leptos",

--- a/crates/applications/cli/src/cli_utils.rs
+++ b/crates/applications/cli/src/cli_utils.rs
@@ -1,8 +1,50 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
+use gfs_domain::model::layout::{GFS_DIR, HEADS_DIR, REFS_DIR};
+
 /// Returns the current working directory as the default repo path.
 pub fn get_repo_dir() -> PathBuf {
     std::env::current_dir().expect("current directory not available")
+}
+
+/// Collect branch tips: Vec<(branch_name, commit_hash)>.
+///
+/// When `missing_ok` is true and the refs directory doesn't exist, returns an empty list.
+pub fn list_branch_tips(repo_path: &Path, missing_ok: bool) -> Result<Vec<(String, String)>> {
+    let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
+    if !refs_dir.exists() {
+        if missing_ok {
+            return Ok(Vec::new());
+        }
+        anyhow::bail!("not a GFS repository (no refs directory)");
+    }
+    collect_refs(&refs_dir, "")
+}
+
+fn collect_refs(dir: &Path, prefix: &str) -> Result<Vec<(String, String)>> {
+    let mut result = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+        let branch_name = if prefix.is_empty() {
+            name
+        } else {
+            format!("{}/{}", prefix, name)
+        };
+        if path.is_file() {
+            let tip = std::fs::read_to_string(&path)?.trim().to_string();
+            result.push((branch_name, tip));
+        } else if path.is_dir() {
+            result.extend(collect_refs(&path, &branch_name)?);
+        }
+    }
+    Ok(result)
 }
 
 /// Return a path relative to the repo root (e.g. `.gfs/workspaces/dev/.../data`).

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -17,8 +17,9 @@ use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::repo_utils::repo_layout;
 use gfs_domain::usecases::repository::checkout_repo_usecase::CheckoutRepoUseCase;
+use serde_json::json;
 
-use crate::cli_utils::get_repo_dir;
+use crate::cli_utils::{get_repo_dir, list_branch_tips};
 use crate::output::{cyan, dimmed, gold, green};
 
 // ---------------------------------------------------------------------------
@@ -31,18 +32,26 @@ pub async fn run(
     start_point: Option<String>,
     delete: Option<String>,
     switch: bool,
+    json_output: bool,
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
 
     if let Some(ref branch_name) = delete {
-        return delete_branch(&repo_path, branch_name);
+        return delete_branch(&repo_path, branch_name, json_output);
     }
 
     match name {
         Some(branch_name) => {
-            create_branch(&repo_path, &branch_name, start_point.as_deref(), switch).await
+            create_branch(
+                &repo_path,
+                &branch_name,
+                start_point.as_deref(),
+                switch,
+                json_output,
+            )
+            .await
         }
-        None => list_branches(&repo_path),
+        None => list_branches(&repo_path, json_output),
     }
 }
 
@@ -50,14 +59,13 @@ pub async fn run(
 // List branches
 // ---------------------------------------------------------------------------
 
-fn list_branches(repo_path: &std::path::Path) -> Result<()> {
-    let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
-    if !refs_dir.exists() {
-        anyhow::bail!("not a GFS repository (no refs directory)");
-    }
-
-    let branches = collect_refs(&refs_dir, "")?;
+fn list_branches(repo_path: &std::path::Path, json_output: bool) -> Result<()> {
+    let branches = list_branch_tips(repo_path, false)?;
     if branches.is_empty() {
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&json!({ "branches": [] }))?);
+            return Ok(());
+        }
         println!("  (no branches)");
         return Ok(());
     }
@@ -76,13 +84,40 @@ fn list_branches(repo_path: &std::path::Path) -> Result<()> {
         }
     });
 
+    if json_output {
+        let out: Vec<_> = sorted
+            .iter()
+            .map(|(name, hash)| {
+                let subject = if hash == "0" || hash.len() < 7 {
+                    String::new()
+                } else {
+                    repo_layout::get_commit_from_hash(repo_path, hash)
+                        .map(|c| c.message.lines().next().unwrap_or("").to_string())
+                        .unwrap_or_default()
+                };
+                json!({
+                    "name": name,
+                    "hash": hash,
+                    "subject": subject,
+                    "current": *name == current,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json!({ "branches": out }))?);
+        return Ok(());
+    }
+
     for (name, hash) in &sorted {
         let short_hash = &hash[..7.min(hash.len())];
 
         // Get the commit message for this branch tip.
-        let subject = repo_layout::get_commit_from_hash(repo_path, hash)
-            .map(|c| c.message.lines().next().unwrap_or("").to_string())
-            .unwrap_or_default();
+        let subject = if hash == "0" || hash.len() < 7 {
+            String::new()
+        } else {
+            repo_layout::get_commit_from_hash(repo_path, hash)
+                .map(|c| c.message.lines().next().unwrap_or("").to_string())
+                .unwrap_or_default()
+        };
 
         if *name == current {
             println!(
@@ -100,31 +135,6 @@ fn list_branches(repo_path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
-fn collect_refs(dir: &std::path::Path, prefix: &str) -> Result<Vec<(String, String)>> {
-    let mut result = Vec::new();
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("")
-            .to_string();
-        let branch_name = if prefix.is_empty() {
-            name
-        } else {
-            format!("{}/{}", prefix, name)
-        };
-        if path.is_file() {
-            let tip = std::fs::read_to_string(&path)?.trim().to_string();
-            result.push((branch_name, tip));
-        } else if path.is_dir() {
-            result.extend(collect_refs(&path, &branch_name)?);
-        }
-    }
-    Ok(result)
-}
-
 // ---------------------------------------------------------------------------
 // Create branch (optionally switch to it)
 // ---------------------------------------------------------------------------
@@ -134,6 +144,7 @@ async fn create_branch(
     name: &str,
     start_point: Option<&str>,
     switch: bool,
+    json_output: bool,
 ) -> Result<()> {
     if switch {
         // Use the full checkout flow (stops/starts compute, creates workspace).
@@ -151,6 +162,19 @@ async fn create_branch(
             .run(repo_path.to_path_buf(), revision, Some(name.to_string()))
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        if json_output {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "action": "create_and_checkout",
+                    "branch": name,
+                    "hash": commit_hash,
+                    "start_point": start_point.unwrap_or("HEAD"),
+                }))?
+            );
+            return Ok(());
+        }
 
         let short_hash = &commit_hash[..7.min(commit_hash.len())];
         println!(
@@ -181,8 +205,22 @@ async fn create_branch(
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        let short_hash = &commit_hash[..7.min(commit_hash.len())];
         let start_label = start_point.unwrap_or("HEAD");
+
+        if json_output {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "action": "create",
+                    "branch": name,
+                    "hash": commit_hash,
+                    "start_point": start_label,
+                }))?
+            );
+            return Ok(());
+        }
+
+        let short_hash = &commit_hash[..7.min(commit_hash.len())];
         println!(
             "{} Created branch '{}' at {} ({})",
             green("✓"),
@@ -199,7 +237,7 @@ async fn create_branch(
 // Delete branch
 // ---------------------------------------------------------------------------
 
-fn delete_branch(repo_path: &std::path::Path, name: &str) -> Result<()> {
+fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> Result<()> {
     let current = repo_layout::get_current_branch(repo_path).unwrap_or_default();
     if name == current {
         anyhow::bail!("cannot delete the currently checked out branch '{}'", name);
@@ -225,6 +263,17 @@ fn delete_branch(repo_path: &std::path::Path, name: &str) -> Result<()> {
             let _ = std::fs::remove_dir(dir);
         }
         parent = dir.parent();
+    }
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "action": "delete",
+                "branch": name,
+            }))?
+        );
+        return Ok(());
     }
 
     println!("{} Deleted branch '{}'", green("✓"), name);

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -1,0 +1,250 @@
+//! `gfs branch` — list, create, and manage branches.
+//!
+//! - `gfs branch` — list all branches (current branch marked with *)
+//! - `gfs branch <name>` — create a new branch at HEAD
+//! - `gfs branch <name> <start>` — create a new branch at a specific commit/branch
+//! - `gfs branch -d <name>` — delete a branch
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use gfs_compute_docker::DockerCompute;
+use gfs_domain::adapters::gfs_repository::GfsRepository;
+use gfs_domain::model::layout::{GFS_DIR, HEADS_DIR, REFS_DIR};
+use gfs_domain::ports::compute::Compute;
+use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
+use gfs_domain::ports::repository::Repository;
+use gfs_domain::repo_utils::repo_layout;
+use gfs_domain::usecases::repository::checkout_repo_usecase::CheckoutRepoUseCase;
+
+use crate::cli_utils::get_repo_dir;
+use crate::output::{cyan, dimmed, gold, green};
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub async fn run(
+    path: Option<PathBuf>,
+    name: Option<String>,
+    start_point: Option<String>,
+    delete: Option<String>,
+    switch: bool,
+) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+
+    if let Some(ref branch_name) = delete {
+        return delete_branch(&repo_path, branch_name);
+    }
+
+    match name {
+        Some(branch_name) => {
+            create_branch(&repo_path, &branch_name, start_point.as_deref(), switch).await
+        }
+        None => list_branches(&repo_path),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// List branches
+// ---------------------------------------------------------------------------
+
+fn list_branches(repo_path: &std::path::Path) -> Result<()> {
+    let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
+    if !refs_dir.exists() {
+        anyhow::bail!("not a GFS repository (no refs directory)");
+    }
+
+    let branches = collect_refs(&refs_dir, "")?;
+    if branches.is_empty() {
+        println!("  (no branches)");
+        return Ok(());
+    }
+
+    let current = repo_layout::get_current_branch(repo_path).unwrap_or_default();
+
+    // Sort branches: current first, then alphabetically.
+    let mut sorted: Vec<(String, String)> = branches;
+    sorted.sort_by(|(a, _), (b, _)| {
+        if *a == current {
+            std::cmp::Ordering::Less
+        } else if *b == current {
+            std::cmp::Ordering::Greater
+        } else {
+            a.cmp(b)
+        }
+    });
+
+    for (name, hash) in &sorted {
+        let short_hash = &hash[..7.min(hash.len())];
+
+        // Get the commit message for this branch tip.
+        let subject = repo_layout::get_commit_from_hash(repo_path, hash)
+            .map(|c| {
+                c.message
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .unwrap_or_default();
+
+        if *name == current {
+            println!(
+                "  {} {} {} {}",
+                gold("*"),
+                green(name),
+                dimmed(short_hash),
+                subject
+            );
+        } else {
+            println!(
+                "    {} {} {}",
+                cyan(name),
+                dimmed(short_hash),
+                subject
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_refs(
+    dir: &std::path::Path,
+    prefix: &str,
+) -> Result<Vec<(String, String)>> {
+    let mut result = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+        let branch_name = if prefix.is_empty() {
+            name
+        } else {
+            format!("{}/{}", prefix, name)
+        };
+        if path.is_file() {
+            let tip = std::fs::read_to_string(&path)?.trim().to_string();
+            result.push((branch_name, tip));
+        } else if path.is_dir() {
+            result.extend(collect_refs(&path, &branch_name)?);
+        }
+    }
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Create branch (optionally switch to it)
+// ---------------------------------------------------------------------------
+
+async fn create_branch(
+    repo_path: &std::path::Path,
+    name: &str,
+    start_point: Option<&str>,
+    switch: bool,
+) -> Result<()> {
+    if switch {
+        // Use the full checkout flow (stops/starts compute, creates workspace).
+        let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
+        let compute: Arc<dyn Compute> = Arc::new(DockerCompute::new().context(
+            "failed to connect to Docker/Podman daemon (is your container runtime running?)",
+        )?);
+        let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
+        gfs_compute_docker::containers::register_all(registry.as_ref())
+            .context("failed to register database providers")?;
+
+        let use_case = CheckoutRepoUseCase::new(repository, compute, registry);
+        let revision = start_point.unwrap_or("").to_string();
+        let commit_hash = use_case
+            .run(
+                repo_path.to_path_buf(),
+                revision,
+                Some(name.to_string()),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let short_hash = &commit_hash[..7.min(commit_hash.len())];
+        println!(
+            "{} Switched to new branch '{}' ({})",
+            green("✓"),
+            green(name),
+            dimmed(short_hash)
+        );
+    } else {
+        // Just create the ref — don't switch.
+        let commit_hash = if let Some(rev) = start_point {
+            repo_layout::rev_parse(repo_path, rev)
+                .map_err(|e| anyhow::anyhow!("failed to resolve '{}': {e}", rev))?
+        } else {
+            repo_layout::get_current_commit_id(repo_path)
+                .map_err(|e| anyhow::anyhow!("failed to get HEAD: {e}"))?
+        };
+
+        // Check if branch already exists.
+        if repo_layout::is_branch(repo_path, name) {
+            anyhow::bail!("branch '{}' already exists", name);
+        }
+
+        // Write the ref file.
+        let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
+        repository
+            .create_branch(repo_path, name, &commit_hash)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let short_hash = &commit_hash[..7.min(commit_hash.len())];
+        let start_label = start_point.unwrap_or("HEAD");
+        println!(
+            "{} Created branch '{}' at {} ({})",
+            green("✓"),
+            cyan(name),
+            start_label,
+            dimmed(short_hash)
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Delete branch
+// ---------------------------------------------------------------------------
+
+fn delete_branch(repo_path: &std::path::Path, name: &str) -> Result<()> {
+    let current = repo_layout::get_current_branch(repo_path).unwrap_or_default();
+    if name == current {
+        anyhow::bail!("cannot delete the currently checked out branch '{}'", name);
+    }
+
+    let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
+    let ref_path = refs_dir.join(name);
+
+    if !ref_path.exists() {
+        anyhow::bail!("branch '{}' not found", name);
+    }
+
+    std::fs::remove_file(&ref_path)
+        .with_context(|| format!("failed to delete branch ref '{}'", name))?;
+
+    // Clean up empty parent directories (for nested branches like feature/foo).
+    let mut parent = ref_path.parent();
+    while let Some(dir) = parent {
+        if dir == refs_dir {
+            break;
+        }
+        if dir.read_dir().map_or(true, |mut d| d.next().is_none()) {
+            let _ = std::fs::remove_dir(dir);
+        }
+        parent = dir.parent();
+    }
+
+    println!("{} Deleted branch '{}'", green("✓"), name);
+    Ok(())
+}

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -81,13 +81,7 @@ fn list_branches(repo_path: &std::path::Path) -> Result<()> {
 
         // Get the commit message for this branch tip.
         let subject = repo_layout::get_commit_from_hash(repo_path, hash)
-            .map(|c| {
-                c.message
-                    .lines()
-                    .next()
-                    .unwrap_or("")
-                    .to_string()
-            })
+            .map(|c| c.message.lines().next().unwrap_or("").to_string())
             .unwrap_or_default();
 
         if *name == current {
@@ -99,22 +93,14 @@ fn list_branches(repo_path: &std::path::Path) -> Result<()> {
                 subject
             );
         } else {
-            println!(
-                "    {} {} {}",
-                cyan(name),
-                dimmed(short_hash),
-                subject
-            );
+            println!("    {} {} {}", cyan(name), dimmed(short_hash), subject);
         }
     }
 
     Ok(())
 }
 
-fn collect_refs(
-    dir: &std::path::Path,
-    prefix: &str,
-) -> Result<Vec<(String, String)>> {
+fn collect_refs(dir: &std::path::Path, prefix: &str) -> Result<Vec<(String, String)>> {
     let mut result = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
@@ -162,11 +148,7 @@ async fn create_branch(
         let use_case = CheckoutRepoUseCase::new(repository, compute, registry);
         let revision = start_point.unwrap_or("").to_string();
         let commit_hash = use_case
-            .run(
-                repo_path.to_path_buf(),
-                revision,
-                Some(name.to_string()),
-            )
+            .run(repo_path.to_path_buf(), revision, Some(name.to_string()))
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -63,7 +63,10 @@ fn list_branches(repo_path: &std::path::Path, json_output: bool) -> Result<()> {
     let branches = list_branch_tips(repo_path, false)?;
     if branches.is_empty() {
         if json_output {
-            println!("{}", serde_json::to_string_pretty(&json!({ "branches": [] }))?);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({ "branches": [] }))?
+            );
             return Ok(());
         }
         println!("  (no branches)");
@@ -103,7 +106,10 @@ fn list_branches(repo_path: &std::path::Path, json_output: bool) -> Result<()> {
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&json!({ "branches": out }))?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "branches": out }))?
+        );
         return Ok(());
     }
 

--- a/crates/applications/cli/src/commands/cmd_checkout.rs
+++ b/crates/applications/cli/src/commands/cmd_checkout.rs
@@ -13,6 +13,7 @@ use gfs_domain::ports::compute::Compute;
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::checkout_repo_usecase::CheckoutRepoUseCase;
+use serde_json::json;
 
 use super::compute_support::compute_for_repo;
 use crate::cli_utils::get_repo_dir;
@@ -26,6 +27,7 @@ pub async fn checkout(
     path: Option<PathBuf>,
     revision: Option<String>,
     create_branch: Option<String>,
+    json_output: bool,
 ) -> Result<()> {
     let (revision, create_branch) = match (&revision, &create_branch) {
         (Some(r), None) => (r.clone(), None),
@@ -50,21 +52,32 @@ pub async fn checkout(
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    let short_hash = &commit_hash[..7.min(commit_hash.len())];
-    if let Some(ref name) = create_branch {
+    if json_output {
         println!(
-            "{} Switched to new branch '{}' ({})",
-            green("✓"),
-            green(name.trim()),
-            dimmed(short_hash)
+            "{}",
+            json!({
+                "hash": commit_hash,
+                "branch": create_branch.as_deref().unwrap_or(&revision),
+                "new_branch": create_branch.is_some(),
+            })
         );
     } else {
-        println!(
-            "{} Switched to {} ({})",
-            green("✓"),
-            cyan(revision.trim()),
-            dimmed(short_hash)
-        );
+        let short_hash = &commit_hash[..7.min(commit_hash.len())];
+        if let Some(ref name) = create_branch {
+            println!(
+                "{} Switched to new branch '{}' ({})",
+                green("✓"),
+                green(name.trim()),
+                dimmed(short_hash)
+            );
+        } else {
+            println!(
+                "{} Switched to {} ({})",
+                green("✓"),
+                cyan(revision.trim()),
+                dimmed(short_hash)
+            );
+        }
     }
     Ok(())
 }

--- a/crates/applications/cli/src/commands/cmd_checkout.rs
+++ b/crates/applications/cli/src/commands/cmd_checkout.rs
@@ -53,13 +53,15 @@ pub async fn checkout(
     let short_hash = &commit_hash[..7.min(commit_hash.len())];
     if let Some(ref name) = create_branch {
         println!(
-            "Switched to new branch '{}' ({})",
+            "{} Switched to new branch '{}' ({})",
+            green("✓"),
             green(name.trim()),
             dimmed(short_hash)
         );
     } else {
         println!(
-            "Switched to {} ({})",
+            "{} Switched to {} ({})",
+            green("✓"),
             cyan(revision.trim()),
             dimmed(short_hash)
         );

--- a/crates/applications/cli/src/commands/cmd_commit.rs
+++ b/crates/applications/cli/src/commands/cmd_commit.rs
@@ -9,6 +9,7 @@ use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::ports::storage::StoragePort;
 use gfs_domain::usecases::repository::commit_repo_usecase::CommitRepoUseCase;
+use serde_json::json;
 
 use super::compute_support::compute_for_repo;
 use crate::cli_utils::get_repo_dir;
@@ -23,19 +24,20 @@ pub async fn commit(
     message: String,
     author: Option<String>,
     author_email: Option<String>,
+    json_output: bool,
 ) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         use gfs_storage_apfs::ApfsStorage;
         let storage: Arc<dyn StoragePort> = Arc::new(ApfsStorage::new());
-        run(path, message, author, author_email, storage).await
+        run(path, message, author, author_email, storage, json_output).await
     }
 
     #[cfg(not(target_os = "macos"))]
     {
         use gfs_storage_file::FileStorage;
         let storage: Arc<dyn StoragePort> = Arc::new(FileStorage::new());
-        run(path, message, author, author_email, storage).await
+        run(path, message, author, author_email, storage, json_output).await
     }
 }
 
@@ -49,6 +51,7 @@ async fn run(
     author: Option<String>,
     author_email: Option<String>,
     storage: Arc<dyn StoragePort>,
+    json_output: bool,
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
 
@@ -72,15 +75,18 @@ async fn run(
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    print_commit_result(&branch, &commit_hash, &message);
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "hash": commit_hash,
+                "branch": branch,
+                "message": message,
+            })
+        );
+    } else {
+        let short = &commit_hash[..7.min(commit_hash.len())];
+        println!("{} [{}] {}  {}", green("✓"), cyan(&branch), dimmed(short), message);
+    }
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Display
-// ---------------------------------------------------------------------------
-
-fn print_commit_result(branch: &str, hash: &str, message: &str) {
-    let short = &hash[..7.min(hash.len())];
-    println!("{} [{}] {}  {}", green("✓"), cyan(branch), dimmed(short), message);
 }

--- a/crates/applications/cli/src/commands/cmd_commit.rs
+++ b/crates/applications/cli/src/commands/cmd_commit.rs
@@ -86,7 +86,13 @@ async fn run(
         );
     } else {
         let short = &commit_hash[..7.min(commit_hash.len())];
-        println!("{} [{}] {}  {}", green("✓"), cyan(&branch), dimmed(short), message);
+        println!(
+            "{} [{}] {}  {}",
+            green("✓"),
+            cyan(&branch),
+            dimmed(short),
+            message
+        );
     }
     Ok(())
 }

--- a/crates/applications/cli/src/commands/cmd_commit.rs
+++ b/crates/applications/cli/src/commands/cmd_commit.rs
@@ -12,7 +12,7 @@ use gfs_domain::usecases::repository::commit_repo_usecase::CommitRepoUseCase;
 
 use super::compute_support::compute_for_repo;
 use crate::cli_utils::get_repo_dir;
-use crate::output::{cyan, dimmed};
+use crate::output::{cyan, dimmed, green};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
@@ -82,5 +82,5 @@ async fn run(
 
 fn print_commit_result(branch: &str, hash: &str, message: &str) {
     let short = &hash[..7.min(hash.len())];
-    println!("[{}] {}  {}", cyan(branch), dimmed(short), message);
+    println!("{} [{}] {}  {}", green("✓"), cyan(branch), dimmed(short), message);
 }

--- a/crates/applications/cli/src/commands/cmd_compute.rs
+++ b/crates/applications/cli/src/commands/cmd_compute.rs
@@ -15,7 +15,10 @@ use gfs_domain::utils::data_dir;
 
 use crate::ComputeAction;
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
-use crate::output::{bold, box_bottom, box_row, box_top, dimmed, green, red, yellow};
+use crate::output::{
+    bold, box_bottom, box_row, box_top, dimmed, fmt_box_row, fmt_box_row_colored, green, red,
+    yellow,
+};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
@@ -114,6 +117,7 @@ async fn dispatch(
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, false).await?;
             let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            println!("{} Compute started", green("✓"));
             print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
@@ -122,6 +126,7 @@ async fn dispatch(
                 .stop(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
+            println!("{} Compute stopped", green("✓"));
             print_status(&status, None, path.as_ref());
         }
 
@@ -130,6 +135,7 @@ async fn dispatch(
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, true).await?;
             let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            println!("{} Compute restarted", green("✓"));
             print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
@@ -138,6 +144,7 @@ async fn dispatch(
                 .pause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
+            println!("{} Compute paused", green("✓"));
             print_status(&status, None, path.as_ref());
         }
 
@@ -146,6 +153,7 @@ async fn dispatch(
                 .unpause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
+            println!("{} Compute unpaused", green("✓"));
             print_status(&status, None, path.as_ref());
         }
 
@@ -201,33 +209,14 @@ async fn dispatch(
 // ---------------------------------------------------------------------------
 
 const BOX_W: usize = 40;
-const LABEL_W: usize = 18;
-
-fn fmt_row(label: &str, value: &str) -> String {
-    let value_w = BOX_W - LABEL_W - 1;
-    let padded_label = format!("{:<w$}", label, w = LABEL_W);
-    let padded_value = format!("{:<w$}", value, w = value_w);
-    format!("{} {}", dimmed(&padded_label), padded_value)
-}
-
-fn fmt_row_colored(label: &str, colored_value: &str, raw_value: &str) -> String {
-    let value_w = BOX_W - LABEL_W - 1;
-    let padded_label = format!("{:<w$}", label, w = LABEL_W);
-    let remaining = value_w.saturating_sub(raw_value.chars().count());
-    format!(
-        "{} {}{}",
-        dimmed(&padded_label),
-        colored_value,
-        " ".repeat(remaining)
-    )
-}
+const LABEL_W: usize = 20;
 
 fn print_status(s: &InstanceStatus, data_dir: Option<&str>, path: Option<&PathBuf>) {
     println!("{}", box_top(&bold("Compute"), BOX_W));
 
     // ID
     let truncated_id = truncate_id(&s.id.0);
-    let row = fmt_row_colored("id", &dimmed(&truncated_id), &truncated_id);
+    let row = fmt_box_row_colored("id", &dimmed(&truncated_id), &truncated_id, LABEL_W, BOX_W);
     println!("{}", box_row(&row, BOX_W));
 
     // State with dot indicator
@@ -235,27 +224,27 @@ fn print_status(s: &InstanceStatus, data_dir: Option<&str>, path: Option<&PathBu
     let dot = status_indicator_colored(&s.state);
     let colored_state = format!("{} {}", dot, format_state_colored_text(&s.state));
     let raw_state = format!("{} {}", status_indicator_raw(&s.state), state_str);
-    let row = fmt_row_colored("state", &colored_state, &raw_state);
+    let row = fmt_box_row_colored("state", &colored_state, &raw_state, LABEL_W, BOX_W);
     println!("{}", box_row(&row, BOX_W));
 
     // PID
     if let Some(pid) = s.pid {
         let pid_str = pid.to_string();
-        let row = fmt_row("pid", &pid_str);
+        let row = fmt_box_row("pid", &pid_str, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
     }
 
     // Started at
     if let Some(started_at) = s.started_at {
         let ts = started_at.format("%Y-%m-%dT%H:%M:%SZ").to_string();
-        let row = fmt_row("started_at", &ts);
+        let row = fmt_box_row("started_at", &ts, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
     }
 
     // Exit code
     if let Some(code) = s.exit_code {
         let code_str = code.to_string();
-        let row = fmt_row("exit_code", &code_str);
+        let row = fmt_box_row("exit_code", &code_str, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
     }
 
@@ -263,7 +252,7 @@ fn print_status(s: &InstanceStatus, data_dir: Option<&str>, path: Option<&PathBu
     if let Some(dir) = data_dir {
         let repo_path = path.cloned().unwrap_or_else(get_repo_dir);
         let rel = relativize_to_repo(&repo_path, dir);
-        let row = fmt_row("data dir", &rel);
+        let row = fmt_box_row("data dir", &rel, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
     }
 

--- a/crates/applications/cli/src/commands/cmd_compute.rs
+++ b/crates/applications/cli/src/commands/cmd_compute.rs
@@ -12,6 +12,7 @@ use gfs_domain::repo_utils::repo_layout;
 #[cfg(unix)]
 use gfs_domain::utils::current_user;
 use gfs_domain::utils::data_dir;
+use serde_json::json;
 
 use crate::ComputeAction;
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
@@ -52,17 +53,17 @@ fn resolve_id(path: Option<PathBuf>, action: &ComputeAction) -> Result<String> {
     Ok(container_name.to_string())
 }
 
-pub async fn run(path: Option<PathBuf>, action: ComputeAction) -> Result<()> {
+pub async fn run(path: Option<PathBuf>, action: ComputeAction, json_output: bool) -> Result<()> {
     if let ComputeAction::Config { ref key, ref value } = action {
-        return handle_config(path, key, value);
+        return handle_config(path, key, value, json_output);
     }
     let compute = DockerCompute::new()
         .map_err(|e| anyhow::anyhow!("failed to connect to Docker/Podman daemon: {e}"))?;
     let id = resolve_id(path.clone(), &action)?;
-    dispatch(&compute, &id, action, path).await
+    dispatch(&compute, &id, action, path, json_output).await
 }
 
-fn handle_config(path: Option<PathBuf>, key: &str, value: &str) -> Result<()> {
+fn handle_config(path: Option<PathBuf>, key: &str, value: &str, json_output: bool) -> Result<()> {
     match key {
         "db.port" => {
             let port: u16 = value
@@ -79,6 +80,17 @@ fn handle_config(path: Option<PathBuf>, key: &str, value: &str) -> Result<()> {
                 );
             }
             config.save(&repo_path).context("failed to save config")?;
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "action": "config_set",
+                        "key": "db.port",
+                        "value": port,
+                    }))?
+                );
+                return Ok(());
+            }
             println!(
                 "{} database_port updated to {}. Run 'gfs compute restart' to apply.",
                 green("✓"),
@@ -99,6 +111,7 @@ async fn dispatch(
     id: &str,
     action: ComputeAction,
     path: Option<PathBuf>,
+    json_output: bool,
 ) -> Result<()> {
     let instance_id = InstanceId(id.to_string());
 
@@ -109,7 +122,11 @@ async fn dispatch(
                 .await
                 .map_err(anyhow::Error::from)?;
             let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
-            print_status(&status, data_dir.as_deref(), path.as_ref());
+            if json_output {
+                print_status_json(&status, data_dir.as_deref(), path.as_ref(), None)?;
+            } else {
+                print_status(&status, data_dir.as_deref(), path.as_ref());
+            }
         }
 
         ComputeAction::Start { .. } => {
@@ -117,8 +134,12 @@ async fn dispatch(
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, false).await?;
             let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
-            println!("{} Compute started", green("✓"));
-            print_status(&status, data_dir.as_deref(), path.as_ref());
+            if json_output {
+                print_status_json(&status, data_dir.as_deref(), path.as_ref(), Some("start"))?;
+            } else {
+                println!("{} Compute started", green("✓"));
+                print_status(&status, data_dir.as_deref(), path.as_ref());
+            }
         }
 
         ComputeAction::Stop { .. } => {
@@ -126,8 +147,12 @@ async fn dispatch(
                 .stop(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            println!("{} Compute stopped", green("✓"));
-            print_status(&status, None, path.as_ref());
+            if json_output {
+                print_status_json(&status, None, path.as_ref(), Some("stop"))?;
+            } else {
+                println!("{} Compute stopped", green("✓"));
+                print_status(&status, None, path.as_ref());
+            }
         }
 
         ComputeAction::Restart { .. } => {
@@ -135,8 +160,12 @@ async fn dispatch(
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, true).await?;
             let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
-            println!("{} Compute restarted", green("✓"));
-            print_status(&status, data_dir.as_deref(), path.as_ref());
+            if json_output {
+                print_status_json(&status, data_dir.as_deref(), path.as_ref(), Some("restart"))?;
+            } else {
+                println!("{} Compute restarted", green("✓"));
+                print_status(&status, data_dir.as_deref(), path.as_ref());
+            }
         }
 
         ComputeAction::Pause { .. } => {
@@ -144,8 +173,12 @@ async fn dispatch(
                 .pause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            println!("{} Compute paused", green("✓"));
-            print_status(&status, None, path.as_ref());
+            if json_output {
+                print_status_json(&status, None, path.as_ref(), Some("pause"))?;
+            } else {
+                println!("{} Compute paused", green("✓"));
+                print_status(&status, None, path.as_ref());
+            }
         }
 
         ComputeAction::Unpause { .. } => {
@@ -153,8 +186,12 @@ async fn dispatch(
                 .unpause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            println!("{} Compute unpaused", green("✓"));
-            print_status(&status, None, path.as_ref());
+            if json_output {
+                print_status_json(&status, None, path.as_ref(), Some("unpause"))?;
+            } else {
+                println!("{} Compute unpaused", green("✓"));
+                print_status(&status, None, path.as_ref());
+            }
         }
 
         ComputeAction::Config { .. } => unreachable!("Config is handled before dispatch"),
@@ -187,6 +224,31 @@ async fn dispatch(
                 .await
                 .map_err(anyhow::Error::from)?;
 
+            if json_output {
+                let out: Vec<_> = entries
+                    .iter()
+                    .map(|e| {
+                        json!({
+                            "timestamp": e.timestamp.to_rfc3339(),
+                            "stream": match e.stream {
+                                gfs_domain::ports::compute::LogStream::Stdout => "stdout",
+                                gfs_domain::ports::compute::LogStream::Stderr => "stderr",
+                            },
+                            "message": e.message,
+                        })
+                    })
+                    .collect();
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "action": "logs",
+                        "id": instance_id.0,
+                        "entries": out,
+                    }))?
+                );
+                return Ok(());
+            }
+
             for entry in &entries {
                 println!(
                     "[{}] [{}] {}",
@@ -210,6 +272,32 @@ async fn dispatch(
 
 const BOX_W: usize = 40;
 const LABEL_W: usize = 20;
+
+fn print_status_json(
+    s: &InstanceStatus,
+    data_dir: Option<&str>,
+    path: Option<&PathBuf>,
+    action: Option<&str>,
+) -> Result<()> {
+    let repo_path = path.cloned().unwrap_or_else(get_repo_dir);
+    let rel_data_dir = data_dir.map(|d| relativize_to_repo(&repo_path, d));
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "action": action,
+            "status": {
+                "id": s.id.0,
+                "state": format_state(&s.state),
+                "pid": s.pid,
+                "started_at": s.started_at.map(|t| t.to_rfc3339()),
+                "exit_code": s.exit_code,
+                "data_dir": rel_data_dir,
+            }
+        }))?
+    );
+    Ok(())
+}
 
 fn print_status(s: &InstanceStatus, data_dir: Option<&str>, path: Option<&PathBuf>) {
     println!("{}", box_top(&bold("Compute"), BOX_W));

--- a/crates/applications/cli/src/commands/cmd_compute.rs
+++ b/crates/applications/cli/src/commands/cmd_compute.rs
@@ -15,7 +15,7 @@ use gfs_domain::utils::data_dir;
 
 use crate::ComputeAction;
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
-use crate::output::{dimmed, green, red, yellow};
+use crate::output::{bold, box_bottom, box_row, box_top, dimmed, green, red, yellow};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
@@ -76,7 +76,11 @@ fn handle_config(path: Option<PathBuf>, key: &str, value: &str) -> Result<()> {
                 );
             }
             config.save(&repo_path).context("failed to save config")?;
-            println!("database_port updated to {port}. Run 'gfs compute restart' to apply.");
+            println!(
+                "{} database_port updated to {}. Run 'gfs compute restart' to apply.",
+                green("✓"),
+                port
+            );
             Ok(())
         }
         _ => anyhow::bail!("unknown config key '{}'; supported keys: db.port", key),
@@ -101,23 +105,16 @@ async fn dispatch(
                 .status(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
-            if let Some(ref dir) = container_data_dir(compute, &instance_id, path.clone()).await {
-                let repo_path = path.clone().unwrap_or_else(get_repo_dir);
-                let rel = relativize_to_repo(&repo_path, dir);
-                println!("Container data dir : {rel}");
-            }
+            let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
         ComputeAction::Start { .. } => {
             let repo_path = path.clone().unwrap_or_else(get_repo_dir);
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, false).await?;
-            print_status(&status);
-            if let Some(ref dir) = container_data_dir(compute, &instance_id, path).await {
-                let rel = relativize_to_repo(&repo_path, dir);
-                println!("Container data dir : {rel}");
-            }
+            let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
         ComputeAction::Stop { .. } => {
@@ -125,18 +122,15 @@ async fn dispatch(
                 .stop(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
+            print_status(&status, None, path.as_ref());
         }
 
         ComputeAction::Restart { .. } => {
             let repo_path = path.clone().unwrap_or_else(get_repo_dir);
             let (instance_id, status) =
                 start_restart_or_recreate(compute, &instance_id, &repo_path, true).await?;
-            print_status(&status);
-            if let Some(ref dir) = container_data_dir(compute, &instance_id, path).await {
-                let rel = relativize_to_repo(&repo_path, dir);
-                println!("Container data dir : {rel}");
-            }
+            let data_dir = container_data_dir(compute, &instance_id, path.clone()).await;
+            print_status(&status, data_dir.as_deref(), path.as_ref());
         }
 
         ComputeAction::Pause { .. } => {
@@ -144,7 +138,7 @@ async fn dispatch(
                 .pause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
+            print_status(&status, None, path.as_ref());
         }
 
         ComputeAction::Unpause { .. } => {
@@ -152,7 +146,7 @@ async fn dispatch(
                 .unpause(&instance_id)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_status(&status);
+            print_status(&status, None, path.as_ref());
         }
 
         ComputeAction::Config { .. } => unreachable!("Config is handled before dispatch"),
@@ -203,21 +197,77 @@ async fn dispatch(
 }
 
 // ---------------------------------------------------------------------------
-// Display helper
+// Display helper — boxed status
 // ---------------------------------------------------------------------------
 
-fn print_status(s: &InstanceStatus) {
-    println!("id          : {}", dimmed(&s.id.0));
-    println!("state       : {}", format_state_colored(&s.state));
+const BOX_W: usize = 40;
+const LABEL_W: usize = 18;
+
+fn fmt_row(label: &str, value: &str) -> String {
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let padded_value = format!("{:<w$}", value, w = value_w);
+    format!("{} {}", dimmed(&padded_label), padded_value)
+}
+
+fn fmt_row_colored(label: &str, colored_value: &str, raw_value: &str) -> String {
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let remaining = value_w.saturating_sub(raw_value.chars().count());
+    format!(
+        "{} {}{}",
+        dimmed(&padded_label),
+        colored_value,
+        " ".repeat(remaining)
+    )
+}
+
+fn print_status(s: &InstanceStatus, data_dir: Option<&str>, path: Option<&PathBuf>) {
+    println!("{}", box_top(&bold("Compute"), BOX_W));
+
+    // ID
+    let truncated_id = truncate_id(&s.id.0);
+    let row = fmt_row_colored("id", &dimmed(&truncated_id), &truncated_id);
+    println!("{}", box_row(&row, BOX_W));
+
+    // State with dot indicator
+    let state_str = format_state(&s.state);
+    let dot = status_indicator_colored(&s.state);
+    let colored_state = format!("{} {}", dot, format_state_colored_text(&s.state));
+    let raw_state = format!("{} {}", status_indicator_raw(&s.state), state_str);
+    let row = fmt_row_colored("state", &colored_state, &raw_state);
+    println!("{}", box_row(&row, BOX_W));
+
+    // PID
     if let Some(pid) = s.pid {
-        println!("pid         : {pid}");
+        let pid_str = pid.to_string();
+        let row = fmt_row("pid", &pid_str);
+        println!("{}", box_row(&row, BOX_W));
     }
+
+    // Started at
     if let Some(started_at) = s.started_at {
-        println!("started_at  : {}", started_at.format("%Y-%m-%dT%H:%M:%SZ"));
+        let ts = started_at.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let row = fmt_row("started_at", &ts);
+        println!("{}", box_row(&row, BOX_W));
     }
+
+    // Exit code
     if let Some(code) = s.exit_code {
-        println!("exit_code   : {code}");
+        let code_str = code.to_string();
+        let row = fmt_row("exit_code", &code_str);
+        println!("{}", box_row(&row, BOX_W));
     }
+
+    // Container data dir
+    if let Some(dir) = data_dir {
+        let repo_path = path.cloned().unwrap_or_else(get_repo_dir);
+        let rel = relativize_to_repo(&repo_path, dir);
+        let row = fmt_row("data dir", &rel);
+        println!("{}", box_row(&row, BOX_W));
+    }
+
+    println!("{}", box_bottom(BOX_W));
 }
 
 fn format_state(state: &InstanceState) -> &'static str {
@@ -233,15 +283,40 @@ fn format_state(state: &InstanceState) -> &'static str {
     }
 }
 
-fn format_state_colored(state: &InstanceState) -> String {
+fn status_indicator_raw(state: &InstanceState) -> &'static str {
+    match state {
+        InstanceState::Running => "●",
+        InstanceState::Starting | InstanceState::Restarting => "◐",
+        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => "○",
+        InstanceState::Failed | InstanceState::Unknown => "✕",
+    }
+}
+
+fn status_indicator_colored(state: &InstanceState) -> String {
+    let dot = status_indicator_raw(state);
+    match state {
+        InstanceState::Running => green(dot),
+        InstanceState::Starting | InstanceState::Restarting => yellow(dot),
+        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => dimmed(dot),
+        InstanceState::Failed | InstanceState::Unknown => red(dot),
+    }
+}
+
+fn format_state_colored_text(state: &InstanceState) -> String {
     let s = format_state(state);
     match state {
-        InstanceState::Running => green(s).to_string(),
-        InstanceState::Starting | InstanceState::Restarting => yellow(s).to_string(),
-        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => {
-            dimmed(s).to_string()
-        }
-        InstanceState::Failed | InstanceState::Unknown => red(s).to_string(),
+        InstanceState::Running => green(s),
+        InstanceState::Starting | InstanceState::Restarting => yellow(s),
+        InstanceState::Stopped | InstanceState::Stopping | InstanceState::Paused => dimmed(s),
+        InstanceState::Failed | InstanceState::Unknown => red(s),
+    }
+}
+
+fn truncate_id(id: &str) -> String {
+    if id.len() <= 16 {
+        id.to_string()
+    } else {
+        format!("{}…", &id[..12])
     }
 }
 

--- a/crates/applications/cli/src/commands/cmd_export.rs
+++ b/crates/applications/cli/src/commands/cmd_export.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use gfs_compute_docker::DockerCompute;
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::usecases::repository::export_repo_usecase::ExportRepoUseCase;
+use serde_json::json;
 
 use crate::cli_utils::get_repo_dir;
 use crate::output::{cyan, green};
@@ -16,6 +17,7 @@ pub async fn run(
     output_dir: Option<PathBuf>,
     format: String,
     id: Option<String>,
+    json_output: bool,
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
 
@@ -23,10 +25,6 @@ pub async fn run(
         "failed to connect to Docker/Podman daemon (is your container runtime running?)",
     )?);
 
-    // If --id is given, we need to override the container name in the config.
-    // The use case loads it from config; for --id override we create a temporary wrapper.
-    // Simplest approach: if --id is set, set env var or just note it's an override.
-    // For now we pass it through a thin shim: if --id is given, override config loading.
     let _ = id; // container name override is reserved for future use; use case reads from config.
 
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
@@ -39,11 +37,21 @@ pub async fn run(
         .await
         .context("export failed")?;
 
-    println!(
-        "{} Exported to {}",
-        green("✓"),
-        cyan(output.file_path.display().to_string())
-    );
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "file_path": output.file_path.display().to_string(),
+                "format": format,
+            })
+        );
+    } else {
+        println!(
+            "{} Exported to {}",
+            green("✓"),
+            cyan(output.file_path.display().to_string())
+        );
+    }
     if !output.stderr.is_empty() {
         eprintln!("{}", output.stderr.trim_end());
     }

--- a/crates/applications/cli/src/commands/cmd_export.rs
+++ b/crates/applications/cli/src/commands/cmd_export.rs
@@ -40,8 +40,8 @@ pub async fn run(
         .context("export failed")?;
 
     println!(
-        "{} {}",
-        green("Exported to"),
+        "{} Exported to {}",
+        green("✓"),
         cyan(output.file_path.display().to_string())
     );
     if !output.stderr.is_empty() {

--- a/crates/applications/cli/src/commands/cmd_import.rs
+++ b/crates/applications/cli/src/commands/cmd_import.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use gfs_compute_docker::DockerCompute;
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::usecases::repository::import_repo_usecase::ImportRepoUseCase;
+use serde_json::json;
 
 use crate::cli_utils::get_repo_dir;
 use crate::output::{cyan, green};
@@ -16,6 +17,7 @@ pub async fn run(
     file: PathBuf,
     format: Option<String>,
     id: Option<String>,
+    json_output: bool,
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
 
@@ -37,11 +39,20 @@ pub async fn run(
         .await
         .context("import failed")?;
 
-    println!(
-        "{} Imported from {}",
-        green("✓"),
-        cyan(output.imported_from.display().to_string())
-    );
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "imported_from": output.imported_from.display().to_string(),
+            })
+        );
+    } else {
+        println!(
+            "{} Imported from {}",
+            green("✓"),
+            cyan(output.imported_from.display().to_string())
+        );
+    }
     if !output.stderr.is_empty() {
         eprintln!("{}", output.stderr.trim_end());
     }

--- a/crates/applications/cli/src/commands/cmd_import.rs
+++ b/crates/applications/cli/src/commands/cmd_import.rs
@@ -38,8 +38,8 @@ pub async fn run(
         .context("import failed")?;
 
     println!(
-        "{} {}",
-        green("Imported from"),
+        "{} Imported from {}",
+        green("✓"),
         cyan(output.imported_from.display().to_string())
     );
     if !output.stderr.is_empty() {

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -9,6 +9,7 @@ use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::init_repo_usecase::InitRepositoryUseCase;
 use gfs_domain::usecases::repository::status_repo_usecase::StatusRepoUseCase;
+use serde_json::json;
 
 use crate::cli_utils::get_repo_dir;
 use crate::output::{cyan, dimmed, green};
@@ -18,6 +19,7 @@ pub async fn init(
     database_provider: Option<String>,
     database_version: Option<String>,
     database_port: Option<u16>,
+    json_output: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing::trace!("Initializing Guepard environment at: {:?}", path);
 
@@ -50,44 +52,41 @@ pub async fn init(
         )
         .await?;
 
-    // Success feedback
-    println!(
-        "  {} Initialized GFS repository at {}",
-        green("✓"),
-        cyan(target_path.display().to_string())
-    );
-    println!();
-    println!(
-        "    {:<16} {}",
-        dimmed("Branch"),
-        cyan("main")
-    );
-    println!(
-        "    {:<16} {}",
-        dimmed("Config"),
-        ".gfs/config.toml"
-    );
-    if let Some(ref provider) = provider_display {
-        println!(
-            "    {:<16} {}",
-            dimmed("Provider"),
-            cyan(provider)
-        );
-    }
-
-    // If a database was provisioned, fetch and show the connection string.
+    let mut connection_string: Option<String> = None;
     if has_provider {
         let status_uc = StatusRepoUseCase::new(repository, compute, registry);
         if let Ok(status) = status_uc.run(&target_path).await {
-            if let Some(ref c) = status.compute {
-                if !c.connection_string.is_empty() {
-                    println!(
-                        "    {:<16} {}",
-                        dimmed("Connection"),
-                        cyan(&c.connection_string)
-                    );
-                }
-            }
+            connection_string = status
+                .compute
+                .and_then(|c| (!c.connection_string.is_empty()).then_some(c.connection_string));
+        }
+    }
+
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "path": target_path.display().to_string(),
+                "branch": "main",
+                "config": ".gfs/config.toml",
+                "provider": provider_display,
+                "connection_string": connection_string,
+            })
+        );
+    } else {
+        println!(
+            "  {} Initialized GFS repository at {}",
+            green("✓"),
+            cyan(target_path.display().to_string())
+        );
+        println!();
+        println!("    {:<16} {}", dimmed("Branch"), cyan("main"));
+        println!("    {:<16} {}", dimmed("Config"), ".gfs/config.toml");
+        if let Some(ref provider) = provider_display {
+            println!("    {:<16} {}", dimmed("Provider"), cyan(provider));
+        }
+        if let Some(ref c) = connection_string {
+            println!("    {:<16} {}", dimmed("Connection"), cyan(c));
         }
     }
 

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -50,7 +50,7 @@ pub async fn init(
         .await?;
 
     let mut connection_string: Option<String> = None;
-    if has_provider {
+    if has_provider && let Some(compute) = compute.clone() {
         let status_uc = StatusRepoUseCase::new(repository, compute, registry);
         if let Ok(status) = status_uc.run(&target_path).await {
             connection_string = status
@@ -78,7 +78,7 @@ pub async fn init(
         );
         println!();
         println!("    {:<16} {}", dimmed("Branch"), cyan("main"));
-        println!("    {:<16} {}", dimmed("Config"), ".gfs/config.toml");
+        println!("    {:<16} .gfs/config.toml", dimmed("Config"));
         if let Some(ref provider) = provider_display {
             println!("    {:<16} {}", dimmed("Provider"), cyan(provider));
         }

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -62,13 +62,13 @@ pub async fn init(
     if json_output {
         println!(
             "{}",
-            json!({
+            serde_json::to_string_pretty(&json!({
                 "path": target_path.display().to_string(),
                 "branch": "main",
                 "config": ".gfs/config.toml",
                 "provider": provider_display,
                 "connection_string": connection_string,
-            })
+            }))?
         );
     } else {
         println!(

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -10,6 +10,7 @@ use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::init_repo_usecase::InitRepositoryUseCase;
 
 use crate::cli_utils::get_repo_dir;
+use crate::output::{cyan, dimmed, green};
 
 pub async fn init(
     path: Option<PathBuf>,
@@ -20,6 +21,7 @@ pub async fn init(
     tracing::trace!("Initializing Guepard environment at: {:?}", path);
 
     let target_path = path.unwrap_or_else(get_repo_dir);
+    let provider_display = database_provider.clone();
 
     let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
     let compute: Option<Arc<dyn Compute>> = if database_provider.is_some() {
@@ -34,13 +36,38 @@ pub async fn init(
     let use_case = InitRepositoryUseCase::new(repository, compute, registry);
     use_case
         .run(
-            target_path,
+            target_path.clone(),
             None,
             database_provider,
             database_version,
             database_port,
         )
         .await?;
+
+    // Success feedback
+    println!(
+        "  {} Initialized GFS repository at {}",
+        green("✓"),
+        cyan(target_path.display().to_string())
+    );
+    println!();
+    println!(
+        "    {:<16} {}",
+        dimmed("Branch"),
+        cyan("main")
+    );
+    println!(
+        "    {:<16} {}",
+        dimmed("Config"),
+        ".gfs/config.toml"
+    );
+    if let Some(ref provider) = provider_display {
+        println!(
+            "    {:<16} {}",
+            dimmed("Provider"),
+            cyan(provider)
+        );
+    }
 
     Ok(())
 }

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -8,6 +8,7 @@ use gfs_domain::ports::compute::Compute;
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::init_repo_usecase::InitRepositoryUseCase;
+use gfs_domain::usecases::repository::status_repo_usecase::StatusRepoUseCase;
 
 use crate::cli_utils::get_repo_dir;
 use crate::output::{cyan, dimmed, green};
@@ -21,6 +22,7 @@ pub async fn init(
     tracing::trace!("Initializing Guepard environment at: {:?}", path);
 
     let target_path = path.unwrap_or_else(get_repo_dir);
+    let has_provider = database_provider.is_some();
     let provider_display = database_provider.clone();
 
     let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
@@ -33,7 +35,11 @@ pub async fn init(
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
     containers::register_all(registry.as_ref())?;
 
-    let use_case = InitRepositoryUseCase::new(repository, compute, registry);
+    let use_case = InitRepositoryUseCase::new(
+        repository.clone(),
+        compute.clone(),
+        registry.clone(),
+    );
     use_case
         .run(
             target_path.clone(),
@@ -67,6 +73,22 @@ pub async fn init(
             dimmed("Provider"),
             cyan(provider)
         );
+    }
+
+    // If a database was provisioned, fetch and show the connection string.
+    if has_provider {
+        let status_uc = StatusRepoUseCase::new(repository, compute, registry);
+        if let Ok(status) = status_uc.run(&target_path).await {
+            if let Some(ref c) = status.compute {
+                if !c.connection_string.is_empty() {
+                    println!(
+                        "    {:<16} {}",
+                        dimmed("Connection"),
+                        cyan(&c.connection_string)
+                    );
+                }
+            }
+        }
     }
 
     Ok(())

--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -37,11 +37,8 @@ pub async fn init(
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
     containers::register_all(registry.as_ref())?;
 
-    let use_case = InitRepositoryUseCase::new(
-        repository.clone(),
-        compute.clone(),
-        registry.clone(),
-    );
+    let use_case =
+        InitRepositoryUseCase::new(repository.clone(), compute.clone(), registry.clone());
     use_case
         .run(
             target_path.clone(),

--- a/crates/applications/cli/src/commands/cmd_log.rs
+++ b/crates/applications/cli/src/commands/cmd_log.rs
@@ -1,9 +1,13 @@
-use std::path::PathBuf;
+use std::collections::{HashSet, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
 use gfs_domain::adapters::gfs_repository::GfsRepository;
+use gfs_domain::model::commit::{Commit, CommitWithRefs};
+use gfs_domain::model::layout::{GFS_DIR, HEADS_DIR, REFS_DIR};
 use gfs_domain::ports::repository::Repository;
+use gfs_domain::repo_utils::repo_layout;
 use gfs_domain::usecases::repository::log_repo_usecase::LogRepoUseCase;
 
 use crate::cli_utils::get_repo_dir;
@@ -19,9 +23,31 @@ pub async fn log(
     from: Option<String>,
     until: Option<String>,
     full_hash: bool,
+    graph: bool,
+    all: bool,
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
 
+    if graph || all {
+        run_graph(&repo_path, max_count, from, full_hash, all)?;
+    } else {
+        run_linear(&repo_path, max_count, from, until, full_hash).await?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Linear mode (existing behavior — first-parent walk)
+// ---------------------------------------------------------------------------
+
+async fn run_linear(
+    repo_path: &Path,
+    max_count: Option<usize>,
+    from: Option<String>,
+    until: Option<String>,
+    full_hash: bool,
+) -> Result<()> {
     let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
     let use_case = LogRepoUseCase::new(repository);
 
@@ -32,30 +58,372 @@ pub async fn log(
     };
 
     let commits = use_case
-        .run(repo_path, options)
+        .run(repo_path.to_path_buf(), options)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     for cwr in &commits {
-        print_commit_block(cwr, full_hash);
+        let dot_prefix = format!("  {}", gold("●"));
+        let pipe_prefix = format!("  {}", dimmed("│"));
+        print_commit_block(cwr, full_hash, &dot_prefix, &pipe_prefix);
     }
 
     Ok(())
 }
 
 // ---------------------------------------------------------------------------
-// Display (graph-style format with ● dots and │ connector lines)
+// Graph mode — full DAG visualization
 // ---------------------------------------------------------------------------
 
-fn print_commit_block(cwr: &gfs_domain::model::commit::CommitWithRefs, full_hash: bool) {
+/// Collect all branch tips: Vec<(branch_name, commit_hash)>.
+fn list_branches(repo_path: &Path) -> Result<Vec<(String, String)>> {
+    let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
+    if !refs_dir.exists() {
+        return Ok(Vec::new());
+    }
+    collect_refs(&refs_dir, "")
+}
+
+fn collect_refs(dir: &Path, prefix: &str) -> Result<Vec<(String, String)>> {
+    let mut result = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+        let branch_name = if prefix.is_empty() {
+            name
+        } else {
+            format!("{}/{}", prefix, name)
+        };
+        if path.is_file() {
+            let tip = std::fs::read_to_string(&path)?.trim().to_string();
+            result.push((branch_name, tip));
+        } else if path.is_dir() {
+            result.extend(collect_refs(&path, &branch_name)?);
+        }
+    }
+    Ok(result)
+}
+
+/// A commit node in the DAG with its metadata.
+struct GraphCommit {
+    commit: Commit,
+    refs: Vec<String>,
+    parents: Vec<String>,
+}
+
+/// Walk the full DAG from the given starting points, collecting all reachable commits.
+fn collect_dag(
+    repo_path: &Path,
+    start_hashes: &[String],
+    limit: Option<usize>,
+) -> Result<Vec<GraphCommit>> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    let mut commits: Vec<GraphCommit> = Vec::new();
+
+    for hash in start_hashes {
+        if visited.insert(hash.clone()) {
+            queue.push_back(hash.clone());
+        }
+    }
+
+    while let Some(hash) = queue.pop_front() {
+        if hash == "0" || hash.is_empty() {
+            continue;
+        }
+
+        let commit = match repo_layout::get_commit_from_hash(repo_path, &hash) {
+            Ok(mut c) => {
+                c.hash = Some(hash.clone());
+                c
+            }
+            Err(_) => continue,
+        };
+
+        let parents: Vec<String> = commit
+            .parents
+            .as_ref()
+            .map(|p| {
+                p.iter()
+                    .filter(|h| *h != "0" && !h.is_empty())
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Enqueue parents
+        for parent in &parents {
+            if visited.insert(parent.clone()) {
+                queue.push_back(parent.clone());
+            }
+        }
+
+        let refs = repo_layout::get_refs_pointing_to(repo_path, &hash).unwrap_or_default();
+
+        commits.push(GraphCommit {
+            commit,
+            refs,
+            parents,
+        });
+
+        if let Some(max) = limit {
+            if commits.len() >= max {
+                break;
+            }
+        }
+    }
+
+    // Sort by timestamp descending (newest first)
+    commits.sort_by(|a, b| b.commit.author_date.cmp(&a.commit.author_date));
+
+    Ok(commits)
+}
+
+/// Assign each commit a column (lane) and compute the graph lines.
+///
+/// The algorithm tracks "active lanes" — each lane holds the hash of the next
+/// expected commit in that column. When a commit appears, it occupies its lane;
+/// its parents replace it in the active set.
+fn render_graph(commits: &[GraphCommit], full_hash: bool) {
+    // Active lanes: each slot holds a commit hash that we expect to see next.
+    let mut lanes: Vec<String> = Vec::new();
+
+    for gc in commits {
+        let hash = gc.commit.hash.as_deref().unwrap_or("");
+
+        // Find which lane this commit occupies (or allocate a new one).
+        let my_col = if let Some(pos) = lanes.iter().position(|h| h == hash) {
+            pos
+        } else {
+            // New branch head — find an empty slot or push a new lane.
+            if let Some(pos) = lanes.iter().position(|h| h.is_empty()) {
+                lanes[pos] = hash.to_string();
+                pos
+            } else {
+                lanes.push(hash.to_string());
+                lanes.len() - 1
+            }
+        };
+
+        let num_lanes = lanes.len();
+
+        // Build the graph prefix for the commit line (● in my_col, │ elsewhere).
+        let commit_prefix = build_commit_line(&lanes, my_col);
+
+        // Build the connector prefix for continuation lines (│ everywhere active).
+        let continuation_prefix = build_continuation_line(&lanes, my_col);
+
+        // Determine parent placement.
+        let first_parent = gc.parents.first().cloned().unwrap_or_default();
+        let merge_parents: Vec<String> = gc.parents.iter().skip(1).cloned().collect();
+
+        // Check if first parent already occupies another lane (convergence).
+        let mut converge_cols: Vec<usize> = Vec::new();
+        if !first_parent.is_empty() {
+            if let Some(existing) = lanes.iter().position(|h| h == &first_parent) {
+                if existing != my_col {
+                    // Parent already has a lane elsewhere — converge into it, close my lane.
+                    converge_cols.push(existing);
+                    lanes[my_col] = String::new();
+                } else {
+                    lanes[my_col] = first_parent;
+                }
+            } else {
+                lanes[my_col] = first_parent;
+            }
+        } else {
+            lanes[my_col] = String::new(); // Root commit — lane dies.
+        }
+
+        // Place merge parents: find or allocate lanes.
+        for mp in &merge_parents {
+            if let Some(pos) = lanes.iter().position(|h| h == mp) {
+                converge_cols.push(pos);
+            } else if let Some(pos) = lanes
+                .iter()
+                .enumerate()
+                .position(|(i, h)| h.is_empty() && i != my_col)
+            {
+                lanes[pos] = mp.clone();
+                converge_cols.push(pos);
+            } else {
+                lanes.push(mp.clone());
+                converge_cols.push(lanes.len() - 1);
+            }
+        }
+
+        // Print the commit block with the graph prefix.
+        let cwr = CommitWithRefs {
+            commit: gc.commit.clone(),
+            refs: gc.refs.clone(),
+        };
+        print_commit_block(&cwr, full_hash, &commit_prefix, &continuation_prefix);
+
+        // Print convergence/merge line after the commit block.
+        if !converge_cols.is_empty() {
+            let merge_line = build_merge_line(&lanes, my_col, &converge_cols, num_lanes);
+            println!("{}", merge_line);
+        }
+
+        // Trim trailing empty lanes.
+        while lanes.last().is_some_and(|h| h.is_empty()) {
+            lanes.pop();
+        }
+    }
+}
+
+/// Build the graph prefix for a commit line: ● in `col`, │ in other active lanes.
+fn build_commit_line(lanes: &[String], col: usize) -> String {
+    let width = lanes.len().max(col + 1);
+    let mut parts: Vec<String> = Vec::with_capacity(width);
+    for i in 0..width {
+        if i == col {
+            parts.push(gold("●"));
+        } else if !lanes.get(i).is_some_and(|h| h.is_empty()) {
+            parts.push(dimmed("│"));
+        } else {
+            parts.push(" ".to_string());
+        }
+    }
+    format!("  {}", parts.join(" "))
+}
+
+/// Build the continuation prefix: │ in all active lanes.
+fn build_continuation_line(lanes: &[String], _col: usize) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(lanes.len());
+    for lane in lanes {
+        if !lane.is_empty() {
+            parts.push(dimmed("│"));
+        } else {
+            parts.push(" ".to_string());
+        }
+    }
+    format!("  {}", parts.join(" "))
+}
+
+/// Build a merge/convergence line showing a branch closing into a parent lane.
+/// `my_col` is the branch that just closed; `merge_cols` are the target parent lanes.
+/// Example: ├─╯   (my_col=1 converging left into col 0)
+///          ╰─┤   (my_col=0 converging right into col 1)
+fn build_merge_line(
+    lanes: &[String],
+    my_col: usize,
+    merge_cols: &[usize],
+    prev_num_lanes: usize,
+) -> String {
+    let width = lanes.len().max(prev_num_lanes).max(my_col + 1);
+
+    // Determine the span.
+    let all_cols: Vec<usize> = std::iter::once(my_col)
+        .chain(merge_cols.iter().copied())
+        .collect();
+    let min_col = *all_cols.iter().min().unwrap();
+    let max_col = *all_cols.iter().max().unwrap();
+
+    let mut line = vec![' '; width * 2]; // char + separator for each column
+
+    // Fill in active lane pipes first.
+    for i in 0..width {
+        let pos = i * 2;
+        let is_active = lanes.get(i).is_some_and(|h| !h.is_empty());
+        if is_active && i != my_col && !merge_cols.contains(&i) {
+            line[pos] = '│';
+        }
+    }
+
+    // Draw horizontal connections in the merge range.
+    let start_pos = min_col * 2;
+    let end_pos = max_col * 2;
+    for p in start_pos..=end_pos {
+        if line[p] == ' ' {
+            line[p] = '─';
+        }
+    }
+
+    // Place junction characters at key columns.
+    for &mc in merge_cols {
+        let pos = mc * 2;
+        // The parent lane continues down and receives a branch.
+        if mc < my_col {
+            line[pos] = '├';
+        } else {
+            line[pos] = '┤';
+        }
+    }
+
+    // Place the closing corner at my_col.
+    let my_pos = my_col * 2;
+    if my_col > *merge_cols.iter().min().unwrap_or(&my_col) {
+        line[my_pos] = '╯'; // Branch closing to the left.
+    } else {
+        line[my_pos] = '╰'; // Branch closing to the right.
+    }
+
+    // Trim trailing spaces.
+    let s: String = line.into_iter().collect();
+    let trimmed = s.trim_end();
+    format!("  {}", dimmed(trimmed))
+}
+
+
+fn run_graph(
+    repo_path: &Path,
+    max_count: Option<usize>,
+    from: Option<String>,
+    full_hash: bool,
+    all: bool,
+) -> Result<()> {
+    let start_hashes = if all {
+        // Collect all branch tips.
+        let branches = list_branches(repo_path)?;
+        if branches.is_empty() {
+            return Ok(());
+        }
+        branches.into_iter().map(|(_, hash)| hash).collect()
+    } else {
+        // Start from HEAD or specified revision.
+        let start = if let Some(ref rev) = from {
+            repo_layout::rev_parse(repo_path, rev)
+                .map_err(|e| anyhow::anyhow!("failed to resolve revision: {e}"))?
+        } else {
+            repo_layout::get_current_commit_id(repo_path)
+                .map_err(|e| anyhow::anyhow!("failed to get HEAD: {e}"))?
+        };
+        vec![start]
+    };
+
+    let commits = collect_dag(repo_path, &start_hashes, max_count)?;
+    if commits.is_empty() {
+        return Ok(());
+    }
+
+    render_graph(&commits, full_hash);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Display — shared commit block printer
+// ---------------------------------------------------------------------------
+
+fn print_commit_block(
+    cwr: &CommitWithRefs,
+    full_hash: bool,
+    commit_prefix: &str,
+    continuation_prefix: &str,
+) {
     let hash_full = cwr
         .commit
         .hash
         .as_deref()
         .unwrap_or("0000000000000000000000000000000000000000000000000000000000000000");
 
-    let hash_display =
-        gfs_domain::repo_utils::repo_layout::format_commit_hash(hash_full, full_hash);
+    let hash_display = repo_layout::format_commit_hash(hash_full, full_hash);
 
     let refs_str = if cwr.refs.is_empty() {
         String::new()
@@ -63,24 +431,28 @@ fn print_commit_block(cwr: &gfs_domain::model::commit::CommitWithRefs, full_hash
         format!("  ({})", cwr.refs.join(", "))
     };
 
-    // Graph dot + hash + refs
+    // Commit line (● already in prefix for graph mode)
     println!(
-        "  {} {}{}",
-        gold("●"),
+        "{} {}{}",
+        commit_prefix,
         dimmed(hash_display),
         green(refs_str)
     );
 
     // Author line
-    let pipe = dimmed("│");
     let author = &cwr.commit.author;
     let author_email = cwr.commit.author_email.as_deref().unwrap_or("");
     if author_email.is_empty() {
-        println!("  {} {} {}", pipe, dimmed("Author:"), author);
+        println!(
+            "{} {} {}",
+            continuation_prefix,
+            dimmed("Author:"),
+            author
+        );
     } else {
         println!(
-            "  {} {} {} <{}>",
-            pipe,
+            "{} {} {} <{}>",
+            continuation_prefix,
             dimmed("Author:"),
             author,
             dimmed(author_email)
@@ -89,17 +461,22 @@ fn print_commit_block(cwr: &gfs_domain::model::commit::CommitWithRefs, full_hash
 
     // Date line
     let date_str = cwr.commit.author_date.format("%a %b %e %H:%M:%S %Y %z");
-    println!("  {} {}   {}", pipe, dimmed("Date:"), date_str);
+    println!(
+        "{} {}   {}",
+        continuation_prefix,
+        dimmed("Date:"),
+        date_str
+    );
 
     // Blank separator
-    println!("  {}", pipe);
+    println!("{}", continuation_prefix);
 
     // Message body (indented)
     for line in cwr.commit.message.lines() {
-        println!("  {}     {}", pipe, line);
+        println!("{}     {}", continuation_prefix, line);
     }
     if !cwr.commit.message.ends_with('\n') && !cwr.commit.message.is_empty() {
-        println!("  {}", pipe);
+        println!("{}", continuation_prefix);
     }
-    println!("  {}", pipe);
+    println!("{}", continuation_prefix);
 }

--- a/crates/applications/cli/src/commands/cmd_log.rs
+++ b/crates/applications/cli/src/commands/cmd_log.rs
@@ -5,33 +5,51 @@ use std::sync::Arc;
 use anyhow::Result;
 use gfs_domain::adapters::gfs_repository::GfsRepository;
 use gfs_domain::model::commit::{Commit, CommitWithRefs};
-use gfs_domain::model::layout::{GFS_DIR, HEADS_DIR, REFS_DIR};
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::repo_utils::repo_layout;
 use gfs_domain::usecases::repository::log_repo_usecase::LogRepoUseCase;
+use serde_json::json;
 
-use crate::cli_utils::get_repo_dir;
+use crate::cli_utils::{get_repo_dir, list_branch_tips};
 use crate::output::{dimmed, gold, green};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
 // ---------------------------------------------------------------------------
 
-pub async fn log(
-    path: Option<PathBuf>,
-    max_count: Option<usize>,
-    from: Option<String>,
-    until: Option<String>,
-    full_hash: bool,
-    graph: bool,
-    all: bool,
-) -> Result<()> {
-    let repo_path = path.unwrap_or_else(get_repo_dir);
+pub struct LogArgs {
+    pub path: Option<PathBuf>,
+    pub max_count: Option<usize>,
+    pub from: Option<String>,
+    pub until: Option<String>,
+    pub full_hash: bool,
+    pub graph: bool,
+    pub all: bool,
+    pub json_output: bool,
+}
 
-    if graph || all {
-        run_graph(&repo_path, max_count, from, full_hash, all)?;
+pub async fn log(args: LogArgs) -> Result<()> {
+    let repo_path = args.path.unwrap_or_else(get_repo_dir);
+
+    if args.graph || args.all {
+        run_graph(
+            &repo_path,
+            args.max_count,
+            args.from,
+            args.full_hash,
+            args.all,
+            args.json_output,
+        )?;
     } else {
-        run_linear(&repo_path, max_count, from, until, full_hash).await?;
+        run_linear(
+            &repo_path,
+            args.max_count,
+            args.from,
+            args.until,
+            args.full_hash,
+            args.json_output,
+        )
+        .await?;
     }
 
     Ok(())
@@ -47,6 +65,7 @@ async fn run_linear(
     from: Option<String>,
     until: Option<String>,
     full_hash: bool,
+    json_output: bool,
 ) -> Result<()> {
     let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
     let use_case = LogRepoUseCase::new(repository);
@@ -62,6 +81,15 @@ async fn run_linear(
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
+    if json_output {
+        let out: Vec<_> = commits
+            .iter()
+            .map(|cwr| json_commit(cwr, full_hash))
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json!({ "commits": out }))?);
+        return Ok(());
+    }
+
     for cwr in &commits {
         let dot_prefix = format!("  {}", gold("●"));
         let pipe_prefix = format!("  {}", dimmed("│"));
@@ -74,40 +102,6 @@ async fn run_linear(
 // ---------------------------------------------------------------------------
 // Graph mode — full DAG visualization
 // ---------------------------------------------------------------------------
-
-/// Collect all branch tips: Vec<(branch_name, commit_hash)>.
-fn list_branches(repo_path: &Path) -> Result<Vec<(String, String)>> {
-    let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
-    if !refs_dir.exists() {
-        return Ok(Vec::new());
-    }
-    collect_refs(&refs_dir, "")
-}
-
-fn collect_refs(dir: &Path, prefix: &str) -> Result<Vec<(String, String)>> {
-    let mut result = Vec::new();
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("")
-            .to_string();
-        let branch_name = if prefix.is_empty() {
-            name
-        } else {
-            format!("{}/{}", prefix, name)
-        };
-        if path.is_file() {
-            let tip = std::fs::read_to_string(&path)?.trim().to_string();
-            result.push((branch_name, tip));
-        } else if path.is_dir() {
-            result.extend(collect_refs(&path, &branch_name)?);
-        }
-    }
-    Ok(result)
-}
 
 /// A commit node in the DAG with its metadata.
 struct GraphCommit {
@@ -171,10 +165,10 @@ fn collect_dag(
             parents,
         });
 
-        if let Some(max) = limit {
-            if commits.len() >= max {
-                break;
-            }
+        if let Some(max) = limit
+            && commits.len() >= max
+        {
+            break;
         }
     }
 
@@ -339,9 +333,9 @@ fn build_merge_line(
     // Draw horizontal connections in the merge range.
     let start_pos = min_col * 2;
     let end_pos = max_col * 2;
-    for p in start_pos..=end_pos {
-        if line[p] == ' ' {
-            line[p] = '─';
+    for ch in line.iter_mut().take(end_pos + 1).skip(start_pos) {
+        if *ch == ' ' {
+            *ch = '─';
         }
     }
 
@@ -376,10 +370,11 @@ fn run_graph(
     from: Option<String>,
     full_hash: bool,
     all: bool,
+    json_output: bool,
 ) -> Result<()> {
     let start_hashes = if all {
         // Collect all branch tips.
-        let branches = list_branches(repo_path)?;
+        let branches = list_branch_tips(repo_path, true)?;
         if branches.is_empty() {
             return Ok(());
         }
@@ -401,9 +396,44 @@ fn run_graph(
         return Ok(());
     }
 
+    if json_output {
+        let out: Vec<_> = commits
+            .iter()
+            .map(|gc| {
+                let cwr = CommitWithRefs {
+                    commit: gc.commit.clone(),
+                    refs: gc.refs.clone(),
+                };
+                json_commit(&cwr, full_hash)
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json!({ "commits": out }))?);
+        return Ok(());
+    }
+
     render_graph(&commits, full_hash);
 
     Ok(())
+}
+
+fn json_commit(cwr: &CommitWithRefs, full_hash: bool) -> serde_json::Value {
+    let hash_full = cwr
+        .commit
+        .hash
+        .as_deref()
+        .unwrap_or("0000000000000000000000000000000000000000000000000000000000000000");
+    let hash = repo_layout::format_commit_hash(hash_full, full_hash);
+
+    json!({
+        "hash": hash,
+        "hash_full": hash_full,
+        "refs": cwr.refs,
+        "author": cwr.commit.author,
+        "author_email": cwr.commit.author_email,
+        "author_date": cwr.commit.author_date.to_rfc3339(),
+        "message": cwr.commit.message,
+        "parents": cwr.commit.parents,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/applications/cli/src/commands/cmd_log.rs
+++ b/crates/applications/cli/src/commands/cmd_log.rs
@@ -370,7 +370,6 @@ fn build_merge_line(
     format!("  {}", dimmed(trimmed))
 }
 
-
 fn run_graph(
     repo_path: &Path,
     max_count: Option<usize>,
@@ -443,12 +442,7 @@ fn print_commit_block(
     let author = &cwr.commit.author;
     let author_email = cwr.commit.author_email.as_deref().unwrap_or("");
     if author_email.is_empty() {
-        println!(
-            "{} {} {}",
-            continuation_prefix,
-            dimmed("Author:"),
-            author
-        );
+        println!("{} {} {}", continuation_prefix, dimmed("Author:"), author);
     } else {
         println!(
             "{} {} {} <{}>",
@@ -461,12 +455,7 @@ fn print_commit_block(
 
     // Date line
     let date_str = cwr.commit.author_date.format("%a %b %e %H:%M:%S %Y %z");
-    println!(
-        "{} {}   {}",
-        continuation_prefix,
-        dimmed("Date:"),
-        date_str
-    );
+    println!("{} {}   {}", continuation_prefix, dimmed("Date:"), date_str);
 
     // Blank separator
     println!("{}", continuation_prefix);

--- a/crates/applications/cli/src/commands/cmd_log.rs
+++ b/crates/applications/cli/src/commands/cmd_log.rs
@@ -86,7 +86,10 @@ async fn run_linear(
             .iter()
             .map(|cwr| json_commit(cwr, full_hash))
             .collect();
-        println!("{}", serde_json::to_string_pretty(&json!({ "commits": out }))?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "commits": out }))?
+        );
         return Ok(());
     }
 
@@ -407,7 +410,10 @@ fn run_graph(
                 json_commit(&cwr, full_hash)
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&json!({ "commits": out }))?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "commits": out }))?
+        );
         return Ok(());
     }
 

--- a/crates/applications/cli/src/commands/cmd_log.rs
+++ b/crates/applications/cli/src/commands/cmd_log.rs
@@ -7,7 +7,7 @@ use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::log_repo_usecase::LogRepoUseCase;
 
 use crate::cli_utils::get_repo_dir;
-use crate::output::{dimmed, green};
+use crate::output::{dimmed, gold, green};
 
 // ---------------------------------------------------------------------------
 // Entry point called from main
@@ -44,7 +44,7 @@ pub async fn log(
 }
 
 // ---------------------------------------------------------------------------
-// Display (git-style format)
+// Display (graph-style format with ● dots and │ connector lines)
 // ---------------------------------------------------------------------------
 
 fn print_commit_block(cwr: &gfs_domain::model::commit::CommitWithRefs, full_hash: bool) {
@@ -54,45 +54,52 @@ fn print_commit_block(cwr: &gfs_domain::model::commit::CommitWithRefs, full_hash
         .as_deref()
         .unwrap_or("0000000000000000000000000000000000000000000000000000000000000000");
 
-    // Display short or full hash based on flag
     let hash_display =
         gfs_domain::repo_utils::repo_layout::format_commit_hash(hash_full, full_hash);
 
     let refs_str = if cwr.refs.is_empty() {
         String::new()
     } else {
-        format!(" ({})", cwr.refs.join(", "))
+        format!("  ({})", cwr.refs.join(", "))
     };
+
+    // Graph dot + hash + refs
     println!(
-        "{} {}{}",
-        dimmed("commit"),
+        "  {} {}{}",
+        gold("●"),
         dimmed(hash_display),
         green(refs_str)
     );
 
+    // Author line
+    let pipe = dimmed("│");
     let author = &cwr.commit.author;
     let author_email = cwr.commit.author_email.as_deref().unwrap_or("");
-    let author_line = if author_email.is_empty() {
-        format!("{} {}", dimmed("Author:"), author)
+    if author_email.is_empty() {
+        println!("  {} {} {}", pipe, dimmed("Author:"), author);
     } else {
-        format!(
-            "{} {} <{}>",
+        println!(
+            "  {} {} {} <{}>",
+            pipe,
             dimmed("Author:"),
             author,
             dimmed(author_email)
-        )
-    };
-    println!("{}", author_line);
+        );
+    }
 
+    // Date line
     let date_str = cwr.commit.author_date.format("%a %b %e %H:%M:%S %Y %z");
-    println!("{}   {}", dimmed("Date:"), date_str);
+    println!("  {} {}   {}", pipe, dimmed("Date:"), date_str);
 
-    println!();
+    // Blank separator
+    println!("  {}", pipe);
+
+    // Message body (indented)
     for line in cwr.commit.message.lines() {
-        println!("    {}", line);
+        println!("  {}     {}", pipe, line);
     }
     if !cwr.commit.message.ends_with('\n') && !cwr.commit.message.is_empty() {
-        println!();
+        println!("  {}", pipe);
     }
-    println!();
+    println!("  {}", pipe);
 }

--- a/crates/applications/cli/src/commands/cmd_providers.rs
+++ b/crates/applications/cli/src/commands/cmd_providers.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use gfs_domain::ports::database_provider::{
     DatabaseProviderRegistry, InMemoryDatabaseProviderRegistry, SupportedFeature,
 };
+use serde_json::json;
 
 use crate::output::{
     TBL_BL, TBL_BR, TBL_CROSS, TBL_T_DOWN, TBL_T_LEFT, TBL_T_RIGHT, TBL_T_UP, TBL_TL, TBL_TR,
@@ -16,14 +17,26 @@ use crate::output::{
 // Entry point
 // ---------------------------------------------------------------------------
 
-pub fn run(provider_name: Option<String>) -> Result<()> {
+pub fn run(provider_name: Option<String>, json_output: bool) -> Result<()> {
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
     gfs_compute_docker::containers::register_all(registry.as_ref())
         .context("failed to register database providers")?;
 
     match provider_name {
-        Some(name) => print_provider_detail(registry.as_ref(), &name)?,
-        None => print_all_providers(registry.as_ref())?,
+        Some(name) => {
+            if json_output {
+                print_provider_detail_json(registry.as_ref(), &name)?
+            } else {
+                print_provider_detail(registry.as_ref(), &name)?
+            }
+        }
+        None => {
+            if json_output {
+                print_all_providers_json(registry.as_ref())?
+            } else {
+                print_all_providers(registry.as_ref())?
+            }
+        }
     }
     Ok(())
 }
@@ -54,6 +67,24 @@ fn print_all_providers(registry: &impl DatabaseProviderRegistry) -> Result<()> {
     Ok(())
 }
 
+fn print_all_providers_json(registry: &impl DatabaseProviderRegistry) -> Result<()> {
+    let names = registry.list();
+    let providers: Vec<_> = names
+        .into_iter()
+        .filter_map(|name| {
+            let provider = registry.get(&name)?;
+            Some(json!({
+                "name": name,
+                "versions": provider.supported_versions(),
+                "features": provider.supported_features().iter().map(|f| f.id.as_str()).collect::<Vec<_>>(),
+            }))
+        })
+        .collect();
+
+    println!("{}", serde_json::to_string_pretty(&json!({ "providers": providers }))?);
+    Ok(())
+}
+
 fn print_provider_detail(registry: &impl DatabaseProviderRegistry, name: &str) -> Result<()> {
     let provider = registry
         .get(name)
@@ -69,6 +100,27 @@ fn print_provider_detail(registry: &impl DatabaseProviderRegistry, name: &str) -
     print_features_table(&features);
     println!();
     println!("  Images are pulled from Docker Hub by default.");
+    Ok(())
+}
+
+fn print_provider_detail_json(registry: &impl DatabaseProviderRegistry, name: &str) -> Result<()> {
+    let provider = registry
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("unknown provider: '{}'", name))?;
+
+    let features = provider.supported_features();
+    let out = json!({
+        "provider": {
+            "name": name,
+            "versions": provider.supported_versions(),
+            "features": features.iter().map(|f| json!({
+                "id": f.id,
+                "description": f.description,
+            })).collect::<Vec<_>>(),
+            "images_source": "docker_hub",
+        }
+    });
+    println!("{}", serde_json::to_string_pretty(&out)?);
     Ok(())
 }
 

--- a/crates/applications/cli/src/commands/cmd_providers.rs
+++ b/crates/applications/cli/src/commands/cmd_providers.rs
@@ -8,8 +8,8 @@ use gfs_domain::ports::database_provider::{
 };
 
 use crate::output::{
-    bold, cyan, tbl_rule, TBL_BL, TBL_BR, TBL_T_DOWN, TBL_T_LEFT, TBL_T_RIGHT, TBL_T_UP,
-    TBL_TL, TBL_TR, TBL_V,
+    TBL_BL, TBL_BR, TBL_T_DOWN, TBL_T_LEFT, TBL_T_RIGHT, TBL_T_UP, TBL_TL, TBL_TR, TBL_V, bold,
+    cyan, tbl_rule,
 };
 
 // ---------------------------------------------------------------------------
@@ -102,10 +102,7 @@ fn print_providers_table(rows: &[(String, String, String)]) {
     );
 
     // Separator: ├──────┼──────┼──────┤
-    println!(
-        "{}",
-        tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT)
-    );
+    println!("{}", tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT));
 
     // Data rows
     for (name, versions, features) in rows {
@@ -155,23 +152,13 @@ fn print_features_table(features: &[SupportedFeature]) {
     );
 
     // Separator
-    println!(
-        "{}",
-        tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT)
-    );
+    println!("{}", tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT));
 
     // Rows
     for f in features {
         let feat = format!("{:<w$}", f.id, w = COL_FEATURE);
-        let desc = format!(
-            "{:<w$}",
-            truncate(&f.description, COL_DESC),
-            w = COL_DESC
-        );
-        println!(
-            "  {} {} {} {} {}",
-            TBL_V, feat, TBL_V, desc, TBL_V
-        );
+        let desc = format!("{:<w$}", truncate(&f.description, COL_DESC), w = COL_DESC);
+        println!("  {} {} {} {} {}", TBL_V, feat, TBL_V, desc, TBL_V);
     }
 
     // Bottom

--- a/crates/applications/cli/src/commands/cmd_providers.rs
+++ b/crates/applications/cli/src/commands/cmd_providers.rs
@@ -8,8 +8,8 @@ use gfs_domain::ports::database_provider::{
 };
 
 use crate::output::{
-    TBL_BL, TBL_BR, TBL_T_DOWN, TBL_T_LEFT, TBL_T_RIGHT, TBL_T_UP, TBL_TL, TBL_TR, TBL_V, bold,
-    cyan, tbl_rule,
+    TBL_BL, TBL_BR, TBL_CROSS, TBL_T_DOWN, TBL_T_LEFT, TBL_T_RIGHT, TBL_T_UP, TBL_TL, TBL_TR,
+    TBL_V, bold, cyan, tbl_rule,
 };
 
 // ---------------------------------------------------------------------------
@@ -102,7 +102,7 @@ fn print_providers_table(rows: &[(String, String, String)]) {
     );
 
     // Separator: ├──────┼──────┼──────┤
-    println!("{}", tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT));
+    println!("{}", tbl_rule(&cols, TBL_T_RIGHT, TBL_CROSS, TBL_T_LEFT));
 
     // Data rows
     for (name, versions, features) in rows {
@@ -152,7 +152,7 @@ fn print_features_table(features: &[SupportedFeature]) {
     );
 
     // Separator
-    println!("{}", tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT));
+    println!("{}", tbl_rule(&cols, TBL_T_RIGHT, TBL_CROSS, TBL_T_LEFT));
 
     // Rows
     for f in features {
@@ -167,9 +167,12 @@ fn print_features_table(features: &[SupportedFeature]) {
 
 fn truncate(s: impl AsRef<str>, max_len: usize) -> String {
     let s = s.as_ref();
-    if s.len() <= max_len {
+    let char_len = s.chars().count();
+    if char_len <= max_len {
         s.to_string()
     } else {
-        format!("{}…", &s[..max_len.saturating_sub(1)])
+        let take = max_len.saturating_sub(1);
+        let prefix: String = s.chars().take(take).collect();
+        format!("{}…", prefix)
     }
 }

--- a/crates/applications/cli/src/commands/cmd_providers.rs
+++ b/crates/applications/cli/src/commands/cmd_providers.rs
@@ -81,7 +81,10 @@ fn print_all_providers_json(registry: &impl DatabaseProviderRegistry) -> Result<
         })
         .collect();
 
-    println!("{}", serde_json::to_string_pretty(&json!({ "providers": providers }))?);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({ "providers": providers }))?
+    );
     Ok(())
 }
 

--- a/crates/applications/cli/src/commands/cmd_providers.rs
+++ b/crates/applications/cli/src/commands/cmd_providers.rs
@@ -7,7 +7,10 @@ use gfs_domain::ports::database_provider::{
     DatabaseProviderRegistry, InMemoryDatabaseProviderRegistry, SupportedFeature,
 };
 
-use crate::output::{bold, cyan};
+use crate::output::{
+    bold, cyan, tbl_rule, TBL_BL, TBL_BR, TBL_T_DOWN, TBL_T_LEFT, TBL_T_RIGHT, TBL_T_UP,
+    TBL_TL, TBL_TR, TBL_V,
+};
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -70,84 +73,109 @@ fn print_provider_detail(registry: &impl DatabaseProviderRegistry, name: &str) -
 }
 
 // ---------------------------------------------------------------------------
-// Output
+// Output — Unicode box tables
 // ---------------------------------------------------------------------------
 
-/// Print providers table. Columns: database_provider | version | features
+const COL_PROVIDER: usize = 20;
+const COL_VERSION: usize = 30;
+const COL_FEATURES: usize = 30;
+
 fn print_providers_table(rows: &[(String, String, String)]) {
-    const COL_PROVIDER: usize = 20;
-    const COL_VERSION: usize = 30;
-    const COL_FEATURES: usize = 50;
+    let cols = [COL_PROVIDER, COL_VERSION, COL_FEATURES];
 
+    // Top border: ┌──────┬──────┬──────┐
+    println!("{}", tbl_rule(&cols, TBL_TL, TBL_T_DOWN, TBL_TR));
+
+    // Header row
+    let h_provider = format!("{:<w$}", "database_provider", w = COL_PROVIDER);
+    let h_version = format!("{:<w$}", "version", w = COL_VERSION);
+    let h_features = format!("{:<w$}", "features", w = COL_FEATURES);
     println!(
-        "  {:<provider$} | {:<version$} | {:<features$}",
-        bold("database_provider"),
-        bold("version"),
-        bold("features"),
-        provider = COL_PROVIDER,
-        version = COL_VERSION,
-        features = COL_FEATURES
-    );
-    println!(
-        "  {:<provider$}-+-{:<version$}-+-{:<features$}",
-        "-".repeat(COL_PROVIDER),
-        "-".repeat(COL_VERSION),
-        "-".repeat(COL_FEATURES),
-        provider = COL_PROVIDER,
-        version = COL_VERSION,
-        features = COL_FEATURES
+        "  {} {} {} {} {} {} {}",
+        TBL_V,
+        bold(&h_provider),
+        TBL_V,
+        bold(&h_version),
+        TBL_V,
+        bold(&h_features),
+        TBL_V
     );
 
+    // Separator: ├──────┼──────┼──────┤
+    println!(
+        "{}",
+        tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT)
+    );
+
+    // Data rows
     for (name, versions, features) in rows {
-        let version_trunc = truncate(versions, COL_VERSION);
-        let features_trunc = truncate(features, COL_FEATURES);
+        let p = format!("{:<w$}", name, w = COL_PROVIDER);
+        let v = format!("{:<w$}", truncate(versions, COL_VERSION), w = COL_VERSION);
+        let f = format!("{:<w$}", truncate(features, COL_FEATURES), w = COL_FEATURES);
         println!(
-            "  {:<provider$} | {:<version$} | {:<features$}",
-            cyan(name),
-            version_trunc,
-            features_trunc,
-            provider = COL_PROVIDER,
-            version = COL_VERSION,
-            features = COL_FEATURES
+            "  {} {} {} {} {} {} {}",
+            TBL_V,
+            cyan(&p),
+            TBL_V,
+            v,
+            TBL_V,
+            f,
+            TBL_V
         );
     }
+
+    // Bottom border: └──────┴──────┴──────┘
+    println!("{}", tbl_rule(&cols, TBL_BL, TBL_T_UP, TBL_BR));
 
     println!();
     println!("  Images are pulled from Docker Hub by default.");
 }
 
-/// Print features table. Columns: feature | description
+const COL_FEATURE: usize = 25;
+const COL_DESC: usize = 45;
+
 fn print_features_table(features: &[SupportedFeature]) {
-    const COL_FEATURE: usize = 25;
-    const COL_DESC: usize = 55;
+    let cols = [COL_FEATURE, COL_DESC];
 
     println!("  {}", bold("Features"));
-    println!("  {}", "─".repeat(COL_FEATURE + COL_DESC + 5));
+
+    // Top border
+    println!("{}", tbl_rule(&cols, TBL_TL, TBL_T_DOWN, TBL_TR));
+
+    // Header
+    let h_feat = format!("{:<w$}", "feature", w = COL_FEATURE);
+    let h_desc = format!("{:<w$}", "description", w = COL_DESC);
     println!(
-        "  {:<feature$} | {:<desc$}",
-        bold("feature"),
-        bold("description"),
-        feature = COL_FEATURE,
-        desc = COL_DESC
-    );
-    println!(
-        "  {:<feature$}-+-{:<desc$}",
-        "-".repeat(COL_FEATURE),
-        "-".repeat(COL_DESC),
-        feature = COL_FEATURE,
-        desc = COL_DESC
+        "  {} {} {} {} {}",
+        TBL_V,
+        bold(&h_feat),
+        TBL_V,
+        bold(&h_desc),
+        TBL_V
     );
 
+    // Separator
+    println!(
+        "{}",
+        tbl_rule(&cols, TBL_T_RIGHT, "┼", TBL_T_LEFT)
+    );
+
+    // Rows
     for f in features {
-        let desc_trunc = truncate(&f.description, COL_DESC);
+        let feat = format!("{:<w$}", f.id, w = COL_FEATURE);
+        let desc = format!(
+            "{:<w$}",
+            truncate(&f.description, COL_DESC),
+            w = COL_DESC
+        );
         println!(
-            "  {:<feature$} | {:<desc$}",
-            f.id,
-            desc_trunc,
-            feature = COL_FEATURE,
-            desc = COL_DESC
+            "  {} {} {} {} {}",
+            TBL_V, feat, TBL_V, desc, TBL_V
         );
     }
+
+    // Bottom
+    println!("{}", tbl_rule(&cols, TBL_BL, TBL_T_UP, TBL_BR));
 }
 
 fn truncate(s: impl AsRef<str>, max_len: usize) -> String {
@@ -155,6 +183,6 @@ fn truncate(s: impl AsRef<str>, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
+        format!("{}…", &s[..max_len.saturating_sub(1)])
     }
 }

--- a/crates/applications/cli/src/commands/cmd_schema.rs
+++ b/crates/applications/cli/src/commands/cmd_schema.rs
@@ -14,7 +14,7 @@ use gfs_domain::repo_utils::repo_layout;
 use gfs_domain::usecases::repository::extract_schema_usecase::ExtractSchemaUseCase;
 
 use crate::cli_utils::get_repo_dir;
-use crate::output::{bold, cyan, dimmed, green};
+use crate::output::{cyan, dimmed, green, header};
 
 /// Extract schema from the running database instance.
 pub async fn run_extract(
@@ -52,8 +52,8 @@ pub async fn run_extract(
         std::fs::write(&output_path, &json)
             .with_context(|| format!("failed to write schema to {}", output_path.display()))?;
         println!(
-            "{} {}",
-            green("Schema extracted to"),
+            "{} Schema extracted to {}",
+            green("✓"),
             cyan(output_path.display().to_string())
         );
     } else {
@@ -101,18 +101,22 @@ pub async fn run_show(
         println!("{}", json);
     } else {
         // Show both metadata and DDL with colors
-        println!("{} {}", dimmed("Schema Hash:"), cyan(schema_hash));
+        println!("  {} {}", dimmed("Schema Hash:"), cyan(schema_hash));
         println!(
-            "{} {} {}",
+            "  {} {} {}",
             dimmed("Driver:"),
             metadata.driver,
             metadata.version
         );
-        println!("\n{}", bold("=== Metadata (JSON) ==="));
+        println!();
+        println!("  {}", header("Metadata (JSON)"));
+        println!();
         let json = serde_json::to_string_pretty(&metadata)
             .context("failed to serialize schema metadata")?;
         println!("{}", json);
-        println!("\n{}", bold("=== DDL (SQL) ==="));
+        println!();
+        println!("  {}", header("DDL (SQL)"));
+        println!();
         println!("{}", ddl);
     }
 

--- a/crates/applications/cli/src/commands/cmd_status.rs
+++ b/crates/applications/cli/src/commands/cmd_status.rs
@@ -13,8 +13,8 @@ use gfs_domain::usecases::repository::status_repo_usecase::StatusRepoUseCase;
 
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
 use crate::output::{
-    bold, box_bottom, box_row, box_top, cyan, dimmed, green, red, yellow, BOX_V,
-    fmt_box_row, fmt_box_row_colored,
+    BOX_V, bold, box_bottom, box_row, box_top, cyan, dimmed, fmt_box_row, fmt_box_row_colored,
+    green, red, yellow,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/applications/cli/src/commands/cmd_status.rs
+++ b/crates/applications/cli/src/commands/cmd_status.rs
@@ -14,6 +14,7 @@ use gfs_domain::usecases::repository::status_repo_usecase::StatusRepoUseCase;
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
 use crate::output::{
     bold, box_bottom, box_row, box_top, cyan, dimmed, green, red, yellow, BOX_V,
+    fmt_box_row, fmt_box_row_colored,
 };
 
 // ---------------------------------------------------------------------------
@@ -59,37 +60,22 @@ pub async fn run(path: Option<PathBuf>, output: String) -> Result<i32> {
 const LABEL_W: usize = 20;
 const BOX_W: usize = 40;
 
-fn fmt_row(label: &str, value: &str) -> String {
-    // Pad label first (plain text), then apply dimmed.
-    // Pad value to fill the box width.
-    let value_w = BOX_W - LABEL_W - 1;
-    let padded_label = format!("{:<w$}", label, w = LABEL_W);
-    let padded_value = format!("{:<w$}", value, w = value_w);
-    format!("{} {}", dimmed(&padded_label), padded_value)
-}
-
-fn fmt_row_colored(label: &str, colored_value: &str, raw_value: &str) -> String {
-    let value_w = BOX_W - LABEL_W - 1;
-    let padded_label = format!("{:<w$}", label, w = LABEL_W);
-    let remaining = value_w.saturating_sub(raw_value.chars().count());
-    format!(
-        "{} {}{}",
-        dimmed(&padded_label),
-        colored_value,
-        " ".repeat(remaining)
-    )
-}
-
 fn print_table(s: &StatusResponse, repo_path: &Path) {
     // Repository section
     println!("{}", box_top(&bold("Repository"), BOX_W));
 
-    let branch_row = fmt_row_colored("Branch", &cyan(&s.current_branch), &s.current_branch);
+    let branch_row = fmt_box_row_colored(
+        "Branch",
+        &cyan(&s.current_branch),
+        &s.current_branch,
+        LABEL_W,
+        BOX_W,
+    );
     println!("{}", box_row(&branch_row, BOX_W));
 
     if let Some(ref active) = s.active_workspace_data_dir {
         let rel = relativize_to_repo(repo_path, active);
-        let row = fmt_row("Active workspace", &rel);
+        let row = fmt_box_row("Active workspace", &rel, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
     }
     println!("{}", box_bottom(BOX_W));
@@ -106,27 +92,33 @@ fn print_table(s: &StatusResponse, repo_path: &Path) {
 
         println!("{}", box_top(&bold("Compute"), BOX_W));
 
-        let row = fmt_row("Provider", &c.provider);
+        let row = fmt_box_row("Provider", &c.provider, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
 
-        let row = fmt_row("Version", &c.version);
+        let row = fmt_box_row("Version", &c.version, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
 
         let status_colored = format!("{} {}", status_dot, c.container_status);
-        let row = fmt_row_colored("Status", &status_colored, &status_raw);
+        let row = fmt_box_row_colored("Status", &status_colored, &status_raw, LABEL_W, BOX_W);
         println!("{}", box_row(&row, BOX_W));
 
         let truncated = truncate_id(&c.container_id);
-        let row = fmt_row_colored("Container ID", &dimmed(&truncated), &truncated);
+        let row = fmt_box_row_colored(
+            "Container ID",
+            &dimmed(&truncated),
+            &truncated,
+            LABEL_W,
+            BOX_W,
+        );
         println!("{}", box_row(&row, BOX_W));
 
         if let Some(ref bind) = c.data_bind_host_path {
             let rel = relativize_to_repo(repo_path, bind);
-            let row = fmt_row("Container data dir", &rel);
+            let row = fmt_box_row("Container data dir", &rel, LABEL_W, BOX_W);
             println!("{}", box_row(&row, BOX_W));
         }
         if !c.connection_string.is_empty() {
-            let row = fmt_row("Connection", &c.connection_string);
+            let row = fmt_box_row("Connection", &c.connection_string, LABEL_W, BOX_W);
             println!("{}", box_row(&row, BOX_W));
         }
         println!("{}", box_bottom(BOX_W));

--- a/crates/applications/cli/src/commands/cmd_status.rs
+++ b/crates/applications/cli/src/commands/cmd_status.rs
@@ -20,7 +20,8 @@ use crate::output::{
 // Entry point
 // ---------------------------------------------------------------------------
 
-pub async fn run(path: Option<PathBuf>, output: String) -> Result<()> {
+/// Returns exit code: 0 = compute running (or no compute configured), 1 = compute not running.
+pub async fn run(path: Option<PathBuf>, output: String) -> Result<i32> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
 
     let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
@@ -42,7 +43,13 @@ pub async fn run(path: Option<PathBuf>, output: String) -> Result<()> {
         _ => print_table(&status, &repo_path),
     }
 
-    Ok(())
+    // Exit code: 0 if no compute or compute is running, 1 otherwise.
+    let exit_code = match &status.compute {
+        Some(c) if c.container_status != "running" => 1,
+        _ => 0,
+    };
+
+    Ok(exit_code)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/applications/cli/src/commands/cmd_status.rs
+++ b/crates/applications/cli/src/commands/cmd_status.rs
@@ -12,7 +12,9 @@ use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::status_repo_usecase::StatusRepoUseCase;
 
 use crate::cli_utils::{get_repo_dir, relativize_to_repo};
-use crate::output::{bold, cyan, dimmed, green, red, yellow};
+use crate::output::{
+    bold, box_bottom, box_row, box_top, cyan, dimmed, green, red, yellow, BOX_V,
+};
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -47,72 +49,85 @@ pub async fn run(path: Option<PathBuf>, output: String) -> Result<()> {
 // Output formats
 // ---------------------------------------------------------------------------
 
-const LABEL_WIDTH: usize = 20;
+const LABEL_W: usize = 20;
+const BOX_W: usize = 40;
+
+fn fmt_row(label: &str, value: &str) -> String {
+    // Pad label first (plain text), then apply dimmed.
+    // Pad value to fill the box width.
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let padded_value = format!("{:<w$}", value, w = value_w);
+    format!("{} {}", dimmed(&padded_label), padded_value)
+}
+
+fn fmt_row_colored(label: &str, colored_value: &str, raw_value: &str) -> String {
+    let value_w = BOX_W - LABEL_W - 1;
+    let padded_label = format!("{:<w$}", label, w = LABEL_W);
+    let remaining = value_w.saturating_sub(raw_value.chars().count());
+    format!(
+        "{} {}{}",
+        dimmed(&padded_label),
+        colored_value,
+        " ".repeat(remaining)
+    )
+}
 
 fn print_table(s: &StatusResponse, repo_path: &Path) {
     // Repository section
-    println!("  {}", bold("Repository"));
-    println!("  {}", "─".repeat(40));
-    println!(
-        "  {:<width$} {}",
-        "Branch",
-        cyan(&s.current_branch),
-        width = LABEL_WIDTH
-    );
+    println!("{}", box_top(&bold("Repository"), BOX_W));
+
+    let branch_row = fmt_row_colored("Branch", &cyan(&s.current_branch), &s.current_branch);
+    println!("{}", box_row(&branch_row, BOX_W));
+
     if let Some(ref active) = s.active_workspace_data_dir {
-        println!(
-            "  {:<width$} {}",
-            "Active workspace",
-            relativize_to_repo(repo_path, active),
-            width = LABEL_WIDTH
-        );
+        let rel = relativize_to_repo(repo_path, active);
+        let row = fmt_row("Active workspace", &rel);
+        println!("{}", box_row(&row, BOX_W));
     }
+    println!("{}", box_bottom(BOX_W));
+
     println!();
 
     if let Some(ref c) = s.compute {
         let status_dot = status_indicator_colored(&c.container_status);
-        println!("  {}", bold("Compute"));
-        println!("  {}", "─".repeat(40));
-        println!(
-            "  {:<width$} {}",
-            "Provider",
-            c.provider,
-            width = LABEL_WIDTH
+        let status_raw = format!(
+            "{} {}",
+            status_indicator(&c.container_status),
+            c.container_status
         );
-        println!("  {:<width$} {}", "Version", c.version, width = LABEL_WIDTH);
-        println!(
-            "  {:<width$} {} {}",
-            "Status",
-            status_dot,
-            c.container_status,
-            width = LABEL_WIDTH
-        );
-        println!(
-            "  {:<width$} {}",
-            "Container ID",
-            dimmed(truncate_id(&c.container_id)),
-            width = LABEL_WIDTH
-        );
+
+        println!("{}", box_top(&bold("Compute"), BOX_W));
+
+        let row = fmt_row("Provider", &c.provider);
+        println!("{}", box_row(&row, BOX_W));
+
+        let row = fmt_row("Version", &c.version);
+        println!("{}", box_row(&row, BOX_W));
+
+        let status_colored = format!("{} {}", status_dot, c.container_status);
+        let row = fmt_row_colored("Status", &status_colored, &status_raw);
+        println!("{}", box_row(&row, BOX_W));
+
+        let truncated = truncate_id(&c.container_id);
+        let row = fmt_row_colored("Container ID", &dimmed(&truncated), &truncated);
+        println!("{}", box_row(&row, BOX_W));
+
         if let Some(ref bind) = c.data_bind_host_path {
-            println!(
-                "  {:<width$} {}",
-                "Container data dir",
-                relativize_to_repo(repo_path, bind),
-                width = LABEL_WIDTH
-            );
+            let rel = relativize_to_repo(repo_path, bind);
+            let row = fmt_row("Container data dir", &rel);
+            println!("{}", box_row(&row, BOX_W));
         }
         if !c.connection_string.is_empty() {
-            println!(
-                "  {:<width$} {}",
-                "Connection",
-                c.connection_string,
-                width = LABEL_WIDTH
-            );
+            let row = fmt_row("Connection", &c.connection_string);
+            println!("{}", box_row(&row, BOX_W));
         }
+        println!("{}", box_bottom(BOX_W));
     } else {
-        println!("  {}", bold("Compute"));
-        println!("  {}", "─".repeat(40));
-        println!("  (no compute instance configured)");
+        println!("{}", box_top(&bold("Compute"), BOX_W));
+        let msg = format!("{:<w$}", "(no compute instance configured)", w = BOX_W);
+        println!("  {} {} {}", BOX_V, dimmed(&msg), BOX_V);
+        println!("{}", box_bottom(BOX_W));
     }
 
     if let Some(ref warning) = s.bind_mismatch_warning {

--- a/crates/applications/cli/src/commands/cmd_version.rs
+++ b/crates/applications/cli/src/commands/cmd_version.rs
@@ -15,7 +15,9 @@ pub fn run() {
     let h = "═";
     let v = "║";
 
-    let w: usize = 39; // inner visible width
+    let indent = "    ";
+    let tagline = "Git For database Systems";
+    let meta = format!("v{} · rust · {}", version, target);
 
     let art = [
         " ██████  ███████ ███████",
@@ -25,8 +27,16 @@ pub fn run() {
         " ██████  ██      ███████",
     ];
 
-    let tagline = "Git For database Systems";
-    let meta = format!("v{} · rust · {}", version, target);
+    let min_w: usize = 39;
+    let art_w = art
+        .iter()
+        .map(|line| indent.len() + line.chars().count())
+        .max()
+        .unwrap_or(0);
+    let w: usize = min_w
+        .max(indent.len() + tagline.chars().count())
+        .max(indent.len() + meta.chars().count())
+        .max(art_w);
 
     // Top border
     println!("  {}{}{}", tl, h.repeat(w + 2), tr);
@@ -36,7 +46,6 @@ pub fn run() {
 
     // ASCII art lines (gold-colored block letters)
     for line in &art {
-        let indent = "    ";
         let plain_len = indent.len() + line.chars().count();
         let remaining = w.saturating_sub(plain_len);
         println!(
@@ -54,7 +63,6 @@ pub fn run() {
 
     // Tagline (bold)
     {
-        let indent = "    ";
         let plain_len = indent.len() + tagline.chars().count();
         let remaining = w.saturating_sub(plain_len);
         println!(
@@ -69,7 +77,6 @@ pub fn run() {
 
     // Version + platform (dimmed)
     {
-        let indent = "    ";
         let plain_len = indent.len() + meta.chars().count();
         let remaining = w.saturating_sub(plain_len);
         println!(

--- a/crates/applications/cli/src/commands/cmd_version.rs
+++ b/crates/applications/cli/src/commands/cmd_version.rs
@@ -1,6 +1,90 @@
-//! `gfs version` — print the CLI version.
+//! `gfs version` — print the CLI version with retro arcade-style ASCII art.
 
-/// Print the current gfs CLI version.
+use crate::output::{bold, dimmed, gold};
+
+/// Print the current gfs CLI version inside a retro branded box.
 pub fn run() {
-    println!("gfs {}", env!("CARGO_PKG_VERSION"));
+    let version = env!("CARGO_PKG_VERSION");
+    let target = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+
+    // Double-line box (DOS/retro style)
+    let tl = "╔";
+    let tr = "╗";
+    let bl = "╚";
+    let br = "╝";
+    let h = "═";
+    let v = "║";
+
+    let w: usize = 39; // inner visible width
+
+    let art = [
+        " ██████  ███████ ███████",
+        "██       ██      ██     ",
+        "██  ███  █████   ███████",
+        "██   ██  ██           ██",
+        " ██████  ██      ███████",
+    ];
+
+    let tagline = "Git For database Systems";
+    let meta = format!("v{} · rust · {}", version, target);
+
+    // Top border
+    println!("  {}{}{}", tl, h.repeat(w + 2), tr);
+
+    // Empty line
+    println!("  {} {} {}", v, " ".repeat(w), v);
+
+    // ASCII art lines (gold-colored block letters)
+    for line in &art {
+        let indent = "    ";
+        let plain_len = indent.len() + line.chars().count();
+        let remaining = w.saturating_sub(plain_len);
+        println!(
+            "  {} {}{}{} {}",
+            v,
+            indent,
+            gold(line),
+            " ".repeat(remaining),
+            v
+        );
+    }
+
+    // Empty line
+    println!("  {} {} {}", v, " ".repeat(w), v);
+
+    // Tagline (bold)
+    {
+        let indent = "    ";
+        let plain_len = indent.len() + tagline.chars().count();
+        let remaining = w.saturating_sub(plain_len);
+        println!(
+            "  {} {}{}{} {}",
+            v,
+            indent,
+            bold(tagline),
+            " ".repeat(remaining),
+            v
+        );
+    }
+
+    // Version + platform (dimmed)
+    {
+        let indent = "    ";
+        let plain_len = indent.len() + meta.chars().count();
+        let remaining = w.saturating_sub(plain_len);
+        println!(
+            "  {} {}{}{} {}",
+            v,
+            indent,
+            dimmed(&meta),
+            " ".repeat(remaining),
+            v
+        );
+    }
+
+    // Empty line
+    println!("  {} {} {}", v, " ".repeat(w), v);
+
+    // Bottom border
+    println!("  {}{}{}", bl, h.repeat(w + 2), br);
 }

--- a/crates/applications/cli/src/commands/mod.rs
+++ b/crates/applications/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod cmd_branch;
 pub mod cmd_checkout;
 pub mod cmd_commit;
 pub mod cmd_compute;

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -315,6 +315,14 @@ enum TopLevel {
         /// Show full 64-character commit hashes
         #[arg(long)]
         full_hash: bool,
+
+        /// Draw a text-based graph of the branch topology
+        #[arg(long)]
+        graph: bool,
+
+        /// Show commits from all branches (implies --graph)
+        #[arg(long)]
+        all: bool,
     },
 
     /// Show repository and compute status (current branch, container state, connection string)
@@ -559,8 +567,11 @@ where
                 from,
                 until,
                 full_hash,
+                graph,
+                all,
             } => {
-                commands::cmd_log::log(path, max_count, from, until, full_hash).await?;
+                commands::cmd_log::log(path, max_count, from, until, full_hash, graph, all)
+                    .await?;
                 Ok(0)
             }
             TopLevel::Status { path, output } => {

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -149,6 +149,10 @@ struct Cli {
     #[arg(long, global = true, default_value_t = ColorMode::Auto, value_enum)]
     color: ColorMode,
 
+    /// Output machine-readable JSON instead of styled text (for agent/script consumption)
+    #[arg(long, global = true)]
+    json: bool,
+
     #[command(subcommand)]
     command: TopLevel,
 }
@@ -473,8 +477,9 @@ where
     let version = env!("CARGO_PKG_VERSION");
     let os = std::env::consts::OS;
 
-    // Capture color before moving cli.command (ColorMode is Copy)
+    // Capture flags before moving cli.command
     let color = cli.color;
+    let json_output = cli.json;
 
     let result: Result<i32> = async move {
         match cli.command {
@@ -484,7 +489,7 @@ where
                 database_version,
                 port,
             } => {
-                commands::cmd_init::init(path, database_provider, database_version, port)
+                commands::cmd_init::init(path, database_provider, database_version, port, json_output)
                     .await
                     .map_err(|e| anyhow::anyhow!("{}", e))?;
                 Ok(0)
@@ -495,7 +500,7 @@ where
                 author,
                 author_email,
             } => {
-                commands::cmd_commit::commit(path, message, author, author_email).await?;
+                commands::cmd_commit::commit(path, message, author, author_email, json_output).await?;
                 Ok(0)
             }
             TopLevel::Config {
@@ -513,7 +518,7 @@ where
                 create_branch,
                 revision,
             } => {
-                commands::cmd_checkout::checkout(path, revision, create_branch).await?;
+                commands::cmd_checkout::checkout(path, revision, create_branch, json_output).await?;
                 Ok(0)
             }
             TopLevel::Branch {
@@ -532,7 +537,7 @@ where
                 format,
                 id,
             } => {
-                commands::cmd_export::run(path, output_dir, format, id).await?;
+                commands::cmd_export::run(path, output_dir, format, id, json_output).await?;
                 Ok(0)
             }
             TopLevel::Import {
@@ -541,7 +546,7 @@ where
                 format,
                 id,
             } => {
-                commands::cmd_import::run(path, file, format, id).await?;
+                commands::cmd_import::run(path, file, format, id, json_output).await?;
                 Ok(0)
             }
             TopLevel::Providers { provider } => {

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -332,8 +332,8 @@ enum TopLevel {
         path: Option<PathBuf>,
 
         /// Output format: table (default) or json
-        #[arg(long, default_value = "table", value_parser = ["table", "json"])]
-        output: String,
+        #[arg(long, value_parser = ["table", "json"])]
+        output: Option<String>,
     },
 
     /// Storage operations (mount, unmount, snapshot, clone, status, quota)
@@ -582,6 +582,11 @@ where
                 Ok(0)
             }
             TopLevel::Status { path, output } => {
+                let output = match output {
+                    Some(o) => o,
+                    None if json_output => "json".to_string(),
+                    None => "table".to_string(),
+                };
                 let exit_code = commands::cmd_status::run(path, output).await?;
                 Ok(exit_code)
             }

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -331,7 +331,7 @@ enum TopLevel {
         #[arg(long)]
         path: Option<PathBuf>,
 
-        /// Output format: table (default) or json
+        /// Output format: table (default) or json. Overrides the global --json flag.
         #[arg(long, value_parser = ["table", "json"])]
         output: Option<String>,
     },
@@ -430,6 +430,18 @@ enum StorageAction {
 // ---------------------------------------------------------------------------
 // Run entry point
 // ---------------------------------------------------------------------------
+
+/// Resolve the output format for commands that support `--output`.
+///
+/// Precedence: explicit `--output` wins; otherwise falls back to global `--json`;
+/// otherwise defaults to `"table"`.
+fn resolve_output_format(cmd_output: Option<String>, json_output: bool) -> String {
+    match cmd_output {
+        Some(fmt) => fmt,
+        None if json_output => "json".to_string(),
+        None => "table".to_string(),
+    }
+}
 
 fn command_name(cmd: &TopLevel) -> &'static str {
     match cmd {
@@ -544,7 +556,8 @@ where
                 checkout,
                 path,
             } => {
-                commands::cmd_branch::run(path, name, start_point, delete, checkout).await?;
+                commands::cmd_branch::run(path, name, start_point, delete, checkout, json_output)
+                    .await?;
                 Ok(0)
             }
             TopLevel::Export {
@@ -566,7 +579,8 @@ where
                 Ok(0)
             }
             TopLevel::Providers { provider } => {
-                commands::cmd_providers::run(provider).map_err(|e| anyhow::anyhow!("{}", e))?;
+                commands::cmd_providers::run(provider, json_output)
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
                 Ok(0)
             }
             TopLevel::Log {
@@ -578,15 +592,21 @@ where
                 graph,
                 all,
             } => {
-                commands::cmd_log::log(path, max_count, from, until, full_hash, graph, all).await?;
+                commands::cmd_log::log(commands::cmd_log::LogArgs {
+                    path,
+                    max_count,
+                    from,
+                    until,
+                    full_hash,
+                    graph,
+                    all,
+                    json_output,
+                })
+                .await?;
                 Ok(0)
             }
             TopLevel::Status { path, output } => {
-                let output = match output {
-                    Some(o) => o,
-                    None if json_output => "json".to_string(),
-                    None => "table".to_string(),
-                };
+                let output = resolve_output_format(output, json_output);
                 let exit_code = commands::cmd_status::run(path, output).await?;
                 Ok(exit_code)
             }
@@ -630,11 +650,11 @@ where
                 }
             },
             TopLevel::Storage { action } => {
-                run_storage(action).await?;
+                run_storage(action, json_output).await?;
                 Ok(0)
             }
             TopLevel::Compute { path, action } => {
-                run_compute(path, action).await?;
+                run_compute(path, action, json_output).await?;
                 Ok(0)
             }
             TopLevel::Mcp { path, action } => {
@@ -682,25 +702,26 @@ where
 // Storage dispatch
 // ---------------------------------------------------------------------------
 
-async fn run_storage(action: StorageAction) -> Result<()> {
+async fn run_storage(action: StorageAction, json_output: bool) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         use gfs_storage_apfs::ApfsStorage;
         let storage = ApfsStorage::new();
-        dispatch_storage(&storage, action).await
+        dispatch_storage(&storage, action, json_output).await
     }
 
     #[cfg(not(target_os = "macos"))]
     {
         use gfs_storage_file::FileStorage;
         let storage = FileStorage::new();
-        dispatch_storage(&storage, action).await
+        dispatch_storage(&storage, action, json_output).await
     }
 }
 
 async fn dispatch_storage(
     storage: &impl gfs_domain::ports::storage::StoragePort,
     action: StorageAction,
+    json_output: bool,
 ) -> Result<()> {
     match action {
         StorageAction::Mount { id, mount_point } => {
@@ -708,25 +729,47 @@ async fn dispatch_storage(
                 .mount(&VolumeId(id), &mount_point)
                 .await
                 .map_err(anyhow::Error::from)?;
-            println!("mounted");
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&json!({"status":"mounted"}))?);
+            } else {
+                println!("mounted");
+            }
         }
         StorageAction::Unmount { id } => {
             storage
                 .unmount(&VolumeId(id))
                 .await
                 .map_err(anyhow::Error::from)?;
-            println!("unmounted");
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&json!({"status":"unmounted"}))?);
+            } else {
+                println!("unmounted");
+            }
         }
         StorageAction::Snapshot { id, label } => {
             let snap = storage
                 .snapshot(&VolumeId(id), SnapshotOptions { label })
                 .await
                 .map_err(anyhow::Error::from)?;
-            println!("snapshot id  : {}", snap.id);
-            println!("volume       : {}", snap.volume_id);
-            println!("created_at   : {}", snap.created_at);
-            if let Some(lbl) = &snap.label {
-                println!("label        : {lbl}");
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "snapshot": {
+                            "id": snap.id.to_string(),
+                            "volume_id": snap.volume_id.to_string(),
+                            "created_at": snap.created_at.to_string(),
+                            "label": snap.label,
+                        }
+                    }))?
+                );
+            } else {
+                println!("snapshot id  : {}", snap.id);
+                println!("volume       : {}", snap.volume_id);
+                println!("created_at   : {}", snap.created_at);
+                if let Some(lbl) = &snap.label {
+                    println!("label        : {lbl}");
+                }
             }
         }
         StorageAction::Clone {
@@ -741,45 +784,76 @@ async fn dispatch_storage(
                 .clone(&VolumeId(source), VolumeId(target), opts)
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_volume_status(&status);
+            print_volume_status(&status, json_output)?;
         }
         StorageAction::Status { id } => {
             let status = storage
                 .status(&VolumeId(id))
                 .await
                 .map_err(anyhow::Error::from)?;
-            print_volume_status(&status);
+            print_volume_status(&status, json_output)?;
         }
         StorageAction::Quota { id } => {
             let quota = storage
                 .quota(&VolumeId(id))
                 .await
                 .map_err(anyhow::Error::from)?;
-            println!("volume      : {}", quota.volume_id);
-            println!("limit_bytes : {}", quota.limit_bytes);
-            println!("used_bytes  : {}", quota.used_bytes);
-            println!("free_bytes  : {}", quota.free_bytes);
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "quota": {
+                            "volume_id": quota.volume_id.to_string(),
+                            "limit_bytes": quota.limit_bytes,
+                            "used_bytes": quota.used_bytes,
+                            "free_bytes": quota.free_bytes,
+                        }
+                    }))?
+                );
+            } else {
+                println!("volume      : {}", quota.volume_id);
+                println!("limit_bytes : {}", quota.limit_bytes);
+                println!("used_bytes  : {}", quota.used_bytes);
+                println!("free_bytes  : {}", quota.free_bytes);
+            }
         }
     }
     Ok(())
 }
 
-async fn run_compute(path: Option<PathBuf>, action: ComputeAction) -> Result<()> {
-    commands::cmd_compute::run(path, action).await
+async fn run_compute(path: Option<PathBuf>, action: ComputeAction, json_output: bool) -> Result<()> {
+    commands::cmd_compute::run(path, action, json_output).await
 }
 
-fn print_volume_status(s: &gfs_domain::ports::storage::VolumeStatus) {
-    println!("id          : {}", s.id);
-    println!(
-        "mount_point : {}",
-        s.mount_point
-            .as_deref()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "-".to_owned())
-    );
-    println!("status      : {:?}", s.status);
-    println!("size_bytes  : {}", s.size_bytes);
-    println!("used_bytes  : {}", s.used_bytes);
+fn print_volume_status(s: &gfs_domain::ports::storage::VolumeStatus, json_output: bool) -> Result<()> {
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "volume": {
+                    "id": s.id.to_string(),
+                    "mount_point": s.mount_point.as_deref().map(|p| p.display().to_string()),
+                    "status": format!("{:?}", s.status),
+                    "size_bytes": s.size_bytes,
+                    "used_bytes": s.used_bytes,
+                }
+            }))?
+        );
+        Ok(())
+    } else {
+        println!("id          : {}", s.id);
+        println!(
+            "mount_point : {}",
+            s.mount_point
+                .as_deref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "-".to_owned())
+        );
+        println!("status      : {:?}", s.status);
+        println!("size_bytes  : {}", s.size_bytes);
+        println!("used_bytes  : {}", s.used_bytes);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -564,8 +564,8 @@ where
                 Ok(0)
             }
             TopLevel::Status { path, output } => {
-                commands::cmd_status::run(path, output).await?;
-                Ok(0)
+                let exit_code = commands::cmd_status::run(path, output).await?;
+                Ok(exit_code)
             }
             TopLevel::Query {
                 path,

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -730,7 +730,10 @@ async fn dispatch_storage(
                 .await
                 .map_err(anyhow::Error::from)?;
             if json_output {
-                println!("{}", serde_json::to_string_pretty(&json!({"status":"mounted"}))?);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({"status":"mounted"}))?
+                );
             } else {
                 println!("mounted");
             }
@@ -741,7 +744,10 @@ async fn dispatch_storage(
                 .await
                 .map_err(anyhow::Error::from)?;
             if json_output {
-                println!("{}", serde_json::to_string_pretty(&json!({"status":"unmounted"}))?);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({"status":"unmounted"}))?
+                );
             } else {
                 println!("unmounted");
             }
@@ -821,11 +827,18 @@ async fn dispatch_storage(
     Ok(())
 }
 
-async fn run_compute(path: Option<PathBuf>, action: ComputeAction, json_output: bool) -> Result<()> {
+async fn run_compute(
+    path: Option<PathBuf>,
+    action: ComputeAction,
+    json_output: bool,
+) -> Result<()> {
     commands::cmd_compute::run(path, action, json_output).await
 }
 
-fn print_volume_status(s: &gfs_domain::ports::storage::VolumeStatus, json_output: bool) -> Result<()> {
+fn print_volume_status(
+    s: &gfs_domain::ports::storage::VolumeStatus,
+    json_output: bool,
+) -> Result<()> {
     if json_output {
         println!(
             "{}",

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -497,9 +497,15 @@ where
                 database_version,
                 port,
             } => {
-                commands::cmd_init::init(path, database_provider, database_version, port, json_output)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                commands::cmd_init::init(
+                    path,
+                    database_provider,
+                    database_version,
+                    port,
+                    json_output,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
                 Ok(0)
             }
             TopLevel::Commit {
@@ -508,7 +514,8 @@ where
                 author,
                 author_email,
             } => {
-                commands::cmd_commit::commit(path, message, author, author_email, json_output).await?;
+                commands::cmd_commit::commit(path, message, author, author_email, json_output)
+                    .await?;
                 Ok(0)
             }
             TopLevel::Config {
@@ -526,7 +533,8 @@ where
                 create_branch,
                 revision,
             } => {
-                commands::cmd_checkout::checkout(path, revision, create_branch, json_output).await?;
+                commands::cmd_checkout::checkout(path, revision, create_branch, json_output)
+                    .await?;
                 Ok(0)
             }
             TopLevel::Branch {
@@ -570,8 +578,7 @@ where
                 graph,
                 all,
             } => {
-                commands::cmd_log::log(path, max_count, from, until, full_hash, graph, all)
-                    .await?;
+                commands::cmd_log::log(path, max_count, from, until, full_hash, graph, all).await?;
                 Ok(0)
             }
             TopLevel::Status { path, output } => {

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -223,6 +223,27 @@ enum TopLevel {
         revision: Option<String>,
     },
 
+    /// List, create, or delete branches
+    Branch {
+        /// Name of the branch to create (omit to list all branches)
+        name: Option<String>,
+
+        /// Commit or branch to start the new branch from (default: HEAD)
+        start_point: Option<String>,
+
+        /// Delete the named branch
+        #[arg(short = 'd', long)]
+        delete: Option<String>,
+
+        /// Switch to the new branch after creating it (like checkout -b)
+        #[arg(short = 'c', long)]
+        checkout: bool,
+
+        /// Path to the GFS repository root (default: current directory)
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+
     /// Export data from the running database instance to a file
     Export {
         /// Path to the GFS repository root (default: current directory)
@@ -404,6 +425,7 @@ fn command_name(cmd: &TopLevel) -> &'static str {
         TopLevel::Commit { .. } => "commit",
         TopLevel::Config { .. } => "config",
         TopLevel::Checkout { .. } => "checkout",
+        TopLevel::Branch { .. } => "branch",
         TopLevel::Export { .. } => "export",
         TopLevel::Import { .. } => "import",
         TopLevel::Providers { .. } => "providers",
@@ -492,6 +514,16 @@ where
                 revision,
             } => {
                 commands::cmd_checkout::checkout(path, revision, create_branch).await?;
+                Ok(0)
+            }
+            TopLevel::Branch {
+                name,
+                start_point,
+                delete,
+                checkout,
+                path,
+            } => {
+                commands::cmd_branch::run(path, name, start_point, delete, checkout).await?;
                 Ok(0)
             }
             TopLevel::Export {

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -833,7 +833,7 @@ fn print_volume_status(s: &gfs_domain::ports::storage::VolumeStatus, json_output
                 "volume": {
                     "id": s.id.to_string(),
                     "mount_point": s.mount_point.as_deref().map(|p| p.display().to_string()),
-                    "status": format!("{:?}", s.status),
+                    "status": s.status,
                     "size_bytes": s.size_bytes,
                     "used_bytes": s.used_bytes,
                 }

--- a/crates/applications/cli/src/main.rs
+++ b/crates/applications/cli/src/main.rs
@@ -3,6 +3,7 @@
 //! Thin wrapper around the library. See `gfs_cli::run()` for programmatic use.
 
 use gfs_cli::output::red;
+use serde_json::json;
 
 #[tokio::main]
 async fn main() {
@@ -11,12 +12,29 @@ async fn main() {
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
+        .with_writer(std::io::stderr)
         .init();
 
-    match gfs_cli::run(std::env::args()).await {
+    let args: Vec<String> = std::env::args().collect();
+    let wants_json = args.iter().any(|a| a == "--json");
+
+    match gfs_cli::run(args).await {
         Ok(exit_code) => std::process::exit(exit_code),
         Err(err) => {
-            eprintln!("{} {err:#}", red("error:"));
+            if wants_json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "error": {
+                            "message": err.to_string(),
+                            "details": format!("{err:#}"),
+                        }
+                    }))
+                    .unwrap_or_else(|_| "{\"error\":{\"message\":\"serialization failed\"}}".into())
+                );
+            } else {
+                eprintln!("{} {err:#}", red("error:"));
+            }
             std::process::exit(1);
         }
     }

--- a/crates/applications/cli/src/main.rs
+++ b/crates/applications/cli/src/main.rs
@@ -5,6 +5,22 @@
 use gfs_cli::output::red;
 use serde_json::json;
 
+fn wants_json(args: &[String]) -> bool {
+    for a in args {
+        if a == "--" {
+            break;
+        }
+        if a == "--json" {
+            return true;
+        }
+        if let Some(rest) = a.strip_prefix("--json=") {
+            let v = rest.trim().to_ascii_lowercase();
+            return matches!(v.as_str(), "1" | "true" | "yes" | "on");
+        }
+    }
+    false
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -16,7 +32,7 @@ async fn main() {
         .init();
 
     let args: Vec<String> = std::env::args().collect();
-    let wants_json = args.iter().any(|a| a == "--json");
+    let wants_json = wants_json(&args);
 
     match gfs_cli::run(args).await {
         Ok(exit_code) => std::process::exit(exit_code),

--- a/crates/applications/cli/src/output.rs
+++ b/crates/applications/cli/src/output.rs
@@ -167,3 +167,37 @@ pub fn tbl_rule(cols: &[usize], left: &str, mid: &str, right: &str) -> String {
     let segments: Vec<String> = cols.iter().map(|&w| TBL_H.repeat(w + 2)).collect();
     format!("  {}{}{}", left, segments.join(mid), right)
 }
+
+// ---------------------------------------------------------------------------
+// Box content formatting (key/value rows)
+// ---------------------------------------------------------------------------
+
+/// Format a key/value row for a rounded box panel.
+///
+/// Contract: `box_row()` expects `content` to already be padded to `box_width`
+/// visible chars. These helpers pad raw text first, then apply styling.
+pub fn fmt_box_row(label: &str, value: &str, label_width: usize, box_width: usize) -> String {
+    let value_w = box_width.saturating_sub(label_width).saturating_sub(1);
+    let padded_label = format!("{:<w$}", label, w = label_width);
+    let padded_value = format!("{:<w$}", value, w = value_w);
+    format!("{} {}", dimmed(&padded_label), padded_value)
+}
+
+/// Same as [`fmt_box_row`], but allows a colored value while padding based on `raw_value`.
+pub fn fmt_box_row_colored(
+    label: &str,
+    colored_value: &str,
+    raw_value: &str,
+    label_width: usize,
+    box_width: usize,
+) -> String {
+    let value_w = box_width.saturating_sub(label_width).saturating_sub(1);
+    let padded_label = format!("{:<w$}", label, w = label_width);
+    let remaining = value_w.saturating_sub(raw_value.chars().count());
+    format!(
+        "{} {}{}",
+        dimmed(&padded_label),
+        colored_value,
+        " ".repeat(remaining)
+    )
+}

--- a/crates/applications/cli/src/output.rs
+++ b/crates/applications/cli/src/output.rs
@@ -79,3 +79,91 @@ pub fn bold(s: impl AsRef<str>) -> String {
     let s = s.as_ref().to_string();
     format!("{}", s.if_supports_color(Stream::Stdout, |t| t.bold()))
 }
+
+/// Brand accent: bright yellow (GFS gold #ffcb51 mapped to ANSI).
+pub fn gold(s: impl AsRef<str>) -> String {
+    let s = s.as_ref().to_string();
+    format!(
+        "{}",
+        s.if_supports_color(Stream::Stdout, |t| t.bright_yellow())
+    )
+}
+
+/// Section header: bold + underline.
+pub fn header(s: impl AsRef<str>) -> String {
+    // Apply bold and underline separately to avoid chained-temporary issues.
+    let s = s.as_ref().to_string();
+    let bolded = format!("{}", s.if_supports_color(Stream::Stdout, |t| t.bold()));
+    format!(
+        "{}",
+        bolded.if_supports_color(Stream::Stdout, |t| t.underline())
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Unicode box-drawing characters
+// ---------------------------------------------------------------------------
+
+// Rounded corners for info panels / status boxes
+pub const BOX_TL: &str = "╭";
+pub const BOX_TR: &str = "╮";
+pub const BOX_BL: &str = "╰";
+pub const BOX_BR: &str = "╯";
+pub const BOX_H: &str = "─";
+pub const BOX_V: &str = "│";
+
+// Sharp corners for data tables
+pub const TBL_TL: &str = "┌";
+pub const TBL_TR: &str = "┐";
+pub const TBL_BL: &str = "└";
+pub const TBL_BR: &str = "┘";
+pub const TBL_V: &str = "│";
+pub const TBL_H: &str = "─";
+pub const TBL_CROSS: &str = "┼";
+pub const TBL_T_DOWN: &str = "┬";
+pub const TBL_T_UP: &str = "┴";
+pub const TBL_T_RIGHT: &str = "├";
+pub const TBL_T_LEFT: &str = "┤";
+
+// ---------------------------------------------------------------------------
+// Box-drawing helpers (rounded panels)
+// ---------------------------------------------------------------------------
+
+/// Top edge of a rounded box with an optional inline title.
+/// Example: `╭─ Repository ──────────────────╮`
+pub fn box_top(title: &str, width: usize) -> String {
+    if title.is_empty() {
+        format!("  {}{}{}", BOX_TL, BOX_H.repeat(width + 2), BOX_TR)
+    } else {
+        let label = format!("{} {} ", BOX_H, title);
+        let fill = width + 2 - label.chars().count().min(width + 2);
+        format!("  {}{}{}{}", BOX_TL, label, BOX_H.repeat(fill), BOX_TR)
+    }
+}
+
+/// A row inside a rounded box. `content` should be pre-padded to `width` visible chars.
+/// Example: `│ Branch               main     │`
+pub fn box_row(content: &str, width: usize) -> String {
+    // NOTE: content may contain ANSI escapes. Callers must ensure
+    // the *visible* portion is exactly `width` characters wide
+    // (pad raw text first, then apply color).
+    let _ = width; // used by callers for formatting
+    format!("  {} {} {}", BOX_V, content, BOX_V)
+}
+
+/// Bottom edge of a rounded box.
+/// Example: `╰──────────────────────────────╯`
+pub fn box_bottom(width: usize) -> String {
+    format!("  {}{}{}", BOX_BL, BOX_H.repeat(width + 2), BOX_BR)
+}
+
+// ---------------------------------------------------------------------------
+// Table-drawing helpers (sharp-cornered data tables)
+// ---------------------------------------------------------------------------
+
+/// Build a horizontal table rule from column widths.
+/// `left`, `mid`, `right` are the corner/junction characters.
+pub fn tbl_rule(cols: &[usize], left: &str, mid: &str, right: &str) -> String {
+    let segments: Vec<String> = cols.iter().map(|&w| TBL_H.repeat(w + 2)).collect();
+    format!("  {}{}{}", left, segments.join(mid), right)
+}

--- a/crates/applications/cli/tests/common/clickhouse.rs
+++ b/crates/applications/cli/tests/common/clickhouse.rs
@@ -4,11 +4,11 @@
 
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
 use super::cli_runner;
+use super::container_runtime;
 use gfs_domain::repo_utils::repo_layout;
 use tempfile::TempDir;
 
@@ -24,10 +24,10 @@ struct ContainerCleanupGuard {
 
 impl Drop for ContainerCleanupGuard {
     fn drop(&mut self) {
-        let _ = Command::new("docker")
+        let _ = container_runtime::runtime_command()
             .args(["stop", &self.initial_container_id])
             .output();
-        let _ = Command::new("docker")
+        let _ = container_runtime::runtime_command()
             .args(["rm", "-f", &self.initial_container_id])
             .output();
 
@@ -37,10 +37,10 @@ impl Drop for ContainerCleanupGuard {
             .map(|r| r.container_name)
             .filter(|id| id != &self.initial_container_id)
         {
-            let _ = Command::new("docker")
+            let _ = container_runtime::runtime_command()
                 .args(["stop", &current_container_id])
                 .output();
-            let _ = Command::new("docker")
+            let _ = container_runtime::runtime_command()
                 .args(["rm", "-f", &current_container_id])
                 .output();
         }
@@ -82,7 +82,7 @@ where
 pub fn run_clickhouse_query(container_id: &str, query: &str) -> String {
     let mut last_output = String::new();
     for _ in 0..10 {
-        let out = Command::new("docker")
+        let out = container_runtime::runtime_command()
             .args([
                 "exec",
                 container_id,
@@ -91,6 +91,8 @@ pub fn run_clickhouse_query(container_id: &str, query: &str) -> String {
                 TEST_USER,
                 "--password",
                 TEST_PASSWORD,
+                "--connect_timeout",
+                "2",
                 "--query",
                 query,
             ])
@@ -118,8 +120,9 @@ pub fn get_container_id(repo_path: &Path) -> String {
 }
 
 pub fn wait_for_clickhouse(container_id: &str) -> bool {
+    let mut last = String::new();
     for _ in 0..30 {
-        let ok = Command::new("docker")
+        let out = container_runtime::runtime_command()
             .args([
                 "exec",
                 container_id,
@@ -128,16 +131,25 @@ pub fn wait_for_clickhouse(container_id: &str) -> bool {
                 TEST_USER,
                 "--password",
                 TEST_PASSWORD,
+                "--connect_timeout",
+                "2",
                 "--query",
                 "SELECT 1",
             ])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+            .output();
+        let ok = out.as_ref().map(|o| o.status.success()).unwrap_or(false);
         if ok {
             return true;
         }
+        if let Ok(o) = out {
+            last = format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&o.stdout),
+                String::from_utf8_lossy(&o.stderr)
+            );
+        }
         thread::sleep(Duration::from_secs(1));
     }
+    eprintln!("clickhouse readiness failed, last output:\n{last}");
     false
 }

--- a/crates/applications/cli/tests/json_output.rs
+++ b/crates/applications/cli/tests/json_output.rs
@@ -1,0 +1,127 @@
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn gfs_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_gfs")
+}
+
+fn run_gfs(cwd: &Path, args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(gfs_bin())
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("failed to run gfs");
+
+    let code = out.status.code().unwrap_or(1);
+    let stdout = String::from_utf8(out.stdout).expect("stdout must be utf-8");
+    let stderr = String::from_utf8(out.stderr).expect("stderr must be utf-8");
+    (code, stdout, stderr)
+}
+
+fn assert_stdout_json(stdout: &str) -> Value {
+    assert!(
+        !stdout.trim().is_empty(),
+        "expected non-empty stdout JSON, got empty"
+    );
+    serde_json::from_str::<Value>(stdout).unwrap_or_else(|e| {
+        panic!("stdout is not valid JSON: {e}\n--- stdout ---\n{stdout}");
+    })
+}
+
+#[test]
+fn json_init_stdout_is_json() {
+    let tmp = TempDir::new().unwrap();
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "init", "."]);
+    assert_eq!(code, 0, "expected init to succeed");
+    let v = assert_stdout_json(&stdout);
+    assert!(
+        v.get("branch").is_some() && v.get("path").is_some(),
+        "expected init JSON to have branch + path"
+    );
+}
+
+#[test]
+fn json_status_stdout_is_json() {
+    let tmp = TempDir::new().unwrap();
+    run_gfs(tmp.path(), &["init", "."]);
+
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "status"]);
+    assert_eq!(code, 0, "expected status to succeed");
+    let v = assert_stdout_json(&stdout);
+    assert!(
+        v.get("current_branch").is_some(),
+        "expected status JSON to have current_branch"
+    );
+}
+
+#[test]
+fn json_providers_stdout_is_json() {
+    let tmp = TempDir::new().unwrap();
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "providers"]);
+    assert_eq!(code, 0, "expected providers to succeed");
+    let v = assert_stdout_json(&stdout);
+    assert!(
+        v.get("providers").is_some() || v.get("provider").is_some(),
+        "expected providers JSON to have providers/provider"
+    );
+}
+
+#[test]
+fn json_branch_stdout_is_json_in_empty_repo() {
+    let tmp = TempDir::new().unwrap();
+    run_gfs(tmp.path(), &["init", "."]);
+
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "branch"]);
+    assert_eq!(code, 0, "expected branch list to succeed");
+    let v = assert_stdout_json(&stdout);
+    assert!(
+        v.get("branches").is_some(),
+        "expected branch JSON to have branches"
+    );
+}
+
+#[test]
+fn json_log_stdout_is_json_in_empty_repo() {
+    let tmp = TempDir::new().unwrap();
+    run_gfs(tmp.path(), &["init", "."]);
+
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "log"]);
+    assert_eq!(code, 0, "expected log to succeed (empty list ok)");
+    let v = assert_stdout_json(&stdout);
+    assert!(v.get("commits").is_some(), "expected log JSON to have commits");
+}
+
+#[test]
+fn json_error_commit_outside_repo_is_json() {
+    let tmp = TempDir::new().unwrap();
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "commit", "-m", "x"]);
+    assert_eq!(code, 1, "expected commit outside repo to fail");
+    let v = assert_stdout_json(&stdout);
+    assert!(v.get("error").is_some(), "expected error envelope");
+}
+
+#[test]
+fn json_error_checkout_main_on_empty_repo_is_json() {
+    let tmp = TempDir::new().unwrap();
+    run_gfs(tmp.path(), &["init", "."]);
+
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "checkout", "main"]);
+    assert_eq!(code, 1, "expected checkout main on empty repo to fail");
+    let v = assert_stdout_json(&stdout);
+    assert!(v.get("error").is_some(), "expected error envelope");
+}
+
+#[test]
+fn json_error_compute_status_without_config_is_json() {
+    let tmp = TempDir::new().unwrap();
+    run_gfs(tmp.path(), &["init", "."]);
+
+    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "compute", "status"]);
+    assert_eq!(code, 1, "expected compute status without config to fail");
+    let v = assert_stdout_json(&stdout);
+    assert!(v.get("error").is_some(), "expected error envelope");
+}
+

--- a/crates/applications/cli/tests/json_output.rs
+++ b/crates/applications/cli/tests/json_output.rs
@@ -12,6 +12,8 @@ fn run_gfs(cwd: &Path, args: &[&str]) -> (i32, String, String) {
     let out = Command::new(gfs_bin())
         .current_dir(cwd)
         .args(args)
+        // Keep stderr clean for --json contract assertions.
+        .env("RUST_LOG", "off")
         .output()
         .expect("failed to run gfs");
 
@@ -31,6 +33,13 @@ fn assert_stdout_json(stdout: &str) -> Value {
     })
 }
 
+fn assert_stderr_empty(stderr: &str) {
+    assert!(
+        stderr.trim().is_empty(),
+        "expected empty stderr, got:\n--- stderr ---\n{stderr}"
+    );
+}
+
 #[test]
 fn json_init_stdout_is_json() {
     let tmp = TempDir::new().unwrap();
@@ -48,8 +57,9 @@ fn json_status_stdout_is_json() {
     let tmp = TempDir::new().unwrap();
     run_gfs(tmp.path(), &["init", "."]);
 
-    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "status"]);
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "status"]);
     assert_eq!(code, 0, "expected status to succeed");
+    assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(
         v.get("current_branch").is_some(),
@@ -60,8 +70,9 @@ fn json_status_stdout_is_json() {
 #[test]
 fn json_providers_stdout_is_json() {
     let tmp = TempDir::new().unwrap();
-    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "providers"]);
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "providers"]);
     assert_eq!(code, 0, "expected providers to succeed");
+    assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(
         v.get("providers").is_some() || v.get("provider").is_some(),
@@ -74,8 +85,9 @@ fn json_branch_stdout_is_json_in_empty_repo() {
     let tmp = TempDir::new().unwrap();
     run_gfs(tmp.path(), &["init", "."]);
 
-    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "branch"]);
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "branch"]);
     assert_eq!(code, 0, "expected branch list to succeed");
+    assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(
         v.get("branches").is_some(),
@@ -88,8 +100,9 @@ fn json_log_stdout_is_json_in_empty_repo() {
     let tmp = TempDir::new().unwrap();
     run_gfs(tmp.path(), &["init", "."]);
 
-    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "log"]);
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "log"]);
     assert_eq!(code, 0, "expected log to succeed (empty list ok)");
+    assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(v.get("commits").is_some(), "expected log JSON to have commits");
 }
@@ -97,8 +110,9 @@ fn json_log_stdout_is_json_in_empty_repo() {
 #[test]
 fn json_error_commit_outside_repo_is_json() {
     let tmp = TempDir::new().unwrap();
-    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "commit", "-m", "x"]);
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "commit", "-m", "x"]);
     assert_eq!(code, 1, "expected commit outside repo to fail");
+    assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(v.get("error").is_some(), "expected error envelope");
 }
@@ -108,8 +122,9 @@ fn json_error_checkout_main_on_empty_repo_is_json() {
     let tmp = TempDir::new().unwrap();
     run_gfs(tmp.path(), &["init", "."]);
 
-    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "checkout", "main"]);
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "checkout", "main"]);
     assert_eq!(code, 1, "expected checkout main on empty repo to fail");
+    assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(v.get("error").is_some(), "expected error envelope");
 }
@@ -119,8 +134,21 @@ fn json_error_compute_status_without_config_is_json() {
     let tmp = TempDir::new().unwrap();
     run_gfs(tmp.path(), &["init", "."]);
 
-    let (code, stdout, _stderr) = run_gfs(tmp.path(), &["--json", "compute", "status"]);
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "compute", "status"]);
     assert_eq!(code, 1, "expected compute status without config to fail");
+    assert_stderr_empty(&stderr);
+    let v = assert_stdout_json(&stdout);
+    assert!(v.get("error").is_some(), "expected error envelope");
+}
+
+#[test]
+fn json_error_compute_logs_without_config_is_json() {
+    let tmp = TempDir::new().unwrap();
+    run_gfs(tmp.path(), &["init", "."]);
+
+    let (code, stdout, stderr) = run_gfs(tmp.path(), &["--json", "compute", "logs"]);
+    assert_eq!(code, 1, "expected compute logs without config to fail");
+    assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(v.get("error").is_some(), "expected error envelope");
 }

--- a/crates/applications/cli/tests/json_output.rs
+++ b/crates/applications/cli/tests/json_output.rs
@@ -104,7 +104,10 @@ fn json_log_stdout_is_json_in_empty_repo() {
     assert_eq!(code, 0, "expected log to succeed (empty list ok)");
     assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
-    assert!(v.get("commits").is_some(), "expected log JSON to have commits");
+    assert!(
+        v.get("commits").is_some(),
+        "expected log JSON to have commits"
+    );
 }
 
 #[test]
@@ -152,4 +155,3 @@ fn json_error_compute_logs_without_config_is_json() {
     let v = assert_stdout_json(&stdout);
     assert!(v.get("error").is_some(), "expected error envelope");
 }
-

--- a/skills/use-gfs-cli/SKILL.md
+++ b/skills/use-gfs-cli/SKILL.md
@@ -31,6 +31,59 @@ Validate the installation:
 gfs version
 ```
 
+## Global Flags
+
+### `--json` — Machine-Readable Output
+
+Add `--json` before any subcommand for structured JSON output instead of styled text. This is the recommended approach for scripts and AI agents:
+
+```shell
+# Commit and get the hash programmatically
+gfs --json commit -m "add users table"
+# → {"hash":"b57732d8...","branch":"main","message":"add users table"}
+
+# Init and get the connection string
+gfs --json init --database-provider postgres --database-version 17
+# → {"path":"/my/project","branch":"main","config":".gfs/config.toml","provider":"postgres"}
+
+# Checkout and confirm
+gfs --json checkout -b feature/auth
+# → {"hash":"b57732d8...","branch":"feature/auth","new_branch":true}
+
+# Export and get the file path
+gfs --json export --format sql
+# → {"file_path":".gfs/exports/dump.sql","format":"sql"}
+```
+
+**Supported commands**: `init`, `commit`, `checkout`, `export`, `import`
+`gfs status --output json` also works (predates the global flag).
+
+### `--color` — Color Control
+
+```shell
+gfs --color never status   # No ANSI colors (for piping)
+gfs --color always log     # Force colors even when piped
+```
+
+### Exit Codes
+
+| Command | Code | Meaning |
+|---------|------|---------|
+| `gfs status` | 0 | Compute running or not configured |
+| `gfs status` | 1 | Compute configured but not running |
+| `gfs schema diff` | 0 | No schema changes |
+| `gfs schema diff` | 1 | Schema changes detected |
+| `gfs schema diff` | 2 | Breaking changes detected |
+
+Use exit codes for conditional logic:
+```shell
+if gfs status > /dev/null 2>&1; then
+    gfs query "SELECT 1"
+else
+    gfs compute start
+fi
+```
+
 ## Quick Start
 
 ### 1. Check available database providers
@@ -138,18 +191,33 @@ gfs log --max-count 10
 
 # View commits in a range
 gfs log --from main --until feature-branch
+
+# Show branch topology graph (all branches)
+gfs log --graph --all
+
+# Show graph for current branch only
+gfs log --graph
 ```
 
-### 3. Create Branches
-
-Experiment with database changes in isolated branches:
+### 3. Manage Branches
 
 ```shell
+# List all branches (* marks current)
+gfs branch
+
+# Create branch at HEAD (without switching)
+gfs branch feature-branch
+
+# Create branch from specific commit/checkpoint
+gfs branch release/v1.0 <commit_id>
+
 # Create and switch to new branch
+gfs branch -c feature-branch
+# or the classic shorthand:
 gfs checkout -b feature-branch
 
-# List available branches (shown in gfs log output)
-gfs log
+# Delete a branch
+gfs branch -d feature-branch
 ```
 
 ### 4. Switch Branches
@@ -363,11 +431,10 @@ gfs schema show HEAD~5
 # Compare schema changes over time
 gfs schema diff HEAD~10 HEAD
 
-# Export schema history
-for commit in $(gfs log --max-count 10 | grep "commit" | awk '{print $2}'); do
-  echo "=== Commit $commit ==="
-  gfs schema show $commit --ddl-only
-done
+# View schema across recent commits using rev~n notation
+gfs schema show HEAD~1 --ddl-only
+gfs schema show HEAD~2 --ddl-only
+gfs schema show HEAD~3 --ddl-only
 ```
 
 ### Rollback to Previous State
@@ -394,14 +461,17 @@ gfs commit -m "rolled back to working state"
 ### Audit Schema Changes
 
 ```shell
-# Find when a specific table was added
-gfs log | grep -A2 "users table"
+# View full commit history to find a specific change
+gfs log
 
 # Show schema at that commit
 gfs schema show <commit_id>
 
 # Compare with current schema
 gfs schema diff <commit_id> HEAD
+
+# Compare with pretty visual output
+gfs schema diff <commit_id> HEAD --pretty
 
 # Extract DDL for code review
 gfs schema show <commit_id> --ddl-only > schema-then.sql

--- a/skills/use-gfs-cli/SKILL.md
+++ b/skills/use-gfs-cli/SKILL.md
@@ -56,7 +56,11 @@ gfs --json export --format sql
 ```
 
 **Supported commands**: `init`, `commit`, `checkout`, `export`, `import`
-`gfs status --output json` also works (predates the global flag).
+
+**Status JSON**:
+- `gfs --json status` outputs JSON by default
+- `gfs status --output json` outputs JSON (explicit format)
+- `gfs status --output table` forces table output (overrides global `--json`)
 
 ### `--color` — Color Control
 

--- a/skills/use-gfs-mcp/SKILL.md
+++ b/skills/use-gfs-mcp/SKILL.md
@@ -163,6 +163,18 @@ Parameters:
 
 Returns: Success status and checked out revision.
 
+**Tip**: For branch listing and creation without switching, use the CLI with `--json`:
+```shell
+# List branches programmatically
+gfs branch
+
+# Create branch from checkpoint without switching
+gfs branch release/v1.0 <commit_hash>
+
+# Delete a branch
+gfs branch -d old-feature
+```
+
 ### 7. Database Container Management
 
 Tool: `compute`
@@ -376,6 +388,30 @@ If `show_schema` returns error about missing schema, the commit was created befo
 
 Check that GFS CLI is installed on MCP server host. Verify Docker is running for database operations. Review error messages in tool response for specific issues.
 
+## CLI Fallback with `--json`
+
+When MCP tools are unavailable or you need operations not yet exposed as MCP tools (e.g., branch management, graph log), use the GFS CLI with `--json` for structured output:
+
+```shell
+# Structured commit output
+gfs --json commit -m "checkpoint before migration"
+# → {"hash":"b57732d8...","branch":"main","message":"checkpoint before migration"}
+
+# Structured checkout output
+gfs --json checkout -b feature/migration
+# → {"hash":"b57732d8...","branch":"feature/migration","new_branch":true}
+
+# Branch listing
+gfs branch
+
+# Branch topology graph
+gfs log --graph --all
+```
+
+**Exit codes** for conditional logic:
+- `gfs status` → 0 (compute running) or 1 (compute down)
+- `gfs schema diff` → 0 (no changes), 1 (changes), 2 (breaking)
+
 ## Key Reminders
 
 1. **Always commit before mutations** - Create safety checkpoints with automatic schema capture
@@ -387,6 +423,7 @@ Check that GFS CLI is installed on MCP server host. Verify Docker is running for
 7. **Show_schema for documentation** - Use to document database structure at any point
 8. **Extract_schema for current state** - Capture current schema without commit
 9. **Tool responses are structured** - Parse JSON responses for programmatic access
+10. **Use `--json` for CLI fallback** - When MCP tools aren't available, CLI with `--json` gives structured output
 
 ## Environment Variables
 

--- a/skills/use-gfs-mcp/SKILL.md
+++ b/skills/use-gfs-mcp/SKILL.md
@@ -401,8 +401,11 @@ gfs --json commit -m "checkpoint before migration"
 gfs --json checkout -b feature/migration
 # → {"hash":"b57732d8...","branch":"feature/migration","new_branch":true}
 
-# Branch listing
-gfs branch
+# Repository status (JSON)
+gfs --json status
+
+# Branch listing (JSON)
+gfs --json branch
 
 # Branch topology graph
 gfs log --graph --all


### PR DESCRIPTION
<!--
Thank you for contributing to GFS!

Please follow the PR title conventions:
🎉 New Database Support: [name]
✨ Feature: add [description]
🐛 Fix: [description]
📝 Documentation update
🚨 Breaking change
-->

## Related issues

This PR combines the WWKoch CLI series (source PRs #46–#52) with follow-up `--json` hardening. It maps to these GitHub issues:

| Issue | Tracks |
|-------|--------|
| #56 | CLI visual overhaul (tables, banners, hierarchy) |
| #57 | `gfs log --graph` and `--all` |
| #58 | `gfs branch` (list, create, delete) |
| #59 | Connection string after `gfs init` with provider |
| #60 | Global `--json` (incl. `gfs status` vs `--output` precedence) |
| #61 | Meaningful `gfs status` exit codes |
| #62 | Skills / MCP documentation |

Closes #56
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62

## What
<!--
Describe what problem this change solves and why it's needed.
Provide background context for reviewers unfamiliar with this area.
-->

## Summary
This PR brings in the CLI visual overhaul series (WWKoch PRs #46–#52) plus follow-up hardening around the global `--json` contract.

## Scope (commits)
- CLI visual overhaul (Unicode boxes/tables + version banner)
- `gfs branch` command
- `gfs log --graph --all` DAG visualization
- `gfs init` shows connection string when provider configured
- Global `--json` flag + JSON output for supported commands
- `gfs status` meaningful exit codes + `--output json/table` precedence
- Hardening: JSON error envelope on failure, storage respects `--json`, `cmd_log` args struct
- Tests: integration tests enforce stdout JSON + clean stderr (with `RUST_LOG=off`)

## How
<!--
Explain how your code changes achieve the solution.
Highlight key implementation decisions and any trade-offs made.
-->

- CLI output overhaul is implemented in `crates/applications/cli/src/output.rs` and adopted across commands.
- New commands/flags live under `crates/applications/cli/src/commands/` (notably `cmd_branch.rs`, `cmd_log.rs`).
- Global `--json` wiring and `--output` precedence are handled in `crates/applications/cli/src/lib.rs`.
- JSON failure envelope is enforced at the binary boundary in `crates/applications/cli/src/main.rs`.
- Contract tests live in `crates/applications/cli/tests/json_output.rs`.

## Review Guide
<!--
Help reviewers navigate your changes:
1. Start with `src/main.rs` - main logic changes
2. `src/lib.rs` - supporting changes
3. Skip `tests/integration.rs` - just test updates
-->

1. `crates/applications/cli/src/output.rs`
2. `crates/applications/cli/src/commands/cmd_status.rs`
3. `crates/applications/cli/src/commands/cmd_log.rs`
4. `crates/applications/cli/src/commands/cmd_branch.rs`
5. `crates/applications/cli/src/lib.rs`
6. `crates/applications/cli/src/main.rs`
7. `crates/applications/cli/tests/json_output.rs`

## Testing
<!--
How was this tested? What scenarios were covered?
- [ ] Manual testing performed
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
-->

## Test plan
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`

- [x] Manual testing performed
- [x] Unit tests added/updated
- [x] E2E tests added/updated

## Documentation
<!--
- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)
-->

- [ ] Code comments added for complex logic
- [x] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact
<!--
What's the end result for users?
- What improves?
- Are there any breaking changes or side effects?
-->

- More polished CLI output (consistent Unicode panels/tables + retro version banner)
- Better CLI ergonomics (`branch`, `log --graph --all`, connection string on init)
- Machine-readable workflows via `--json` with hardened stdout/stderr contract
- No breaking changes intended for human output modes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`cargo test`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Format check passes (`cargo fmt --check`)
- [x] This PR can be safely reverted if needed
