### PR TITLE
feat: add CLI parameters for database initial credentials

### DIFF
--- a/crates/applications/cli/src/commands/cmd_init.rs
+++ b/crates/applications/cli/src/commands/cmd_init.rs
@@ -19,6 +19,9 @@ pub async fn init(
     database_provider: Option<String>,
     database_version: Option<String>,
     database_port: Option<u16>,
+    database_user: Option<String>,
+    database_password: Option<String>,
+    database_name: Option<String>,
     json_output: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing::trace!("Initializing Guepard environment at: {:?}", path);
@@ -46,6 +49,9 @@ pub async fn init(
             database_provider,
             database_version,
             database_port,
+            database_user,
+            database_password,
+            database_name,
         )
         .await?;
 

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -175,6 +175,18 @@ enum TopLevel {
         /// Host port to bind for the database container (e.g. 5432). Default: Docker auto-assigns.
         #[arg(long)]
         port: Option<u16>,
+
+        /// Database user (if provider is set)
+        #[arg(long)]
+        database_user: Option<String>,
+
+        /// Database password (if provider is set)
+        #[arg(long)]
+        database_password: Option<String>,
+
+        /// Database name (if provider is set)
+        #[arg(long)]
+        database_name: Option<String>,
     },
 
     /// Record a commit of the current repository state
@@ -508,12 +520,18 @@ where
                 database_provider,
                 database_version,
                 port,
+                database_user,
+                database_password,
+                database_name,
             } => {
                 commands::cmd_init::init(
                     path,
                     database_provider,
                     database_version,
                     port,
+                    database_user,
+                    database_password,
+                    database_name,
                     json_output,
                 )
                 .await

--- a/crates/domain/src/usecases/repository/init_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/init_repo_usecase.rs
@@ -68,6 +68,9 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
         database_provider: Option<String>,
         database_version: Option<String>,
         database_port: Option<u16>,
+        database_user: Option<String>,
+        database_password: Option<String>,
+        database_name: Option<String>,
     ) -> std::result::Result<(), InitRepoError> {
         self.repository.init(&path, mount_point).await?;
 
@@ -75,8 +78,16 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
             let version = database_version
                 .filter(|v| !v.is_empty())
                 .ok_or(InitRepoError::DatabaseVersionRequired)?;
-            self.deploy_database(&path, provider, version, database_port)
-                .await?;
+            self.deploy_database(
+                &path,
+                provider,
+                version,
+                database_port,
+                database_user,
+                database_password,
+                database_name,
+            )
+            .await?;
         }
 
         Ok(())
@@ -88,6 +99,9 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
         provider_name: String,
         database_version: String,
         database_port: Option<u16>,
+        database_user: Option<String>,
+        database_password: Option<String>,
+        database_name: Option<String>,
     ) -> std::result::Result<(), InitRepoError> {
         let compute = self.compute.as_ref().ok_or_else(|| {
             InitRepoError::Compute(ComputeError::Internal(
@@ -123,6 +137,29 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
             for mapping in &mut definition.ports {
                 if mapping.compute_port == provider.default_port() {
                     mapping.host_port = Some(port);
+                }
+            }
+        }
+
+        // Apply user-provided credentials if supported by the provider's env vars
+        if let Some(user) = database_user {
+            for env in &mut definition.env {
+                if env.name.contains("USER") {
+                    env.default = Some(user.clone());
+                }
+            }
+        }
+        if let Some(password) = database_password {
+            for env in &mut definition.env {
+                if env.name.contains("PASSWORD") {
+                    env.default = Some(password.clone());
+                }
+            }
+        }
+        if let Some(db) = database_name {
+            for env in &mut definition.env {
+                if env.name.contains("DB") || env.name.contains("DATABASE") {
+                    env.default = Some(db.clone());
                 }
             }
         }
@@ -553,7 +590,16 @@ mod tests {
             InitRepositoryUseCase::new(Arc::new(MockRepository), None, Arc::new(MockRegistry));
         let dir = tempfile::tempdir().unwrap();
         let result = usecase
-            .run(dir.path().to_path_buf(), None, None, None, None)
+            .run(
+                dir.path().to_path_buf(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .await;
         assert!(result.is_ok());
     }
@@ -573,6 +619,9 @@ mod tests {
                 Some("postgres".into()),
                 Some("17".into()),
                 None,
+                None,
+                None,
+                None,
             )
             .await;
         assert!(result.is_ok());
@@ -591,6 +640,9 @@ mod tests {
                 dir.path().to_path_buf(),
                 None,
                 Some("postgres".into()),
+                None,
+                None,
+                None,
                 None,
                 None,
             )
@@ -616,6 +668,9 @@ mod tests {
                 Some("mysql".into()),
                 Some("8".into()),
                 None,
+                None,
+                None,
+                None,
             )
             .await;
         assert!(matches!(
@@ -635,11 +690,33 @@ mod tests {
         let path = dir.path().to_path_buf();
 
         // First init succeeds
-        let first = usecase.run(path.clone(), None, None, None, None).await;
+        let first = usecase
+            .run(
+                path.clone(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
         assert!(first.is_ok(), "first init should succeed: {:?}", first);
 
         // Second init fails with AlreadyInitialized
-        let second = usecase.run(path, None, None, None, None).await;
+        let second = usecase
+            .run(
+                path,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
         assert!(
             matches!(
                 second,


### PR DESCRIPTION
This PR adds three new optional parameters to the `gfs init` command: `--database-user`, `--database-password`, and `--database-name`.

When a database provider is provisioned during initialization, these credentials are used to configure the container via its environment variables (e.g., `POSTGRES_USER`).

Changes:
- Updated `Cli` struct in `crates/applications/cli/src/lib.rs` to include the new arguments.
- Updated `init` command handler to pass these values to the use case.
- Updated `InitRepositoryUseCase` in `crates/domain` to apply these values to the `ComputeDefinition` environment variables.

Fixes #64