### PR TITLE
fix permission denied error on commit (gfs commit command)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1024,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "gfs-domain",
+ "tar",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1853,6 +1865,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
 name = "linear-map"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,7 +2074,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2110,6 +2134,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "posthog-rs"
@@ -2295,6 +2325,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3034,6 +3073,17 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4025,6 +4075,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ kube                 = { version = "3.0.1", features = ["runtime", "derive"] }
 k8s-openapi          = { version = "0.27.0", features = ["latest"] }
 bollard              = { version = "0.20" }
 sha2                 = { version = "0.10" }
+tar                  = { version = "0.4" }
 rmcp = { version = "0.16.0", features = [
     "server",
     "transport-streamable-http-server",

--- a/crates/adapters/compute-docker/Cargo.toml
+++ b/crates/adapters/compute-docker/Cargo.toml
@@ -12,6 +12,7 @@ async-trait               = { workspace = true }
 bollard                   = { workspace = true }
 chrono                    = { workspace = true }
 futures-util              = { version = "0.3" }
+tar                       = { workspace = true }
 gfs-domain = { workspace = true }
 thiserror                 = { workspace = true }
 tokio                     = { workspace = true }

--- a/crates/adapters/compute-docker/src/containers/clickhouse.rs
+++ b/crates/adapters/compute-docker/src/containers/clickhouse.rs
@@ -198,6 +198,14 @@ impl DatabaseProvider for ClickhouseProvider {
         Ok(vec![])
     }
 
+    fn data_dir_owner(&self) -> Option<&'static str> {
+        Some("clickhouse:clickhouse")
+    }
+
+    fn container_startup_probes(&self) -> &'static [&'static str] {
+        &["clickhouse-client --host 127.0.0.1 --query \"SELECT 1\" >/dev/null"]
+    }
+
     fn supported_export_formats(&self) -> Vec<DataFormat> {
         vec![DataFormat {
             id: "schema".into(),

--- a/crates/adapters/compute-docker/src/containers/mysql.rs
+++ b/crates/adapters/compute-docker/src/containers/mysql.rs
@@ -220,6 +220,18 @@ impl DatabaseProvider for MysqlProvider {
         Ok(vec![])
     }
 
+    fn data_dir_owner(&self) -> Option<&'static str> {
+        // Official MySQL image runs `mysqld` as `mysql`.
+        Some("mysql:mysql")
+    }
+
+    fn container_startup_probes(&self) -> &'static [&'static str] {
+        &[
+            "mysqladmin ping -h 127.0.0.1 -u root -p\"$MYSQL_ROOT_PASSWORD\" --silent",
+            "mysql -h 127.0.0.1 -u root -p\"$MYSQL_ROOT_PASSWORD\" -e \"SELECT 1;\" >/dev/null",
+        ]
+    }
+
     // -----------------------------------------------------------------------
     // Import / Export
     // -----------------------------------------------------------------------

--- a/crates/adapters/compute-docker/src/containers/mysql.rs
+++ b/crates/adapters/compute-docker/src/containers/mysql.rs
@@ -227,8 +227,8 @@ impl DatabaseProvider for MysqlProvider {
 
     fn container_startup_probes(&self) -> &'static [&'static str] {
         &[
-            "mysqladmin ping -h 127.0.0.1 -u root -p\"$MYSQL_ROOT_PASSWORD\" --silent",
-            "mysql -h 127.0.0.1 -u root -p\"$MYSQL_ROOT_PASSWORD\" -e \"SELECT 1;\" >/dev/null",
+            "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysqladmin ping -h 127.0.0.1 -u root --silent",
+            "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysql -h 127.0.0.1 -u root -e \"SELECT 1;\" >/dev/null",
         ]
     }
 

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -238,6 +238,17 @@ impl DatabaseProvider for PostgresqlProvider {
         ])
     }
 
+    fn data_dir_owner(&self) -> Option<&'static str> {
+        Some("postgres:postgres")
+    }
+
+    fn container_startup_probes(&self) -> &'static [&'static str] {
+        &[
+            "pg_isready -h 127.0.0.1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" >/dev/null",
+            "PGPASSWORD=\"$POSTGRES_PASSWORD\" psql -h 127.0.0.1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -v ON_ERROR_STOP=1 -c \"SELECT 1;\" >/dev/null",
+        ]
+    }
+
     // -----------------------------------------------------------------------
     // Import / Export
     // -----------------------------------------------------------------------

--- a/crates/adapters/compute-docker/src/error.rs
+++ b/crates/adapters/compute-docker/src/error.rs
@@ -50,7 +50,25 @@ pub(crate) fn classify(container_id: &str, err: bollard::errors::Error) -> Compu
                         ComputeError::Internal(message.clone())
                     }
                 }
-                _ => ComputeError::Internal(message.clone()),
+                _ => {
+                    // Rootless Podman / cgroup v1 hosts cannot freeze container
+                    // processes.  The daemon surfaces this as a 500 with a message
+                    // containing one of these phrases.
+                    let pause_phrases = [
+                        "cgroup",
+                        "freezing",
+                        "freeze",
+                        "pause is not",
+                        "cannot pause",
+                        "not supported",
+                        "rootless",
+                    ];
+                    if pause_phrases.iter().any(|p| msg.contains(p)) {
+                        ComputeError::PauseUnsupported(message.clone())
+                    } else {
+                        ComputeError::Internal(message.clone())
+                    }
+                }
             }
         }
         bollard::errors::Error::IOError { err } => ComputeError::Internal(err.to_string()),

--- a/crates/adapters/compute-docker/src/error.rs
+++ b/crates/adapters/compute-docker/src/error.rs
@@ -53,17 +53,22 @@ pub(crate) fn classify(container_id: &str, err: bollard::errors::Error) -> Compu
                 _ => {
                     // Rootless Podman / cgroup v1 hosts cannot freeze container
                     // processes.  The daemon surfaces this as a 500 with a message
-                    // containing one of these phrases.
-                    let pause_phrases = [
-                        "cgroup",
-                        "freezing",
-                        "freeze",
-                        "pause is not",
-                        "cannot pause",
-                        "not supported",
-                        "rootless",
-                    ];
-                    if pause_phrases.iter().any(|p| msg.contains(p)) {
+                    // that is semantically about *pausing* being unsupported.
+                    //
+                    // We require the message to be explicitly about pause/freeze
+                    // to avoid false-positives from unrelated 500 errors that
+                    // happen to mention "cgroup" or "not supported" in other contexts
+                    // (e.g. "cgroup memory limit exceeded", "network feature not supported").
+                    let is_about_pause =
+                        msg.contains("pause") || msg.contains("freeze") || msg.contains("freezing");
+                    let is_unsupported_reason = msg.contains("cgroup v1")
+                        || msg.contains("rootless")
+                        || msg.contains("pause is not")
+                        || msg.contains("cannot pause")
+                        || (msg.contains("cgroup")
+                            && (msg.contains("freeze") || msg.contains("pause")))
+                        || (msg.contains("not supported") && is_about_pause);
+                    if is_about_pause && is_unsupported_reason {
                         ComputeError::PauseUnsupported(message.clone())
                     } else {
                         ComputeError::Internal(message.clone())
@@ -134,6 +139,42 @@ mod tests {
     fn classify_500_internal() {
         let err = classify("c1", docker_err(500, "Server error"));
         assert!(matches!(err, ComputeError::Internal(s) if s == "Server error"));
+    }
+
+    #[test]
+    fn classify_500_cgroup_v1_freeze_is_pause_unsupported() {
+        let err = classify(
+            "c1",
+            docker_err(
+                500,
+                "OCI: cgroup v1 does not support freezing a single process",
+            ),
+        );
+        assert!(matches!(err, ComputeError::PauseUnsupported(_)));
+    }
+
+    #[test]
+    fn classify_500_pause_not_supported_rootless_is_pause_unsupported() {
+        let err = classify("c1", docker_err(500, "pause is not supported on rootless"));
+        assert!(matches!(err, ComputeError::PauseUnsupported(_)));
+    }
+
+    #[test]
+    fn classify_500_unrelated_cgroup_error_is_internal() {
+        let err = classify("c1", docker_err(500, "cgroup memory limit exceeded"));
+        assert!(
+            matches!(err, ComputeError::Internal(_)),
+            "unrelated cgroup error must not be classified as PauseUnsupported"
+        );
+    }
+
+    #[test]
+    fn classify_500_unrelated_not_supported_is_internal() {
+        let err = classify("c1", docker_err(500, "network feature not supported"));
+        assert!(
+            matches!(err, ComputeError::Internal(_)),
+            "unrelated 'not supported' message must not be classified as PauseUnsupported"
+        );
     }
 
     #[test]

--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -14,8 +14,9 @@
 pub mod containers;
 mod error;
 
+use std::io::ErrorKind;
 use std::io::Write as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use futures_util::{StreamExt, TryStreamExt};
@@ -27,6 +28,21 @@ use gfs_domain::ports::compute::{
 use tracing::instrument;
 
 use crate::error::classify;
+
+/// Reject tar paths that could escape `dest` (`..`, absolute components, etc.).
+fn tar_stripped_path_is_safe(stripped: &Path) -> bool {
+    if stripped.as_os_str().is_empty() {
+        return false;
+    }
+    for c in stripped.components() {
+        match c {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => return false,
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => return false,
+        }
+    }
+    true
+}
 
 /// Host path string suitable for Docker bind mounts. Verbatim Windows paths
 /// (`\\?\...`) break Docker’s `host:container` parsing; map them to normal paths.
@@ -902,17 +918,27 @@ impl Compute for DockerCompute {
         // Spawn the blocking unpack side first so the reader is already
         // consuming when the writer starts filling the pipe.
         let unpack = tokio::task::spawn_blocking(move || -> std::io::Result<usize> {
+            use std::io;
+
             let mut archive = tar::Archive::new(pipe_reader);
             archive.set_preserve_permissions(false);
             let mut files = 0usize;
             for entry in archive.entries()? {
                 let mut entry = entry?;
+                if entry.header().entry_type().is_symlink() {
+                    continue;
+                }
                 let raw_path = entry.path()?.into_owned();
                 // Strip the leading directory component Docker always adds.
-                let stripped: std::path::PathBuf =
-                    raw_path.components().skip(1).collect();
+                let stripped: PathBuf = raw_path.components().skip(1).collect();
                 if stripped.as_os_str().is_empty() {
                     continue;
+                }
+                if !tar_stripped_path_is_safe(&stripped) {
+                    return Err(io::Error::new(
+                        ErrorKind::InvalidData,
+                        format!("refusing unsafe tar path: {}", stripped.display()),
+                    ));
                 }
                 let dest_path = dest.join(&stripped);
                 if entry.header().entry_type().is_dir() {
@@ -971,6 +997,7 @@ impl DockerCompute {
             cmd: Some(vec!["sh".into(), "-c".into(), cmd.to_string()]),
             attach_stdout: Some(true),
             attach_stderr: Some(true),
+            user: Some("0:0".into()),
             ..Default::default()
         };
         let exec = self

--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -935,6 +935,38 @@ impl Compute for DockerCompute {
         result
     }
 
+    /// Stream a container's data directory out through `docker cp` and extract
+    /// it into `dest`. Used as the permission-denied fallback when the host
+    /// user cannot read files inside a bind-mounted container data dir.
+    ///
+    /// # Equivalence vs host-path snapshots
+    ///
+    /// On restore, a snapshot produced by this function must be
+    /// indistinguishable from one produced by `storage.snapshot` (the host-path
+    /// `cp --reflink=auto -a`). Three properties are worth spelling out:
+    ///
+    /// * **Directory modes.** This function chmods created directories to `0755`
+    ///   during extraction; the host path preserves whatever mode cp `-a` copied.
+    ///   Both converge because `FileStorage::snapshot` / `finalize_snapshot`
+    ///   runs `chmod -R u+rX,u-w,go-rwx` on the final tree, normalizing every
+    ///   directory to `0500` regardless of the starting mode.
+    /// * **Ownership.** This function extracts files as the host user running
+    ///   gfs. The host path preserves the container UID (e.g. `postgres:999`).
+    ///   The two diverge on disk in the snapshot, but `pre_start_repair_data_dir`
+    ///   in the checkout use case chowns the restored workspace to the target
+    ///   UID on every container start, so restored DB state is equivalent.
+    /// * **Hard-link topology.** Both paths preserve hard links (`cp -a` honors
+    ///   them; tar archives encode hard-link entries, which we recreate via
+    ///   `std::fs::hard_link`). Divergence can only occur if the hard-link
+    ///   target hasn't been extracted yet (treated as a hard error — see the
+    ///   `InvalidData` branch below) or if `hard_link` fails with EXDEV — which
+    ///   is effectively unreachable because `src` and `dest_path` both live
+    ///   under `dest`. A `warn!` fires if the EXDEV branch ever runs.
+    ///
+    /// Mode/permission clamps on individual file entries are intentionally
+    /// suppressed via `set_preserve_permissions(false)` because tar headers
+    /// from Docker may contain UID-specific modes the host user cannot stat;
+    /// the final mode is established by `finalize_snapshot`.
     #[instrument(skip(self))]
     async fn stream_snapshot(
         &self,
@@ -1119,11 +1151,21 @@ impl Compute for DockerCompute {
                         Err(e) if e.kind() != ErrorKind::PermissionDenied => {
                             // Cross-device link (EXDEV), unsupported filesystem, etc.:
                             // fall back to a regular copy so the snapshot still succeeds.
-                            tracing::debug!(
+                            //
+                            // This branch should be effectively unreachable: `src` and
+                            // `dest_path` are both below `dest` (the snapshot root), so
+                            // they share a filesystem. If this fires, the operator has
+                            // pointed `.gfs/snapshots/` at a path that crosses a mount
+                            // boundary — which breaks the hard-link topology guarantee
+                            // vs the host-snapshot path. Surfacing at `warn!` makes the
+                            // rare event observable in production logs.
+                            tracing::warn!(
                                 source = %src.display(),
                                 dest = %dest_path.display(),
                                 error = %e,
-                                "stream_snapshot: hard_link failed; falling back to copy"
+                                "stream_snapshot: hard_link failed — falling back to copy; \
+                                 snapshot's hard-link topology will differ from the source \
+                                 (possible if .gfs/snapshots/ spans a mount boundary)"
                             );
                             std::fs::copy(&src, &dest_path)?;
                         }

--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -44,6 +44,18 @@ fn tar_stripped_path_is_safe(stripped: &Path) -> bool {
     true
 }
 
+/// Validate a symlink target: must be non-empty, relative, and contain no `..` or root components.
+fn tar_link_target_is_safe(target: &Path) -> bool {
+    !target.as_os_str().is_empty()
+        && !target.is_absolute()
+        && target.components().all(|c| {
+            matches!(
+                c,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )
+        })
+}
+
 /// Host path string suitable for Docker bind mounts. Verbatim Windows paths
 /// (`\\?\...`) break Docker’s `host:container` parsing; map them to normal paths.
 fn host_path_for_docker_bind(path: &Path) -> String {
@@ -836,6 +848,8 @@ impl Compute for DockerCompute {
             host_config: Some(host_config),
             entrypoint: Some(vec!["sh".into(), "-c".into()]),
             cmd: Some(vec![command.to_string()]),
+            // Honour the user override from the definition (e.g. "0:0" for root-level repair tasks).
+            user: definition.user.clone(),
             ..Default::default()
         };
 
@@ -932,15 +946,6 @@ impl Compute for DockerCompute {
             .path(container_path)
             .build();
 
-        // `gfs commit` may have created a *partial* destination directory when the
-        // fast host snapshot (`cp`) failed mid-flight. That partial tree can contain
-        // non-traversable permissions (e.g. `000` dirs) that would prevent both
-        // cleanup and tar extraction. Be defensive here: repair + remove before
-        // unpacking the streamed snapshot.
-        if dest.exists() {
-            let _ = std::fs::remove_dir_all(dest);
-        }
-        std::fs::create_dir_all(dest).map_err(ComputeError::Io)?;
         let dest = dest.to_path_buf();
 
         // std::io::pipe() gives a synchronous (reader, writer) pair backed by
@@ -991,8 +996,9 @@ impl Compute for DockerCompute {
                 }
             }
 
-            // If a partial snapshot dir exists (created by failed host snapshot), make it
-            // traversable and remove it so the streamed snapshot can be unpacked cleanly.
+            // If a partial snapshot dir exists (from a failed host-side `cp` or a prior
+            // interrupted stream_snapshot run), repair any 000-mode dirs that would block
+            // traversal, then remove the whole tree so the fresh tar stream unpacks cleanly.
             if dest.exists() {
                 repair_tree_for_removal(&dest);
                 let _ = std::fs::remove_dir_all(&dest);
@@ -1006,9 +1012,8 @@ impl Compute for DockerCompute {
             for entry in archive.entries()? {
                 let mut entry = entry?;
                 let ty = entry.header().entry_type();
-                if ty.is_symlink() || ty.is_hard_link() {
-                    continue;
-                }
+
+                // Compute path components for all entry types.
                 let raw_path = entry.path()?.into_owned();
                 // Strip the leading directory component Docker always adds.
                 let stripped: PathBuf = raw_path.components().skip(1).collect();
@@ -1022,6 +1027,91 @@ impl Compute for DockerCompute {
                     ));
                 }
                 let dest_path = dest.join(&stripped);
+
+                if ty.is_symlink() {
+                    let raw_target = entry
+                        .header()
+                        .link_name()?
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                ErrorKind::InvalidData,
+                                format!(
+                                    "stream_snapshot: symlink '{}' has no link target",
+                                    stripped.display()
+                                ),
+                            )
+                        })?
+                        .into_owned();
+
+                    if !tar_link_target_is_safe(&raw_target) {
+                        return Err(io::Error::new(
+                            ErrorKind::InvalidData,
+                            format!(
+                                "stream_snapshot: symlink '{}' has external target '{}'; \
+                                 cannot capture data outside container data dir",
+                                stripped.display(),
+                                raw_target.display()
+                            ),
+                        ));
+                    }
+                    if let Some(parent) = dest_path.parent() {
+                        std::fs::create_dir_all(parent)?;
+                        chmod_best_effort(parent, 0o755);
+                    }
+                    #[cfg(unix)]
+                    {
+                        std::os::unix::fs::symlink(&raw_target, &dest_path)?;
+                        continue;
+                    }
+                    #[cfg(not(unix))]
+                    return Err(io::Error::new(
+                        ErrorKind::Unsupported,
+                        "stream_snapshot: symlinks not supported on this platform",
+                    ));
+                }
+
+                if ty.is_hard_link() {
+                    let raw_link = entry
+                        .header()
+                        .link_name()?
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                ErrorKind::InvalidData,
+                                format!(
+                                    "stream_snapshot: hard link '{}' has no source",
+                                    stripped.display()
+                                ),
+                            )
+                        })?
+                        .into_owned();
+                    let link_stripped: PathBuf = raw_link.components().skip(1).collect();
+                    if !tar_stripped_path_is_safe(&link_stripped) {
+                        return Err(io::Error::new(
+                            ErrorKind::InvalidData,
+                            format!(
+                                "stream_snapshot: hard link '{}' points to unsafe path",
+                                stripped.display()
+                            ),
+                        ));
+                    }
+                    let src = dest.join(&link_stripped);
+                    if !src.exists() {
+                        tracing::warn!(
+                            path = %stripped.display(),
+                            source = %link_stripped.display(),
+                            "stream_snapshot: hard link source not yet extracted; skipping"
+                        );
+                        continue;
+                    }
+                    if let Some(parent) = dest_path.parent() {
+                        std::fs::create_dir_all(parent)?;
+                        chmod_best_effort(parent, 0o755);
+                    }
+                    std::fs::copy(&src, &dest_path)?;
+                    files += 1;
+                    continue;
+                }
+
                 if entry.header().entry_type().is_dir() {
                     std::fs::create_dir_all(&dest_path)?;
                     chmod_best_effort(&dest_path, 0o755);
@@ -1217,6 +1307,34 @@ impl DockerCompute {
             return Err(ComputeError::Internal(msg));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tar_safety_tests {
+    use super::tar_link_target_is_safe;
+    use std::path::Path;
+
+    #[test]
+    fn relative_target_is_safe() {
+        assert!(tar_link_target_is_safe(Path::new("pg_wal")));
+        assert!(tar_link_target_is_safe(Path::new("./sub/dir")));
+    }
+
+    #[test]
+    fn empty_target_is_unsafe() {
+        assert!(!tar_link_target_is_safe(Path::new("")));
+    }
+
+    #[test]
+    fn absolute_target_is_unsafe() {
+        assert!(!tar_link_target_is_safe(Path::new("/tmp/external-wal")));
+    }
+
+    #[test]
+    fn parent_dir_component_is_unsafe() {
+        assert!(!tar_link_target_is_safe(Path::new("../escape")));
+        assert!(!tar_link_target_is_safe(Path::new("a/../../b")));
     }
 }
 

--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -1148,6 +1148,16 @@ impl Compute for DockerCompute {
             .map_err(ComputeError::Io)?;
 
         // Surface any stream error after the unpack has drained.
+        // Also guard against an empty archive — zero files means Docker returned
+        // an empty (or header-only) tar, which would commit an empty snapshot and
+        // cause the database to reinitialize on the next checkout (data loss).
+        if files == 0 {
+            return Err(ComputeError::Internal(format!(
+                "stream_snapshot: container '{container_path}' produced an empty archive \
+                 (0 regular files extracted); refusing to commit empty snapshot",
+                container_path = container_path,
+            )));
+        }
         //
         // When `tar::Archive` reaches the end-of-archive markers it may stop reading
         // even if the Docker stream still has trailing padding bytes. That closes the

--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -1044,15 +1044,16 @@ impl Compute for DockerCompute {
                         .into_owned();
 
                     if !tar_link_target_is_safe(&raw_target) {
-                        return Err(io::Error::new(
-                            ErrorKind::InvalidData,
-                            format!(
-                                "stream_snapshot: symlink '{}' has external target '{}'; \
-                                 cannot capture data outside container data dir",
-                                stripped.display(),
-                                raw_target.display()
-                            ),
-                        ));
+                        // Absolute or parent-escaping targets are legitimate in some DB setups
+                        // (e.g. PostgreSQL external tablespaces: pg_tblspc/<oid> → /mnt/...).
+                        // Capture the symlink as-is so the directory structure is preserved,
+                        // but warn that the target itself is not included in this snapshot.
+                        tracing::warn!(
+                            symlink = %stripped.display(),
+                            target = %raw_target.display(),
+                            "stream_snapshot: symlink points outside container data dir; \
+                             capturing dangling link (target is not snapshotted)"
+                        );
                     }
                     if let Some(parent) = dest_path.parent() {
                         std::fs::create_dir_all(parent)?;
@@ -1096,23 +1097,62 @@ impl Compute for DockerCompute {
                     }
                     let src = dest.join(&link_stripped);
                     if !src.exists() {
-                        tracing::warn!(
-                            path = %stripped.display(),
-                            source = %link_stripped.display(),
-                            "stream_snapshot: hard link source not yet extracted; skipping"
-                        );
-                        continue;
+                        return Err(io::Error::new(
+                            ErrorKind::InvalidData,
+                            format!(
+                                "stream_snapshot: hard link '{}' references '{}' which has \
+                                 not yet been extracted — tar stream is out of order or the \
+                                 archive is incomplete. This can happen with certain Docker \
+                                 versions that emit links before their source; retrying the \
+                                 commit or upgrading Docker typically resolves it",
+                                stripped.display(),
+                                link_stripped.display()
+                            ),
+                        ));
                     }
                     if let Some(parent) = dest_path.parent() {
                         std::fs::create_dir_all(parent)?;
                         chmod_best_effort(parent, 0o755);
                     }
-                    std::fs::copy(&src, &dest_path)?;
+                    match std::fs::hard_link(&src, &dest_path) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() != ErrorKind::PermissionDenied => {
+                            // Cross-device link (EXDEV), unsupported filesystem, etc.:
+                            // fall back to a regular copy so the snapshot still succeeds.
+                            tracing::debug!(
+                                source = %src.display(),
+                                dest = %dest_path.display(),
+                                error = %e,
+                                "stream_snapshot: hard_link failed; falling back to copy"
+                            );
+                            std::fs::copy(&src, &dest_path)?;
+                        }
+                        Err(e) => return Err(e),
+                    }
                     files += 1;
                     continue;
                 }
 
-                if entry.header().entry_type().is_dir() {
+                // Positive allow-list: at this point we've already handled symlinks and
+                // hard links. Anything remaining must be a directory or a regular file
+                // (`is_file()` covers both `Regular` and `Continuous`). Block, char, fifo,
+                // and any future exotic type would otherwise fall through to
+                // `entry.unpack()` and could create device nodes on the host — a container
+                // compromise vector. Reject them explicitly.
+                if !ty.is_dir() && !ty.is_file() {
+                    return Err(io::Error::new(
+                        ErrorKind::InvalidData,
+                        format!(
+                            "stream_snapshot: refusing to extract unexpected tar entry \
+                             type {:?} for '{}'; database workspaces must contain only \
+                             regular files, directories, symlinks, and hard links",
+                            ty,
+                            stripped.display()
+                        ),
+                    ));
+                }
+
+                if ty.is_dir() {
                     std::fs::create_dir_all(&dest_path)?;
                     chmod_best_effort(&dest_path, 0o755);
                 } else {

--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod containers;
 mod error;
 
+use std::io::Write as _;
 use std::path::Path;
 
 use async_trait::async_trait;
@@ -875,6 +876,88 @@ impl Compute for DockerCompute {
         let _ = self.docker.remove_container(&task_name, None).await;
 
         result
+    }
+
+    #[instrument(skip(self))]
+    async fn stream_snapshot(
+        &self,
+        id: &InstanceId,
+        container_path: &str,
+        dest: &Path,
+    ) -> Result<()> {
+        let opts = bollard::query_parameters::DownloadFromContainerOptionsBuilder::default()
+            .path(container_path)
+            .build();
+
+        std::fs::create_dir_all(dest).map_err(ComputeError::Io)?;
+        let dest = dest.to_path_buf();
+
+        // std::io::pipe() gives a synchronous (reader, writer) pair backed by
+        // an OS pipe — no heap allocation of the full archive.
+        // The writer end is fed from the async bollard stream; the reader end
+        // is consumed by `tar::Archive` inside a blocking thread.  Both sides
+        // run concurrently so back-pressure is handled by the OS pipe buffer.
+        let (pipe_reader, mut pipe_writer) = std::io::pipe().map_err(ComputeError::Io)?;
+
+        // Spawn the blocking unpack side first so the reader is already
+        // consuming when the writer starts filling the pipe.
+        let unpack = tokio::task::spawn_blocking(move || -> std::io::Result<usize> {
+            let mut archive = tar::Archive::new(pipe_reader);
+            archive.set_preserve_permissions(false);
+            let mut files = 0usize;
+            for entry in archive.entries()? {
+                let mut entry = entry?;
+                let raw_path = entry.path()?.into_owned();
+                // Strip the leading directory component Docker always adds.
+                let stripped: std::path::PathBuf =
+                    raw_path.components().skip(1).collect();
+                if stripped.as_os_str().is_empty() {
+                    continue;
+                }
+                let dest_path = dest.join(&stripped);
+                if entry.header().entry_type().is_dir() {
+                    std::fs::create_dir_all(&dest_path)?;
+                } else {
+                    if let Some(parent) = dest_path.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    entry.unpack(&dest_path)?;
+                    files += 1;
+                }
+            }
+            Ok(files)
+        });
+
+        // Drive the bollard stream into the pipe writer on the async side.
+        let container_name = id.0.clone();
+        let mut stream = self.docker.download_from_container(&id.0, Some(opts));
+        let write_result: Result<()> = async {
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.map_err(|e| classify(&container_name, e))?;
+                pipe_writer.write_all(&chunk).map_err(ComputeError::Io)?;
+            }
+            Ok(())
+        }
+        .await;
+
+        // Drop writer so the reader sees EOF and the unpack task can finish.
+        drop(pipe_writer);
+
+        let files = unpack
+            .await
+            .map_err(|e| ComputeError::Internal(format!("tar unpack task panicked: {e}")))?
+            .map_err(ComputeError::Io)?;
+
+        // Surface any stream error after the unpack has drained.
+        write_result?;
+
+        tracing::info!(
+            container = %id.0,
+            container_path,
+            files,
+            "stream_snapshot: unpacked tar archive from container"
+        );
+        Ok(())
     }
 }
 

--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -21,9 +21,9 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use futures_util::{StreamExt, TryStreamExt};
 use gfs_domain::ports::compute::{
-    Compute, ComputeDefinition, ComputeError, ExecOutput, InstanceConnectionInfo, InstanceId,
-    InstanceState, InstanceStatus, LogEntry, LogStream, LogsOptions, Result, RuntimeDescriptor,
-    StartOptions,
+    Compute, ComputeCapabilities, ComputeDefinition, ComputeError, ExecOutput,
+    InstanceConnectionInfo, InstanceId, InstanceState, InstanceStatus, LogEntry, LogStream,
+    LogsOptions, Result, RuntimeDescriptor, StartOptions,
 };
 use tracing::instrument;
 
@@ -534,7 +534,15 @@ impl Compute for DockerCompute {
             if cmd.trim().is_empty() {
                 continue;
             }
-            self.run_exec_command(id, cmd).await?;
+            let out = self.run_exec_command(id, cmd, Some("0:0")).await?;
+            if out.exit_code != 0 {
+                return Err(ComputeError::Internal(format!(
+                    "prepare_for_snapshot command failed (exit {}): {}\nstderr: {}",
+                    out.exit_code,
+                    cmd,
+                    out.stderr.trim()
+                )));
+            }
         }
 
         if self.is_podman_engine().await
@@ -544,7 +552,15 @@ impl Compute for DockerCompute {
             // on the host. Ensure they are host-readable before filesystem snapshot.
             let escaped = data_mount.replace('\'', "'\"'\"'");
             let chmod_cmd = format!("chmod -R a+rX '{}'", escaped);
-            self.run_exec_command(id, &chmod_cmd).await?;
+            let out = self.run_exec_command(id, &chmod_cmd, Some("0:0")).await?;
+            if out.exit_code != 0 {
+                return Err(ComputeError::Internal(format!(
+                    "prepare_for_snapshot chmod failed (exit {}): {}\nstderr: {}",
+                    out.exit_code,
+                    chmod_cmd,
+                    out.stderr.trim()
+                )));
+            }
         }
 
         Ok(())
@@ -552,6 +568,17 @@ impl Compute for DockerCompute {
 
     async fn describe_runtime(&self) -> Result<RuntimeDescriptor> {
         self.describe_runtime_impl().await
+    }
+
+    async fn capabilities(&self) -> Result<ComputeCapabilities> {
+        Ok(ComputeCapabilities {
+            supports_stream_snapshot: true,
+            supports_exec_as_root: true,
+        })
+    }
+
+    async fn exec(&self, id: &InstanceId, command: &str, user: Option<&str>) -> Result<ExecOutput> {
+        self.run_exec_command(id, command, user).await
     }
 
     #[instrument(skip(self))]
@@ -905,6 +932,14 @@ impl Compute for DockerCompute {
             .path(container_path)
             .build();
 
+        // `gfs commit` may have created a *partial* destination directory when the
+        // fast host snapshot (`cp`) failed mid-flight. That partial tree can contain
+        // non-traversable permissions (e.g. `000` dirs) that would prevent both
+        // cleanup and tar extraction. Be defensive here: repair + remove before
+        // unpacking the streamed snapshot.
+        if dest.exists() {
+            let _ = std::fs::remove_dir_all(dest);
+        }
         std::fs::create_dir_all(dest).map_err(ComputeError::Io)?;
         let dest = dest.to_path_buf();
 
@@ -919,13 +954,59 @@ impl Compute for DockerCompute {
         // consuming when the writer starts filling the pipe.
         let unpack = tokio::task::spawn_blocking(move || -> std::io::Result<usize> {
             use std::io;
+            #[cfg(unix)]
+            use std::os::unix::fs::PermissionsExt;
+
+            fn chmod_best_effort(path: &std::path::Path, mode: u32) {
+                #[cfg(unix)]
+                {
+                    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = mode;
+                    let _ = path;
+                }
+            }
+
+            fn repair_tree_for_removal(path: &std::path::Path) {
+                #[cfg(unix)]
+                {
+                    if let Ok(md) = std::fs::symlink_metadata(path) {
+                        if md.is_dir() {
+                            chmod_best_effort(path, 0o700);
+                            if let Ok(rd) = std::fs::read_dir(path) {
+                                for e in rd.flatten() {
+                                    repair_tree_for_removal(&e.path());
+                                }
+                            }
+                        } else {
+                            chmod_best_effort(path, 0o600);
+                        }
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = path;
+                }
+            }
+
+            // If a partial snapshot dir exists (created by failed host snapshot), make it
+            // traversable and remove it so the streamed snapshot can be unpacked cleanly.
+            if dest.exists() {
+                repair_tree_for_removal(&dest);
+                let _ = std::fs::remove_dir_all(&dest);
+            }
+            std::fs::create_dir_all(&dest)?;
+            chmod_best_effort(&dest, 0o755);
 
             let mut archive = tar::Archive::new(pipe_reader);
             archive.set_preserve_permissions(false);
             let mut files = 0usize;
             for entry in archive.entries()? {
                 let mut entry = entry?;
-                if entry.header().entry_type().is_symlink() {
+                let ty = entry.header().entry_type();
+                if ty.is_symlink() || ty.is_hard_link() {
                     continue;
                 }
                 let raw_path = entry.path()?.into_owned();
@@ -943,9 +1024,11 @@ impl Compute for DockerCompute {
                 let dest_path = dest.join(&stripped);
                 if entry.header().entry_type().is_dir() {
                     std::fs::create_dir_all(&dest_path)?;
+                    chmod_best_effort(&dest_path, 0o755);
                 } else {
                     if let Some(parent) = dest_path.parent() {
                         std::fs::create_dir_all(parent)?;
+                        chmod_best_effort(parent, 0o755);
                     }
                     entry.unpack(&dest_path)?;
                     files += 1;
@@ -975,7 +1058,17 @@ impl Compute for DockerCompute {
             .map_err(ComputeError::Io)?;
 
         // Surface any stream error after the unpack has drained.
-        write_result?;
+        //
+        // When `tar::Archive` reaches the end-of-archive markers it may stop reading
+        // even if the Docker stream still has trailing padding bytes. That closes the
+        // read end of the pipe and can produce a BrokenPipe on the writer.
+        // This is harmless as long as extraction completed successfully.
+        if let Err(e) = write_result {
+            match &e {
+                ComputeError::Io(ioe) if ioe.kind() == std::io::ErrorKind::BrokenPipe => {}
+                _ => return Err(e),
+            }
+        }
 
         tracing::info!(
             container = %id.0,
@@ -992,12 +1085,19 @@ impl Compute for DockerCompute {
 // ---------------------------------------------------------------------------
 
 impl DockerCompute {
-    async fn run_exec_command(&self, id: &InstanceId, cmd: &str) -> Result<()> {
+    async fn run_exec_command(
+        &self,
+        id: &InstanceId,
+        cmd: &str,
+        user: Option<&str>,
+    ) -> Result<ExecOutput> {
+        const MAX_CAPTURE_BYTES: usize = 256 * 1024; // per-stream cap
+
         let opts = bollard::exec::CreateExecOptions {
             cmd: Some(vec!["sh".into(), "-c".into(), cmd.to_string()]),
             attach_stdout: Some(true),
             attach_stderr: Some(true),
-            user: Some("0:0".into()),
+            user: user.map(|u| u.to_string()),
             ..Default::default()
         };
         let exec = self
@@ -1006,6 +1106,10 @@ impl DockerCompute {
             .await
             .map_err(|e| classify(&id.0, e))?;
 
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut stdout_truncated = false;
+        let mut stderr_truncated = false;
         match self
             .docker
             .start_exec(&exec.id, None::<bollard::exec::StartExecOptions>)
@@ -1013,10 +1117,30 @@ impl DockerCompute {
             .map_err(|e| classify(&id.0, e))?
         {
             bollard::exec::StartExecResults::Attached { output, .. } => {
-                output
-                    .try_collect::<Vec<_>>()
-                    .await
-                    .map_err(|e| classify(&id.0, e))?;
+                let mut output = output;
+                while let Some(item) = output.next().await {
+                    let f = item.map_err(|e| classify(&id.0, e))?;
+                    match f {
+                        bollard::container::LogOutput::StdOut { message }
+                        | bollard::container::LogOutput::Console { message } => {
+                            if stdout.len() < MAX_CAPTURE_BYTES {
+                                let remaining = MAX_CAPTURE_BYTES - stdout.len();
+                                stdout.extend_from_slice(&message[..message.len().min(remaining)]);
+                            } else {
+                                stdout_truncated = true;
+                            }
+                        }
+                        bollard::container::LogOutput::StdErr { message } => {
+                            if stderr.len() < MAX_CAPTURE_BYTES {
+                                let remaining = MAX_CAPTURE_BYTES - stderr.len();
+                                stderr.extend_from_slice(&message[..message.len().min(remaining)]);
+                            } else {
+                                stderr_truncated = true;
+                            }
+                        }
+                        bollard::container::LogOutput::StdIn { .. } => {}
+                    }
+                }
             }
             bollard::exec::StartExecResults::Detached => {}
         }
@@ -1027,14 +1151,23 @@ impl DockerCompute {
             .await
             .map_err(|e| classify(&id.0, e))?;
 
-        if inspect.exit_code != Some(0) {
-            return Err(gfs_domain::ports::compute::ComputeError::Internal(format!(
-                "prepare_for_snapshot command failed (exit {:?}): {}",
-                inspect.exit_code, cmd
-            )));
+        let mut stdout_s = String::from_utf8_lossy(&stdout).into_owned();
+        let mut stderr_s = String::from_utf8_lossy(&stderr).into_owned();
+        if stdout_truncated {
+            stdout_s.push_str("\n<stdout truncated>\n");
+        }
+        if stderr_truncated {
+            stderr_s.push_str("\n<stderr truncated>\n");
         }
 
-        Ok(())
+        Ok(ExecOutput {
+            exit_code: inspect
+                .exit_code
+                .and_then(|c| i32::try_from(c).ok())
+                .unwrap_or(-1),
+            stdout: stdout_s,
+            stderr: stderr_s,
+        })
     }
 
     async fn get_instance_data_mount_container_path(

--- a/crates/adapters/storage-apfs/src/lib.rs
+++ b/crates/adapters/storage-apfs/src/lib.rs
@@ -40,6 +40,25 @@ use tracing::instrument;
 
 use crate::error::classify_diskutil_stderr;
 
+async fn make_tree_read_only(path: &Path) -> Result<()> {
+    let chmod_out = Command::new("chmod")
+        .arg("-R")
+        .arg("a-w")
+        .arg(path)
+        .output()
+        .await
+        .map_err(StorageError::Io)?;
+    if !chmod_out.status.success() {
+        let stderr = String::from_utf8_lossy(&chmod_out.stderr);
+        return Err(StorageError::Internal(format!(
+            "chmod -R a-w '{}' failed: {}",
+            path.display(),
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // ApfsStorage
 // ---------------------------------------------------------------------------
@@ -145,30 +164,20 @@ impl StoragePort for ApfsStorage {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(StorageError::Internal(format!(
+            let msg = format!(
                 "cp -cRp '{}' '{}' failed: {}",
                 id,
                 dest.display(),
                 stderr.trim()
-            )));
+            );
+            let lower = stderr.to_ascii_lowercase();
+            if lower.contains("permission denied") || lower.contains("operation not permitted") {
+                return Err(StorageError::PermissionDenied(msg));
+            }
+            return Err(StorageError::Internal(msg));
         }
 
-        // Make the snapshot directory tree read-only so it cannot be modified.
-        let chmod_out = Command::new("chmod")
-            .arg("-R")
-            .arg("a-w")
-            .arg(&dest)
-            .output()
-            .await
-            .map_err(StorageError::Io)?;
-        if !chmod_out.status.success() {
-            let stderr = String::from_utf8_lossy(&chmod_out.stderr);
-            return Err(StorageError::Internal(format!(
-                "chmod -R a-w '{}' failed: {}",
-                dest.display(),
-                stderr.trim()
-            )));
-        }
+        make_tree_read_only(&dest).await?;
 
         Ok(Snapshot {
             id: SnapshotId(dest.to_string_lossy().into_owned()),
@@ -212,12 +221,17 @@ impl StoragePort for ApfsStorage {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(StorageError::Internal(format!(
+            let msg = format!(
                 "cp -cRp '{}' '{}' failed: {}",
                 src,
                 target_id,
                 stderr.trim()
-            )));
+            );
+            let lower = stderr.to_ascii_lowercase();
+            if lower.contains("permission denied") || lower.contains("operation not permitted") {
+                return Err(StorageError::PermissionDenied(msg));
+            }
+            return Err(StorageError::Internal(msg));
         }
 
         let target_path = PathBuf::from(&target_id.0);
@@ -260,6 +274,10 @@ impl StoragePort for ApfsStorage {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         parse_df_output(id, &stdout)
+    }
+
+    async fn finalize_snapshot(&self, dest: &Path) -> Result<()> {
+        make_tree_read_only(dest).await
     }
 }
 

--- a/crates/adapters/storage-apfs/src/lib.rs
+++ b/crates/adapters/storage-apfs/src/lib.rs
@@ -43,7 +43,7 @@ use crate::error::classify_diskutil_stderr;
 async fn make_tree_read_only(path: &Path) -> Result<()> {
     let chmod_out = Command::new("chmod")
         .arg("-R")
-        .arg("a-w")
+        .arg("u+rX,u-w,go-rwx")
         .arg(path)
         .output()
         .await
@@ -51,7 +51,7 @@ async fn make_tree_read_only(path: &Path) -> Result<()> {
     if !chmod_out.status.success() {
         let stderr = String::from_utf8_lossy(&chmod_out.stderr);
         return Err(StorageError::Internal(format!(
-            "chmod -R a-w '{}' failed: {}",
+            "chmod -R u+rX,u-w,go-rwx '{}' failed: {}",
             path.display(),
             stderr.trim()
         )));

--- a/crates/adapters/storage-apfs/src/lib.rs
+++ b/crates/adapters/storage-apfs/src/lib.rs
@@ -45,6 +45,7 @@ async fn make_tree_read_only(path: &Path) -> Result<()> {
         .arg("-R")
         .arg("u+rX,u-w,go-rwx")
         .arg(path)
+        .env("LANG", "C")
         .output()
         .await
         .map_err(StorageError::Io)?;
@@ -158,6 +159,7 @@ impl StoragePort for ApfsStorage {
 
         let output = Command::new("cp")
             .args(["-cRp", &id.0, dest.to_string_lossy().as_ref()])
+            .env("LANG", "C")
             .output()
             .await
             .map_err(StorageError::Io)?;
@@ -215,6 +217,7 @@ impl StoragePort for ApfsStorage {
 
         let output = Command::new("cp")
             .args(["-cRp", src, &target_id.0])
+            .env("LANG", "C")
             .output()
             .await
             .map_err(StorageError::Io)?;

--- a/crates/adapters/storage-btrfs/src/lib.rs
+++ b/crates/adapters/storage-btrfs/src/lib.rs
@@ -158,8 +158,11 @@ fn shell_quote(value: &str) -> String {
 
 #[cfg(target_os = "linux")]
 fn run_podman_unshare_sync(script: &str) -> std::io::Result<std::process::Output> {
+    // Force LANG=C so classify_stderr's substring matches (e.g. "permission
+    // denied") don't silently fail on localized hosts.
     StdCommand::new("podman")
         .args(["unshare", "sh", "-lc", script])
+        .env("LANG", "C")
         .output()
 }
 
@@ -167,6 +170,7 @@ fn run_podman_unshare_sync(script: &str) -> std::io::Result<std::process::Output
 async fn run_podman_unshare(script: &str) -> std::io::Result<std::process::Output> {
     Command::new("podman")
         .args(["unshare", "sh", "-lc", script])
+        .env("LANG", "C")
         .output()
         .await
 }
@@ -305,6 +309,7 @@ async fn run_btrfs(args: &[&str], path_for_errors: &Path) -> Result<()> {
 
     let output = Command::new("btrfs")
         .args(args)
+        .env("LANG", "C")
         .output()
         .await
         .map_err(StorageError::Io)?;
@@ -598,6 +603,13 @@ fn classify_stderr(volume_id: &str, stderr: &str) -> StorageError {
         StorageError::Busy(volume_id.to_owned())
     } else if lower.contains("already exists") || lower.contains("already exist") {
         StorageError::AlreadyExists(volume_id.to_owned())
+    } else if lower.contains("permission denied") || lower.contains("operation not permitted") {
+        // Surface as PermissionDenied so the commit use case can trigger the
+        // stream_snapshot fallback. Without this branch, rootful btrfs with
+        // UID-mismatched data dirs silently wraps the cp/subvolume failure as
+        // Internal, the `storage_error_looks_like_permission_denied` heuristic
+        // ignores it, and the commit fails hard instead of falling back.
+        StorageError::PermissionDenied(stderr.trim().to_owned())
     } else {
         StorageError::Internal(stderr.trim().to_owned())
     }
@@ -847,5 +859,49 @@ mod tests {
         assert!(!is_subvolume(&regular_dir));
 
         let _ = std::fs::remove_dir_all(&regular_dir);
+    }
+
+    /// Permission-denied failures from `btrfs subvolume snapshot/create/delete`
+    /// must surface as [`StorageError::PermissionDenied`] so the commit use case
+    /// can trigger the `stream_snapshot` fallback. Regression test for a bug
+    /// where the classifier wrapped these as `Internal` and the fallback never
+    /// fired on rootful btrfs with UID-mismatched data dirs.
+    #[test]
+    fn classify_stderr_maps_permission_denied() {
+        // Real-world btrfs-progs stderr strings observed on Linux 6.x, plus
+        // the lower-case `operation not permitted` variant that surfaces via
+        // `podman unshare sh -lc` wrappers.
+        let samples = [
+            "ERROR: cannot snapshot '/data': Permission denied",
+            "ERROR: Could not create subvolume: Operation not permitted",
+            "ERROR: cannot delete '/data': Permission denied",
+            "cp: cannot open '/data/pg_control' for reading: Permission denied",
+        ];
+        for stderr in samples {
+            let err = classify_stderr("/vol/x", stderr);
+            assert!(
+                matches!(err, StorageError::PermissionDenied(_)),
+                "expected PermissionDenied for stderr {stderr:?}, got {err:?}"
+            );
+        }
+    }
+
+    /// Non-permission errors must NOT get swallowed into PermissionDenied —
+    /// the fallback path is expensive (tar-streaming the whole data dir) and
+    /// must only trigger on the right failure class.
+    #[test]
+    fn classify_stderr_leaves_unrelated_errors_as_internal() {
+        let samples = [
+            "ERROR: no space left on device",
+            "ERROR: input/output error during snapshot",
+            "ERROR: quotacheck failed",
+        ];
+        for stderr in samples {
+            let err = classify_stderr("/vol/x", stderr);
+            assert!(
+                matches!(err, StorageError::Internal(_)),
+                "expected Internal for stderr {stderr:?}, got {err:?}"
+            );
+        }
     }
 }

--- a/crates/adapters/storage-btrfs/src/lib.rs
+++ b/crates/adapters/storage-btrfs/src/lib.rs
@@ -408,7 +408,7 @@ async fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Err(StorageError::Internal(format!(
+    let msg = format!(
         "copy '{}' -> '{}' failed: {}{}",
         src.display(),
         dst.display(),
@@ -418,7 +418,12 @@ async fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
         } else {
             String::new()
         }
-    )))
+    );
+    let lower = stderr.to_ascii_lowercase();
+    if lower.contains("permission denied") || lower.contains("operation not permitted") {
+        return Err(StorageError::PermissionDenied(msg));
+    }
+    Err(StorageError::Internal(msg))
 }
 
 #[cfg(target_os = "linux")]
@@ -736,6 +741,33 @@ impl StoragePort for BtrfsStorage {
         #[cfg(not(target_os = "linux"))]
         {
             let _ = id;
+            Err(unsupported())
+        }
+    }
+
+    async fn finalize_snapshot(&self, dest: &Path) -> Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            let output = Command::new("chmod")
+                .args(["-R", "a-w"])
+                .arg(dest)
+                .output()
+                .await
+                .map_err(StorageError::Io)?;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(StorageError::Internal(format!(
+                    "chmod -R a-w '{}' failed: {}",
+                    dest.display(),
+                    stderr.trim()
+                )));
+            }
+            return Ok(());
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = dest;
             Err(unsupported())
         }
     }

--- a/crates/adapters/storage-btrfs/src/lib.rs
+++ b/crates/adapters/storage-btrfs/src/lib.rs
@@ -749,7 +749,7 @@ impl StoragePort for BtrfsStorage {
         #[cfg(target_os = "linux")]
         {
             let output = Command::new("chmod")
-                .args(["-R", "a-w"])
+                .args(["-R", "u+rX,u-w,go-rwx"])
                 .arg(dest)
                 .output()
                 .await
@@ -757,7 +757,7 @@ impl StoragePort for BtrfsStorage {
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 return Err(StorageError::Internal(format!(
-                    "chmod -R a-w '{}' failed: {}",
+                    "chmod -R u+rX,u-w,go-rwx '{}' failed: {}",
                     dest.display(),
                     stderr.trim()
                 )));

--- a/crates/adapters/storage-btrfs/src/lib.rs
+++ b/crates/adapters/storage-btrfs/src/lib.rs
@@ -398,6 +398,7 @@ async fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
         .args(["--reflink=auto", "-a"])
         .arg(&source)
         .arg(dst)
+        .env("LANG", "C")
         .output()
         .await
         .map_err(StorageError::Io)?;
@@ -751,6 +752,7 @@ impl StoragePort for BtrfsStorage {
             let output = Command::new("chmod")
                 .args(["-R", "u+rX,u-w,go-rwx"])
                 .arg(dest)
+                .env("LANG", "C")
                 .output()
                 .await
                 .map_err(StorageError::Io)?;

--- a/crates/adapters/storage-file/src/lib.rs
+++ b/crates/adapters/storage-file/src/lib.rs
@@ -50,6 +50,14 @@ use tracing::instrument;
 
 use crate::error::classify_stderr;
 
+fn map_copy_error(stderr: &str, msg: String) -> StorageError {
+    let lower = stderr.to_ascii_lowercase();
+    if lower.contains("permission denied") || lower.contains("operation not permitted") {
+        return StorageError::PermissionDenied(msg);
+    }
+    StorageError::Internal(msg)
+}
+
 // ---------------------------------------------------------------------------
 // FileStorage (public struct, cross-platform)
 // ---------------------------------------------------------------------------
@@ -218,7 +226,7 @@ async fn copy_dir(src: &str, dst: &str) -> Result<()> {
     if !success {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
-        return Err(StorageError::Internal(format!(
+        let msg = format!(
             "copy '{}' -> '{}' failed: {}{}",
             src,
             dst,
@@ -228,7 +236,8 @@ async fn copy_dir(src: &str, dst: &str) -> Result<()> {
             } else {
                 String::new()
             }
-        )));
+        );
+        return Err(map_copy_error(&stderr, msg));
     }
     Ok(())
 }
@@ -469,6 +478,10 @@ impl StoragePort for FileStorage {
                 free_bytes: 0,
             })
         }
+    }
+
+    async fn finalize_snapshot(&self, dest: &Path) -> Result<()> {
+        make_read_only(dest).await
     }
 }
 

--- a/crates/adapters/storage-file/src/lib.rs
+++ b/crates/adapters/storage-file/src/lib.rs
@@ -117,7 +117,7 @@ async fn make_read_only(path: &Path) -> Result<()> {
         .map_err(StorageError::Io)?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
-        return Err(StorageError::Internal(format!(
+        return Err(map_copy_error(&stderr, format!(
             "chmod -R u+rX,u-w,go-rwx '{}' failed: {}",
             path.display(),
             stderr.trim()

--- a/crates/adapters/storage-file/src/lib.rs
+++ b/crates/adapters/storage-file/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! | Platform | `snapshot` / `clone` | Read-only lock | `status` / `quota` |
 //! |---|---|---|---|
-//! | macOS | `cp -cRp` (APFS clonefile COW) | `chmod -R a-w` | `diskutil info` / `df -k` |
-//! | Linux | `cp --reflink=auto -a` (Btrfs/XFS COW or deep copy) | `chmod -R a-w` | `df --block-size=1` |
+//! | macOS | `cp -cRp` (APFS clonefile COW) | `chmod -R u+rX,u-w,go-rwx` | `diskutil info` / `df -k` |
+//! | Linux | `cp --reflink=auto -a` (Btrfs/XFS COW or deep copy) | `chmod -R u+rX,u-w,go-rwx` | `df --block-size=1` |
 //! | Windows | `robocopy /E /COPY:DAT` | `attrib +R /S /D` | PowerShell `Get-PSDrive` |
 //!
 //! # mount / unmount
@@ -110,7 +110,7 @@ impl FileStorage {
 async fn make_read_only(path: &Path) -> Result<()> {
     let out = Command::new("chmod")
         .arg("-R")
-        .arg("a-w")
+        .arg("u+rX,u-w,go-rwx")
         .arg(path)
         .output()
         .await
@@ -118,7 +118,7 @@ async fn make_read_only(path: &Path) -> Result<()> {
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         return Err(StorageError::Internal(format!(
-            "chmod -R a-w '{}' failed: {}",
+            "chmod -R u+rX,u-w,go-rwx '{}' failed: {}",
             path.display(),
             stderr.trim()
         )));

--- a/crates/adapters/storage-file/src/lib.rs
+++ b/crates/adapters/storage-file/src/lib.rs
@@ -213,6 +213,8 @@ async fn copy_dir(src: &str, dst: &str) -> Result<()> {
 
     let output = Command::new(prog)
         .args(&args)
+        // Avoid locale-dependent stderr parsing (permission denied classification).
+        .env("LANG", "C")
         .output()
         .await
         .map_err(StorageError::Io)?;

--- a/crates/adapters/storage-file/src/lib.rs
+++ b/crates/adapters/storage-file/src/lib.rs
@@ -117,11 +117,14 @@ async fn make_read_only(path: &Path) -> Result<()> {
         .map_err(StorageError::Io)?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
-        return Err(map_copy_error(&stderr, format!(
-            "chmod -R u+rX,u-w,go-rwx '{}' failed: {}",
-            path.display(),
-            stderr.trim()
-        )));
+        return Err(map_copy_error(
+            &stderr,
+            format!(
+                "chmod -R u+rX,u-w,go-rwx '{}' failed: {}",
+                path.display(),
+                stderr.trim()
+            ),
+        ));
     }
     Ok(())
 }

--- a/crates/applications/cli/src/commands/cmd_compute.rs
+++ b/crates/applications/cli/src/commands/cmd_compute.rs
@@ -465,7 +465,13 @@ async fn start_restart_or_recreate(
     definition.host_data_dir = Some(std::path::PathBuf::from(&active));
     #[cfg(unix)]
     {
-        definition.user = current_user::current_user_uid_gid();
+        match current_user::current_user_uid_gid() {
+            Some(uid_gid) => definition.user = Some(uid_gid),
+            None => tracing::warn!(
+                "could not determine host uid:gid; container will run as its default user — \
+                 workspace files may be unreadable by the host user during snapshot"
+            ),
+        }
     }
     let new_id = compute.provision(&definition).await?;
     let status = compute.start(&new_id, Default::default()).await?;

--- a/crates/applications/cli/tests/e2e_checkout_postgres.rs
+++ b/crates/applications/cli/tests/e2e_checkout_postgres.rs
@@ -373,7 +373,7 @@ fn count_commits_from_main(repo_path: &Path) -> usize {
 
 #[test]
 #[serial]
-fn test_01_init_config_validate_commit_log() {
+fn postgres_test_01_init_config_validate_commit_log() {
     install_panic_cleanup_hook();
     let repo_path = shared_repo_path();
 
@@ -433,7 +433,7 @@ fn test_01_init_config_validate_commit_log() {
 
 #[test]
 #[serial]
-fn test_02_pgbench_commit_compute_status() {
+fn postgres_test_02_pgbench_commit_compute_status() {
     let repo_path = shared_repo_path();
     let container_id = get_container_id(repo_path).expect("container should exist from test_01");
 
@@ -486,7 +486,7 @@ fn test_02_pgbench_commit_compute_status() {
 
 #[test]
 #[serial]
-fn test_03_checkout_previous_no_pgbench() {
+fn postgres_test_03_checkout_previous_no_pgbench() {
     let repo_path = shared_repo_path();
     let hash1 = get_first_commit_hash(repo_path);
 
@@ -530,7 +530,7 @@ fn test_03_checkout_previous_no_pgbench() {
 
 #[test]
 #[serial]
-fn test_04_checkout_head_has_pgbench() {
+fn postgres_test_04_checkout_head_has_pgbench() {
     let repo_path = shared_repo_path();
 
     let start = Instant::now();
@@ -584,7 +584,7 @@ fn test_04_checkout_head_has_pgbench() {
 
 #[test]
 #[serial]
-fn test_05_checkout_b_new_branch_has_pgbench() {
+fn postgres_test_05_checkout_b_new_branch_has_pgbench() {
     let repo_path = shared_repo_path();
     // We are on main at tip (with pgbench). Create a new branch from current HEAD.
     let (ok, stdout, stderr) = cli_runner::gfs_checkout_b(repo_path, "pgbench-branch", None);
@@ -639,7 +639,7 @@ fn test_05_checkout_b_new_branch_has_pgbench() {
 
 #[test]
 #[serial]
-fn test_06_checkout_back_to_main() {
+fn postgres_test_06_checkout_back_to_main() {
     let repo_path = shared_repo_path();
 
     let (ok, stdout, stderr) = cli_runner::gfs_checkout(repo_path, "main");
@@ -691,6 +691,6 @@ fn test_06_checkout_back_to_main() {
 /// Must run last (use `--test-threads=1`). One-off containers are removed by their guard on drop.
 #[test]
 #[serial]
-fn test_99_cleanup_main_container() {
+fn postgres_test_99_cleanup_main_container() {
     cleanup_main_container(shared_repo_path());
 }

--- a/crates/applications/cli/tests/e2e_commit.rs
+++ b/crates/applications/cli/tests/e2e_commit.rs
@@ -349,7 +349,7 @@ fn commit_with_missing_mount_point_source_fails_gracefully() {
 }
 
 #[test]
-fn commit_with_real_database_snapshots_workspace() {
+fn commit_with_real_postgres_database_snapshots_workspace() {
     let tmp = tempdir().expect("create temp dir");
     let repo_path = tmp.path();
 

--- a/crates/applications/cli/tests/e2e_short_hash.rs
+++ b/crates/applications/cli/tests/e2e_short_hash.rs
@@ -79,7 +79,7 @@ fn gfs_init_with_database(path: &Path, provider: &str, version: &str) -> bool {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn log_shows_short_hash_by_default() {
+fn postgres_log_shows_short_hash_by_default() {
     let tmp = tempdir().expect("create temp dir");
     let repo_path = tmp.path();
 
@@ -124,7 +124,7 @@ fn log_shows_short_hash_by_default() {
 }
 
 #[test]
-fn log_shows_full_hash_with_flag() {
+fn postgres_log_shows_full_hash_with_flag() {
     let tmp = tempdir().expect("create temp dir");
     let repo_path = tmp.path();
 
@@ -167,7 +167,7 @@ fn log_shows_full_hash_with_flag() {
 }
 
 #[test]
-fn checkout_accepts_short_hash() {
+fn postgres_checkout_accepts_short_hash() {
     let tmp = tempdir().expect("create temp dir");
     let repo_path = tmp.path();
 
@@ -206,7 +206,7 @@ fn checkout_accepts_short_hash() {
 }
 
 #[test]
-fn short_hash_works_with_tilde_notation() {
+fn postgres_short_hash_works_with_tilde_notation() {
     let tmp = tempdir().expect("create temp dir");
     let repo_path = tmp.path();
 
@@ -263,7 +263,7 @@ fn short_hash_error_on_not_found() {
 }
 
 #[test]
-fn short_hash_minimum_length() {
+fn postgres_short_hash_minimum_length() {
     let tmp = tempdir().expect("create temp dir");
     let repo_path = tmp.path();
 

--- a/crates/applications/cli/tests/perf_snapshot_fallback.rs
+++ b/crates/applications/cli/tests/perf_snapshot_fallback.rs
@@ -1,0 +1,411 @@
+//! Manual perf sweep for snapshot paths.
+//!
+//! This test is intentionally `#[ignore]` so it does not run in CI. It measures:
+//! - baseline commit (host-side snapshot)
+//! - forced permission-denied fallback commit (stream_snapshot)
+//! - a heavier “real-ish” workload across multiple branches
+//!
+//! Run:
+//! - `cargo test -p gfs-cli perf_snapshot_paths -- --ignored --nocapture`
+//! - `cargo test -p gfs-cli perf_heavy_real_world -- --ignored --nocapture`
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use common::{cli_runner, container_runtime};
+use gfs_domain::repo_utils::repo_layout;
+use tempfile::Builder;
+
+fn run_cmd_timed(mut cmd: std::process::Command) -> (std::time::Duration, std::process::Output) {
+    let t0 = Instant::now();
+    let out = cmd.output().expect("command output");
+    (t0.elapsed(), out)
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn temp_repo_dir() -> tempfile::TempDir {
+    // Prefer a Docker-shareable dir on Linux (home), fall back to /var/tmp, then system temp.
+    let base = std::env::var("HOME")
+        .ok()
+        .map(|h| {
+            let p = PathBuf::from(h).join(".gfs-test-tmp");
+            let _ = std::fs::create_dir_all(&p);
+            p
+        })
+        .or_else(|| {
+            let p = PathBuf::from("/var/tmp");
+            p.exists().then_some(p)
+        })
+        .unwrap_or_else(std::env::temp_dir);
+
+    Builder::new()
+        .prefix("gfs-perf-")
+        .tempdir_in(base)
+        .expect("tempdir")
+}
+
+/// Guard that stops and removes a container on drop (best effort).
+struct ContainerCleanupGuard(String);
+
+impl Drop for ContainerCleanupGuard {
+    fn drop(&mut self) {
+        let _ = container_runtime::runtime_command()
+            .args(["stop", &self.0])
+            .output();
+        let _ = container_runtime::runtime_command()
+            .args(["rm", "-f", &self.0])
+            .output();
+    }
+}
+
+fn container_name(repo_path: &std::path::Path) -> String {
+    repo_layout::get_runtime_config(repo_path)
+        .ok()
+        .flatten()
+        .map(|r| r.container_name)
+        .expect("runtime config container_name")
+}
+
+fn psql(repo_path: &std::path::Path, sql: &str) {
+    let container = container_name(repo_path);
+    let out = container_runtime::runtime_command()
+        .args([
+            "exec",
+            &container,
+            "psql",
+            "-U",
+            "postgres",
+            "-d",
+            "postgres",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            sql,
+        ])
+        .output()
+        .expect("psql exec");
+    assert!(
+        out.status.success(),
+        "psql failed\ncontainer: {container}\nsql: {sql}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn head_ref_path(repo_path: &std::path::Path) -> PathBuf {
+    let head = std::fs::read_to_string(repo_path.join(".gfs/HEAD")).expect("HEAD");
+    let head = head.trim();
+    if let Some(rest) = head.strip_prefix("ref: ") {
+        return repo_path.join(".gfs").join(rest);
+    }
+    // Detached HEAD: HEAD file contains the hash itself.
+    repo_path.join(".gfs/HEAD")
+}
+
+fn head_commit_hash(repo_path: &std::path::Path) -> String {
+    let ref_path = head_ref_path(repo_path);
+    std::fs::read_to_string(&ref_path)
+        .unwrap_or_else(|_| panic!("head ref missing: {}", ref_path.display()))
+        .trim()
+        .to_string()
+}
+
+fn snapshot_dir_for_head(repo_path: &std::path::Path) -> PathBuf {
+    let commit_hash = head_commit_hash(repo_path);
+    let (d, f) = commit_hash.split_at(2);
+    let obj_bytes = std::fs::read(repo_path.join(".gfs/objects").join(d).join(f)).unwrap();
+    let commit: gfs_domain::model::commit::Commit = serde_json::from_slice(&obj_bytes).unwrap();
+    let (pfx, rest) = commit.snapshot_hash.split_at(2);
+    repo_path.join(".gfs/snapshots").join(pfx).join(rest)
+}
+
+#[test]
+#[ignore]
+fn perf_snapshot_paths() {
+    let tmp = temp_repo_dir();
+    let repo_path = tmp.path();
+
+    let (init_ok, init_stdout, init_stderr) = cli_runner::run_gfs(vec![
+        "gfs",
+        "init",
+        "--database-provider",
+        "postgres",
+        "--database-version",
+        "17",
+        repo_path.to_str().unwrap(),
+    ]);
+    assert!(
+        init_ok,
+        "gfs init failed\nstdout: {init_stdout}\nstderr: {init_stderr}"
+    );
+
+    let container_name = container_name(repo_path);
+    let _cleanup = ContainerCleanupGuard(container_name.clone());
+
+    // Baseline commit (host snapshot path).
+    let t0 = Instant::now();
+    let (ok1, _stdout1, stderr1) = cli_runner::gfs_commit(repo_path, "baseline", None, None);
+    let baseline_dt = t0.elapsed();
+    assert!(ok1, "baseline commit failed; stderr: {stderr1}");
+
+    // Force the permission-denied precondition.
+    let out = container_runtime::runtime_command()
+        .args([
+            "exec",
+            "-u",
+            "0:0",
+            &container_name,
+            "sh",
+            "-lc",
+            "touch /var/lib/postgresql/data/root_owned_test && chmod 600 /var/lib/postgresql/data/root_owned_test",
+        ])
+        .output()
+        .expect("docker exec");
+    assert!(
+        out.status.success(),
+        "failed to create root-owned file\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Fallback commit (should invoke stream_snapshot).
+    let t1 = Instant::now();
+    let (ok2, _stdout2, stderr2) = cli_runner::gfs_commit(repo_path, "after-root-file", None, None);
+    let fallback_dt = t1.elapsed();
+    assert!(ok2, "fallback commit failed; stderr: {stderr2}");
+    // The in-process runner may or may not capture tracing logs reliably. We validate fallback
+    // behavior by checking that the root-owned file made it into the snapshot and is readable.
+    let snapdir = snapshot_dir_for_head(repo_path);
+    let meta = std::fs::metadata(snapdir.join("root_owned_test")).expect("snapshot has file");
+    assert!(
+        meta.permissions().readonly(),
+        "expected snapshot file to be read-only (finalized)"
+    );
+
+    eprintln!(
+        "perf_snapshot_paths: baseline_commit_wall={:?}, fallback_commit_wall={:?}",
+        baseline_dt, fallback_dt
+    );
+}
+
+#[test]
+#[ignore]
+fn perf_heavy_real_world() {
+    // Tune via env vars:
+    // - GFS_PERF_ROWS (default 200000)
+    // - GFS_PERF_PAYLOAD_BYTES (default 512)
+    // - GFS_PERF_BRANCHES (default 3)
+    // - GFS_PERF_COMMITS_PER_BRANCH (default 3)
+    let rows = env_usize("GFS_PERF_ROWS", 200_000);
+    let payload_bytes = env_usize("GFS_PERF_PAYLOAD_BYTES", 512);
+    let branches = env_usize("GFS_PERF_BRANCHES", 3);
+    let commits_per_branch = env_usize("GFS_PERF_COMMITS_PER_BRANCH", 3);
+    let sleep_ms = env_u64("GFS_PERF_SLEEP_MS", 0);
+
+    let tmp = temp_repo_dir();
+    let repo_path = tmp.path();
+
+    let (init_ok, init_stdout, init_stderr) = cli_runner::run_gfs(vec![
+        "gfs",
+        "init",
+        "--database-provider",
+        "postgres",
+        "--database-version",
+        "17",
+        repo_path.to_str().unwrap(),
+    ]);
+    assert!(
+        init_ok,
+        "gfs init failed\nstdout: {init_stdout}\nstderr: {init_stderr}"
+    );
+
+    let container = container_name(repo_path);
+    let _cleanup = ContainerCleanupGuard(container.clone());
+
+    // Grow a realistic-ish DB.
+    // Use unlogged table for speed, then CHECKPOINT happens during commit anyway.
+    psql(
+        repo_path,
+        "CREATE UNLOGGED TABLE IF NOT EXISTS perf_big(id BIGINT PRIMARY KEY, payload TEXT);",
+    );
+    psql(repo_path, "TRUNCATE perf_big;");
+    psql(
+        repo_path,
+        &format!(
+            "INSERT INTO perf_big(id, payload)\n\
+             SELECT gs, repeat(md5(gs::text), CEIL({payload_bytes}::numeric / 32)::int)\n\
+             FROM generate_series(1, {rows}) AS gs;",
+        ),
+    );
+    psql(repo_path, "ANALYZE perf_big;");
+
+    // Baseline commit on main (host snapshot path expected).
+    let t0 = Instant::now();
+    let (ok, _out, err) = cli_runner::gfs_commit(repo_path, "heavy-main-0", None, None);
+    let main0_dt = t0.elapsed();
+    assert!(ok, "commit heavy-main-0 failed; stderr: {err}");
+    let main0_snap = snapshot_dir_for_head(repo_path);
+    let main0_size = std::fs::read_dir(&main0_snap).map(|_| ()).is_ok();
+    let _ = main0_size; // keep cheap; size is measured via du below.
+
+    let du0 = std::process::Command::new("du")
+        .args(["-sb", main0_snap.to_str().unwrap()])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default();
+
+    // Snapshot-only timing (best-effort, does not affect correctness):
+    // - host path: cp --reflink=auto -a <workspace>/. <dest>
+    // - stream-ish path: docker cp <container>:<PGDATA>/. <dest>
+    let workspace = repo_path.join(".gfs/workspaces/main/0/data");
+    let snap_only_host = {
+        let dest = repo_path.join(".gfs/tmp").join("perf-snap-only-host");
+        let _ = std::fs::remove_dir_all(&dest);
+        std::fs::create_dir_all(&dest).ok();
+        let mut cmd = std::process::Command::new("cp");
+        cmd.args(["--reflink=auto", "-a"])
+            .arg(workspace.join("."))
+            .arg(&dest);
+        let (dt, out) = run_cmd_timed(cmd);
+        let ok = out.status.success();
+        (ok, dt, String::from_utf8_lossy(&out.stderr).to_string())
+    };
+    let snap_only_docker = {
+        let dest = repo_path.join(".gfs/tmp").join("perf-snap-only-docker");
+        let _ = std::fs::remove_dir_all(&dest);
+        std::fs::create_dir_all(&dest).ok();
+        let container = container_name(repo_path);
+        let mut cmd = container_runtime::runtime_command();
+        cmd.args([
+            "cp",
+            &format!("{container}:/var/lib/postgresql/data/."),
+            dest.to_str().unwrap(),
+        ]);
+        let (dt, out) = run_cmd_timed(cmd);
+        let ok = out.status.success();
+        (ok, dt, String::from_utf8_lossy(&out.stderr).to_string())
+    };
+
+    eprintln!(
+        "perf_heavy_real_world: main_commit_0_wall={main0_dt:?} du={du0:?} snap_only_host={:?} ok={} snap_only_docker={:?} ok={}",
+        snap_only_host.1, snap_only_host.0, snap_only_docker.1, snap_only_docker.0
+    );
+    if !snap_only_host.0 {
+        eprintln!(
+            "perf_heavy_real_world: snap_only_host stderr={}",
+            snap_only_host.2.trim()
+        );
+    }
+    if !snap_only_docker.0 {
+        eprintln!(
+            "perf_heavy_real_world: snap_only_docker stderr={}",
+            snap_only_docker.2.trim()
+        );
+    }
+
+    // Create multiple branches and do commits.
+    for b in 0..branches {
+        let branch = format!("perf/b{b}");
+        let (ok, _o, e) = cli_runner::run_gfs(vec![
+            "gfs",
+            "checkout",
+            "--path",
+            repo_path.to_str().unwrap(),
+            "-b",
+            &branch,
+        ]);
+        assert!(ok, "checkout -b {branch} failed: {e}");
+
+        // Each branch: do a few commits; on the last branch + last commit, force fallback.
+        for c in 0..commits_per_branch {
+            // Mutate DB a bit so snapshot diffs are real.
+            psql(
+                repo_path,
+                &format!(
+                    "INSERT INTO perf_big(id, payload)\n\
+                     SELECT {base} + gs, repeat(md5(({base}+gs)::text), 8)\n\
+                     FROM generate_series(1, 5000) AS gs;",
+                    base = (b * 10_000_000 + c * 100_000) as u64
+                ),
+            );
+
+            if sleep_ms > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(sleep_ms));
+            }
+
+            let want_fallback = b + 1 == branches && c + 1 == commits_per_branch;
+            if want_fallback {
+                // Deterministically trigger PermissionDenied in the bind mount.
+                let container = container_name(repo_path);
+                let out = container_runtime::runtime_command()
+                    .args([
+                        "exec",
+                        "-u",
+                        "0:0",
+                        &container,
+                        "sh",
+                        "-lc",
+                        "touch /var/lib/postgresql/data/root_owned_test && chmod 600 /var/lib/postgresql/data/root_owned_test",
+                    ])
+                    .output()
+                    .expect("docker exec");
+                assert!(out.status.success(), "failed to set up fallback trigger");
+            }
+
+            let msg = format!("{branch}-c{c}");
+            let t = Instant::now();
+            let (ok, _out, err) = cli_runner::gfs_commit(repo_path, &msg, None, None);
+            let dt = t.elapsed();
+            assert!(ok, "commit {msg} failed; stderr: {err}");
+
+            let snap = snapshot_dir_for_head(repo_path);
+            let du = std::process::Command::new("du")
+                .args(["-sb", snap.to_str().unwrap()])
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .unwrap_or_default();
+
+            if want_fallback {
+                let meta =
+                    std::fs::metadata(snap.join("root_owned_test")).expect("snapshot has file");
+                assert!(
+                    meta.permissions().readonly(),
+                    "expected fallback snapshot file to be read-only (finalized)"
+                );
+            }
+
+            eprintln!(
+                "perf_heavy_real_world: branch={branch} commit={c} fallback={want_fallback} wall={dt:?} du={du:?}"
+            );
+        }
+
+        // Return to main between branches to simulate real branching workflow.
+        let (ok, _o, e) = cli_runner::run_gfs(vec![
+            "gfs",
+            "checkout",
+            "--path",
+            repo_path.to_str().unwrap(),
+            "main",
+        ]);
+        assert!(ok, "checkout main failed: {e}");
+    }
+}

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -1043,7 +1043,13 @@ async fn start_or_restart(
         definition.host_data_dir = Some(std::path::PathBuf::from(&active));
         #[cfg(unix)]
         {
-            definition.user = current_user::current_user_uid_gid();
+            match current_user::current_user_uid_gid() {
+                Some(uid_gid) => definition.user = Some(uid_gid),
+                None => tracing::warn!(
+                    "could not determine host uid:gid; container will run as its default user — \
+                     workspace files may be unreadable by the host user during snapshot"
+                ),
+            }
         }
         let new_id = compute
             .provision(&definition)

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -18,6 +18,7 @@ bincode     = { workspace = true, features = ["serde"] }
 anyhow      = { workspace = true }
 tracing     = { workspace = true }
 sha2        = { workspace = true }
+tokio       = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -559,6 +559,10 @@ impl Repository for GfsRepository {
                 // Remove stale Postgres lock files so a new instance can start on this copy.
                 let _ = fs::remove_file(workspace_path.join("postmaster.pid"));
                 let _ = fs::remove_file(workspace_path.join("postmaster.opts"));
+                // Signal that a pre-start ownership repair is required for this workspace.
+                if let Some(parent) = workspace_path.parent() {
+                    let _ = fs::write(parent.join(".needs-repair"), b"");
+                }
             } else {
                 tracing::warn!(
                     "Checkout: snapshot_dir does not exist or is not a directory, creating empty workspace"

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -385,14 +385,17 @@ fn set_workspace_dir_permissions(path: &Path) -> std::io::Result<()> {
             };
 
             if is_permission_error {
-                let unshare = run_podman_unshare(&format!(
-                    "chmod -R 0700 {}",
-                    shell_quote(&path.to_string_lossy())
-                ));
-                if let Ok(unshare) = unshare
-                    && unshare.status.success()
+                #[cfg(target_os = "linux")]
                 {
-                    return Ok(());
+                    let unshare = run_podman_unshare(&format!(
+                        "chmod -R 0700 {}",
+                        shell_quote(&path.to_string_lossy())
+                    ));
+                    if let Ok(unshare) = unshare
+                        && unshare.status.success()
+                    {
+                        return Ok(());
+                    }
                 }
 
                 tracing::warn!(

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -64,16 +64,17 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
             return Ok(());
         }
 
-        if is_permission_error_output(&output)
-            && run_podman_unshare(&format!(
+        if is_permission_error_output(&output) {
+            if let Ok(unshare) = run_podman_unshare(&format!(
                 "cp --reflink=auto -a {}/. {}",
                 shell_quote(&src.to_string_lossy()),
                 shell_quote(&dst.to_string_lossy())
-            ))?
-            .status
-            .success()
-        {
-            return Ok(());
+            )) {
+                if unshare.status.success() {
+                    return Ok(());
+                }
+            }
+            // podman unavailable or also failed — report the original cp error
         }
 
         Err(command_error("cp --reflink=auto -a failed", &output))

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -43,6 +43,7 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
             .arg("-cRp")
             .arg(&source)
             .arg(dst)
+            .env("LANG", "C")
             .status()
             .map_err(std::io::Error::other)?;
         if !status.success() {
@@ -58,23 +59,11 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
             .args(["--reflink=auto", "-a"])
             .arg(&source)
             .arg(dst)
+            .env("LANG", "C")
             .output()
             .map_err(std::io::Error::other)?;
         if output.status.success() {
             return Ok(());
-        }
-
-        if is_permission_error_output(&output) {
-            if let Ok(unshare) = run_podman_unshare(&format!(
-                "cp --reflink=auto -a {}/. {}",
-                shell_quote(&src.to_string_lossy()),
-                shell_quote(&dst.to_string_lossy())
-            )) {
-                if unshare.status.success() {
-                    return Ok(());
-                }
-            }
-            // podman unavailable or also failed — report the original cp error
         }
 
         Err(command_error("cp --reflink=auto -a failed", &output))

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -66,6 +66,26 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
             return Ok(());
         }
 
+        // On rootless Podman the host user may lack read access to files that are
+        // owned by the container UID namespace.  `podman unshare` enters that
+        // namespace and retries the copy from there.  This path is used during
+        // checkout/restore; commit uses `stream_snapshot` instead.
+        // Guard with is_likely_podman_runtime() to avoid entering Podman's UID
+        // namespace on Docker hosts where a podman binary may still be installed
+        // (which would produce copies with unexpected ownership).
+        if is_permission_error_output(&output)
+            && is_likely_podman_runtime()
+            && run_podman_unshare(&format!(
+                "LANG=C cp --reflink=auto -a {}/. {}",
+                shell_quote(&src.to_string_lossy()),
+                shell_quote(&dst.to_string_lossy())
+            ))
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+
         Err(command_error("cp --reflink=auto -a failed", &output))
     }
 
@@ -116,6 +136,46 @@ fn run_podman_unshare(script: &str) -> std::io::Result<std::process::Output> {
 fn is_permission_error_output(output: &std::process::Output) -> bool {
     let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
     stderr.contains("permission denied") || stderr.contains("operation not permitted")
+}
+
+/// Read the real UID of the current process from `/proc/self/status`.
+/// Used by `is_likely_podman_runtime` to locate the rootless Podman socket path.
+#[cfg(target_os = "linux")]
+fn get_current_uid() -> Option<u32> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("Uid:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|v| v.parse().ok())
+        })
+}
+
+/// Returns `true` when the host is running rootless Podman as the container runtime.
+///
+/// Checks, in order:
+/// 1. `DOCKER_HOST` env var — if it contains "podman" it is set to a Podman socket.
+/// 2. `/run/user/<uid>/podman/podman.sock` — rootless Podman per-user socket.
+/// 3. `/run/podman/podman.sock` — system-wide (rootful) Podman socket.
+///
+/// This avoids invoking `podman unshare` on Docker hosts where a `podman` binary
+/// may happen to be installed, which would copy files with wrong UID namespace
+/// ownership.
+#[cfg(target_os = "linux")]
+fn is_likely_podman_runtime() -> bool {
+    if let Ok(host) = std::env::var("DOCKER_HOST")
+        && host.contains("podman")
+    {
+        return true;
+    }
+    if let Some(uid) = get_current_uid() {
+        let sock = std::path::PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"));
+        if sock.exists() {
+            return true;
+        }
+    }
+    std::path::Path::new("/run/podman/podman.sock").exists()
 }
 
 #[cfg(target_os = "linux")]
@@ -560,8 +620,8 @@ impl Repository for GfsRepository {
                 let _ = fs::remove_file(workspace_path.join("postmaster.pid"));
                 let _ = fs::remove_file(workspace_path.join("postmaster.opts"));
                 // Signal that a pre-start ownership repair is required for this workspace.
-                if let Some(parent) = workspace_path.parent() {
-                    let _ = fs::write(parent.join(".needs-repair"), b"");
+                if let Some(marker) = repo_layout::repair_marker_path(&workspace_path) {
+                    let _ = fs::write(marker, b"");
                 }
             } else {
                 tracing::warn!(

--- a/crates/domain/src/ports/compute.rs
+++ b/crates/domain/src/ports/compute.rs
@@ -28,6 +28,12 @@ pub enum ComputeError {
     #[error("instance is not paused: '{0}'")]
     NotPaused(String),
 
+    /// The runtime does not support cgroup freezing (e.g. rootless Podman on
+    /// cgroup v1).  The snapshot will be crash-consistent rather than
+    /// freeze-consistent, which is safe for PostgreSQL after a CHECKPOINT.
+    #[error("pause not supported by runtime: {0}")]
+    PauseUnsupported(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/domain/src/ports/compute.rs
+++ b/crates/domain/src/ports/compute.rs
@@ -29,8 +29,13 @@ pub enum ComputeError {
     NotPaused(String),
 
     /// The runtime does not support cgroup freezing (e.g. rootless Podman on
-    /// cgroup v1).  The snapshot will be crash-consistent rather than
-    /// freeze-consistent, which is safe for PostgreSQL after a CHECKPOINT.
+    /// cgroup v1).  Callers that cannot tolerate torn reads must refuse the
+    /// operation: a file-level snapshot of an unfrozen database can capture
+    /// partially-written pages and half-applied WAL records, and is NOT
+    /// crash-consistent.  `CHECKPOINT` alone does not make such a snapshot
+    /// safe — it only flushes up to a point in time; subsequent writes between
+    /// the CHECKPOINT and the snapshot read are not ordered with respect to the
+    /// per-file tar export.
     #[error("pause not supported by runtime: {0}")]
     PauseUnsupported(String),
 

--- a/crates/domain/src/ports/compute.rs
+++ b/crates/domain/src/ports/compute.rs
@@ -113,6 +113,13 @@ pub struct ExecOutput {
     pub stderr: String,
 }
 
+/// Capabilities supported by a compute runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeCapabilities {
+    pub supports_stream_snapshot: bool,
+    pub supports_exec_as_root: bool,
+}
+
 /// Human-readable description of the connected container runtime.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeDescriptor {
@@ -258,6 +265,22 @@ pub trait Compute: Send + Sync {
     /// Run the given pre-snapshot commands inside the instance (e.g. database CHECKPOINT).
     /// Commands are executed in order; typically provided by the database provider.
     async fn prepare_for_snapshot(&self, id: &InstanceId, commands: &[String]) -> Result<()>;
+
+    /// Return runtime capabilities (used by domain-level invariants).
+    async fn capabilities(&self) -> Result<ComputeCapabilities> {
+        Ok(ComputeCapabilities {
+            supports_stream_snapshot: false,
+            supports_exec_as_root: false,
+        })
+    }
+
+    /// Execute a shell command inside the running instance.
+    ///
+    /// If `user` is `Some`, the runtime attempts to execute as that user (e.g. `"0:0"`).
+    /// Implementations may return an error if user switching is not supported.
+    async fn exec(&self, _id: &InstanceId, _command: &str, _user: Option<&str>) -> Result<ExecOutput> {
+        Err(ComputeError::Internal("exec not supported by this compute runtime".into()))
+    }
 
     /// Describe the connected container runtime (for example Docker or Podman).
     async fn describe_runtime(&self) -> Result<RuntimeDescriptor> {

--- a/crates/domain/src/ports/compute.rs
+++ b/crates/domain/src/ports/compute.rs
@@ -278,8 +278,15 @@ pub trait Compute: Send + Sync {
     ///
     /// If `user` is `Some`, the runtime attempts to execute as that user (e.g. `"0:0"`).
     /// Implementations may return an error if user switching is not supported.
-    async fn exec(&self, _id: &InstanceId, _command: &str, _user: Option<&str>) -> Result<ExecOutput> {
-        Err(ComputeError::Internal("exec not supported by this compute runtime".into()))
+    async fn exec(
+        &self,
+        _id: &InstanceId,
+        _command: &str,
+        _user: Option<&str>,
+    ) -> Result<ExecOutput> {
+        Err(ComputeError::Internal(
+            "exec not supported by this compute runtime".into(),
+        ))
     }
 
     /// Describe the connected container runtime (for example Docker or Podman).

--- a/crates/domain/src/ports/compute.rs
+++ b/crates/domain/src/ports/compute.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -286,6 +286,28 @@ pub trait Compute: Send + Sync {
 
     /// Stop the instance if running, then remove it. Used when recreating a container with a new data bind.
     async fn remove_instance(&self, id: &InstanceId) -> Result<()>;
+
+    /// Stream the contents of `container_path` from inside the running instance
+    /// and unpack them into `dest` on the host.
+    ///
+    /// This is used during `gfs commit` as a permission-safe alternative to the
+    /// host-side `cp` used by the storage adapter.  The Docker daemon reads the
+    /// bind-mounted directory on behalf of the container process (which may be
+    /// root or a different UID), so the host user's read permissions on those
+    /// files do not matter.
+    ///
+    /// The default implementation returns an error; adapters that support this
+    /// operation (e.g. [`DockerCompute`]) override it.
+    async fn stream_snapshot(
+        &self,
+        _id: &InstanceId,
+        _container_path: &str,
+        _dest: &Path,
+    ) -> Result<()> {
+        Err(ComputeError::Internal(
+            "stream_snapshot not supported by this compute runtime".into(),
+        ))
+    }
 
     // -----------------------------------------------------------------------
     // Task execution (sidecar / ephemeral instances)

--- a/crates/domain/src/ports/database_provider.rs
+++ b/crates/domain/src/ports/database_provider.rs
@@ -216,6 +216,35 @@ pub trait DatabaseProvider: Send + Sync {
     /// The compute runtime runs these commands in the container before taking the snapshot.
     fn prepare_for_snapshot(&self, params: &ConnectionParams) -> Result<Vec<String>>;
 
+    /// Return the user/group that should own files under the provider's `definition().data_dir`
+    /// inside the container (for example `"postgres:postgres"`).
+    ///
+    /// This is used for best-effort permission repair after checkout when the workspace
+    /// was populated from a snapshot created via container streaming (which intentionally
+    /// does not preserve original ownership/mode bits).
+    ///
+    /// Default: `None` (provider does not declare a canonical owner).
+    fn data_dir_owner(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Startup probes executed **inside the running database container** after checkout.
+    ///
+    /// Goal: turn “container is running” into “database is actually usable on this workspace”.
+    /// Probes should be:
+    /// - fast
+    /// - deterministic
+    /// - safe (no mutations unless explicitly intended)
+    ///
+    /// The compute runtime should execute these probes with root privileges when available,
+    /// because permission repair may be needed before the container’s default user can read
+    /// the mounted data directory.
+    ///
+    /// Default: empty (no health gate).
+    fn container_startup_probes(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     // -----------------------------------------------------------------------
     // Import / Export
     // -----------------------------------------------------------------------

--- a/crates/domain/src/ports/storage.rs
+++ b/crates/domain/src/ports/storage.rs
@@ -30,6 +30,9 @@ pub enum StorageError {
         limit_bytes: u64,
     },
 
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 
@@ -149,6 +152,14 @@ pub trait StoragePort: Send + Sync {
 
     /// Return disk-usage quota information for a volume.
     async fn quota(&self, id: &VolumeId) -> Result<Quota>;
+
+    /// Make the directory tree at `dest` read-only.
+    ///
+    /// Called after `Compute::stream_snapshot` to restore the same immutability
+    /// that `snapshot()` already provides internally.  Implementations should
+    /// apply the platform-appropriate mechanism (e.g. `chmod -R a-w` on Unix,
+    /// `attrib +R /S /D` on Windows).
+    async fn finalize_snapshot(&self, dest: &Path) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -310,6 +310,26 @@ pub fn snapshot_path(repo_path: &Path, hash: &str) -> PathBuf {
         .join(rest)
 }
 
+/// Returns the canonical path for the `.needs-repair` marker file associated
+/// with the workspace whose data directory is at `workspace_data_dir`.
+///
+/// The marker is written after a `stream_snapshot` fallback commit (which does
+/// not preserve original file ownership) and is consumed by checkout to trigger
+/// a pre-start `chown` repair before the database container boots.
+///
+/// Returns `None` when `workspace_data_dir` has no parent (e.g. `/` or a bare
+/// component), so callers skip the marker write rather than placing `.needs-repair`
+/// inside the database data directory itself.
+///
+/// **Always use this function** — never compute `parent().join(".needs-repair")`
+/// inline, as the three write/read sites must agree on the exact path.
+pub fn repair_marker_path(workspace_data_dir: &Path) -> Option<PathBuf> {
+    workspace_data_dir
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.join(".needs-repair"))
+}
+
 /// Logical size of a directory tree (sum of file lengths in bytes).
 pub fn directory_logical_size_bytes(dir: &Path) -> Result<u64, RepoError> {
     let mut total = 0u64;
@@ -2054,5 +2074,27 @@ name = "test-repo"
             assert!(matches.contains(&hash1.to_string()));
             assert!(matches.contains(&hash2.to_string()));
         }
+    }
+
+    #[test]
+    fn repair_marker_path_normal_returns_sibling_dotfile() {
+        let data_dir = std::path::Path::new("/foo/bar/data");
+        let marker = repair_marker_path(data_dir);
+        assert_eq!(
+            marker,
+            Some(std::path::PathBuf::from("/foo/bar/.needs-repair"))
+        );
+    }
+
+    #[test]
+    fn repair_marker_path_root_returns_none() {
+        let marker = repair_marker_path(std::path::Path::new("/"));
+        assert_eq!(marker, None);
+    }
+
+    #[test]
+    fn repair_marker_path_bare_component_returns_none() {
+        let marker = repair_marker_path(std::path::Path::new("data"));
+        assert_eq!(marker, None);
     }
 }

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -6,12 +6,13 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use thiserror::Error;
 
 use crate::model::config::RuntimeConfig;
 use crate::ports::compute::{
-    Compute, ComputeCapabilities, ComputeError, InstanceId, RuntimeDescriptor,
+    Compute, ComputeCapabilities, ComputeDefinition, ComputeError, InstanceId, RuntimeDescriptor,
 };
 use crate::ports::database_provider::DatabaseProviderRegistry;
 use crate::ports::repository::{Repository, RepositoryError};
@@ -215,8 +216,22 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             paths_differ(&active_str, current_bind.as_deref().unwrap_or(""))
         );
 
+        let repair_marker = std::path::Path::new(&active_str)
+            .parent()
+            .map(|p| p.join(".needs-repair"));
+        let repair_needed = repair_marker.as_ref().map(|m| m.exists()).unwrap_or(false);
+
         if !paths_differ(&active_str, current_bind.as_deref().unwrap_or("")) {
             tracing::info!("ensure_compute_started_after_checkout: starting existing container");
+            if repair_needed {
+                self.pre_start_repair_data_dir(
+                    &definition,
+                    &compute_data_path,
+                    repair_target.as_deref(),
+                    repair_marker.as_deref(),
+                )
+                .await;
+            }
             match self.compute.start(instance_id, Default::default()).await {
                 Ok(_) => {
                     self.repair_data_dir_permissions_in_container(
@@ -230,7 +245,6 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
                     return Ok(());
                 }
                 Err(ComputeError::NotFound(_)) => {
-                    // Container was removed externally; fall through to recreate it.
                     tracing::info!(
                         "ensure_compute_started_after_checkout: container not found, recreating"
                     );
@@ -247,7 +261,17 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             Err(e) => return Err(CheckoutRepoError::Compute(e)),
         }
         let new_id = self.compute.provision(&definition).await?;
+        // Always repair before first start of a new container — the workspace was just
+        // populated from snapshot and ownership may not match the DB process user.
+        self.pre_start_repair_data_dir(
+            &definition,
+            &compute_data_path,
+            repair_target.as_deref(),
+            repair_marker.as_deref(),
+        )
+        .await;
         let _ = self.compute.start(&new_id, Default::default()).await?;
+        // Belt-and-suspenders: also repair inside the running container.
         self.repair_data_dir_permissions_in_container(
             &new_id,
             &compute_data_path,
@@ -301,19 +325,36 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             )));
         }
 
+        const PROBE_ATTEMPTS: u32 = 15;
+        const PROBE_SLEEP_MS: u64 = 200;
+
         for probe in startup_probes {
             let cmd = probe.trim();
             if cmd.is_empty() {
                 continue;
             }
-            let out = self
-                .compute
-                .exec(instance_id, cmd, Some("0:0"))
-                .await
-                .map_err(CheckoutRepoError::Compute)?;
-            if out.exit_code != 0 {
+            let mut last_out = None;
+            let mut ok = false;
+            for attempt in 0..PROBE_ATTEMPTS {
+                if attempt > 0 {
+                    tokio::time::sleep(Duration::from_millis(PROBE_SLEEP_MS)).await;
+                }
+                let out = self
+                    .compute
+                    .exec(instance_id, cmd, Some("0:0"))
+                    .await
+                    .map_err(CheckoutRepoError::Compute)?;
+                if out.exit_code == 0 {
+                    ok = true;
+                    break;
+                }
+                last_out = Some(out);
+            }
+            if !ok {
+                let out = last_out.unwrap();
                 return Err(CheckoutRepoError::Compute(ComputeError::Internal(format!(
-                    "database startup probe failed (exit {}): {}\nstdout: {}\nstderr: {}",
+                    "database startup probe failed after {} attempts (exit {}): {}\nstdout: {}\nstderr: {}",
+                    PROBE_ATTEMPTS,
                     out.exit_code,
                     cmd,
                     out.stdout.trim(),
@@ -322,6 +363,53 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             }
         }
         Ok(())
+    }
+
+    /// Best-effort pre-start permission repair via an ephemeral container.
+    ///
+    /// Spins up a throwaway container (same image + data-dir bind, running as root)
+    /// to `chown` + `chmod` the data directory _before_ the real container starts.
+    /// This is necessary when a prior `stream_snapshot` commit left files owned by the
+    /// host user rather than the database process user (e.g. `postgres:postgres`).
+    ///
+    /// Runs as root (`0:0`) so the operation succeeds regardless of current ownership.
+    /// Best-effort: logs and continues on failure so checkout is not blocked.
+    async fn pre_start_repair_data_dir(
+        &self,
+        definition: &ComputeDefinition,
+        container_data_path: &str,
+        chown_target: Option<&str>,
+        marker: Option<&std::path::Path>,
+    ) {
+        let Some(target) = chown_target.filter(|s| !s.trim().is_empty()) else {
+            return;
+        };
+        let escaped = container_data_path.replace('\'', "'\"'\"'");
+        let cmd = format!("chown -R {target} '{escaped}' && chmod -R 0700 '{escaped}'");
+
+        let mut repair_def = definition.clone();
+        repair_def.user = Some("0:0".to_string());
+
+        tracing::info!(
+            data_dir = container_data_path,
+            chown_target = target,
+            "pre_start_repair_data_dir: running pre-start chown via ephemeral container"
+        );
+
+        match self.compute.run_task(&repair_def, &cmd, None).await {
+            Ok(_) => {
+                if let Some(m) = marker {
+                    let _ = std::fs::remove_file(m);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    data_dir = container_data_path,
+                    "pre_start_repair_data_dir: repair task failed; container may fail to start"
+                );
+            }
+        }
     }
 
     /// Best-effort: ensure the DB process user can read/write its data dir.
@@ -1153,6 +1241,295 @@ mod tests {
         assert!(
             result.is_ok(),
             "checkout should recreate compute when container was removed: {result:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Probe retry tests
+    // -----------------------------------------------------------------------
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Compute mock whose `exec` fails `exec_fail_count` times before succeeding.
+    struct MockComputeWithProbeFailures {
+        exec_fail_remaining: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Compute for MockComputeWithProbeFailures {
+        async fn capabilities(&self) -> crate::ports::compute::Result<ComputeCapabilities> {
+            Ok(ComputeCapabilities {
+                supports_stream_snapshot: false,
+                supports_exec_as_root: true,
+            })
+        }
+        async fn exec(
+            &self,
+            _id: &InstanceId,
+            _command: &str,
+            _user: Option<&str>,
+        ) -> crate::ports::compute::Result<crate::ports::compute::ExecOutput> {
+            let remaining = self.exec_fail_remaining.load(Ordering::SeqCst);
+            if remaining > 0 {
+                self.exec_fail_remaining.fetch_sub(1, Ordering::SeqCst);
+                return Ok(crate::ports::compute::ExecOutput {
+                    exit_code: 1,
+                    stdout: String::new(),
+                    stderr: "not ready yet".into(),
+                });
+            }
+            Ok(crate::ports::compute::ExecOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+        async fn provision(
+            &self,
+            _: &ComputeDefinition,
+        ) -> crate::ports::compute::Result<InstanceId> {
+            Ok(InstanceId("mock-probe".into()))
+        }
+        async fn start(
+            &self,
+            id: &InstanceId,
+            _: StartOptions,
+        ) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn stop(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Stopped,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn restart(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn status(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn prepare_for_snapshot(
+            &self,
+            _: &InstanceId,
+            _: &[String],
+        ) -> crate::ports::compute::Result<()> {
+            Ok(())
+        }
+        async fn logs(
+            &self,
+            _: &InstanceId,
+            _: crate::ports::compute::LogsOptions,
+        ) -> crate::ports::compute::Result<Vec<crate::ports::compute::LogEntry>> {
+            Ok(vec![])
+        }
+        async fn pause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Paused,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn unpause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn get_connection_info(
+            &self,
+            _id: &InstanceId,
+            port: u16,
+        ) -> crate::ports::compute::Result<crate::ports::compute::InstanceConnectionInfo> {
+            Ok(crate::ports::compute::InstanceConnectionInfo {
+                host: "127.0.0.1".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn get_instance_data_mount_host_path(
+            &self,
+            _id: &InstanceId,
+            _: &str,
+        ) -> crate::ports::compute::Result<Option<PathBuf>> {
+            Ok(None)
+        }
+        async fn remove_instance(&self, _id: &InstanceId) -> crate::ports::compute::Result<()> {
+            Ok(())
+        }
+        async fn get_task_connection_info(
+            &self,
+            _id: &InstanceId,
+            port: u16,
+        ) -> crate::ports::compute::Result<crate::ports::compute::InstanceConnectionInfo> {
+            Ok(crate::ports::compute::InstanceConnectionInfo {
+                host: "172.17.0.2".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn run_task(
+            &self,
+            _: &ComputeDefinition,
+            _: &str,
+            _: Option<&InstanceId>,
+        ) -> crate::ports::compute::Result<crate::ports::compute::ExecOutput> {
+            Ok(crate::ports::compute::ExecOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    /// Provider that exposes one startup probe so `assert_container_healthy` is exercised.
+    struct MockProviderWithProbe;
+
+    impl DatabaseProvider for MockProviderWithProbe {
+        fn name(&self) -> &str {
+            "postgres"
+        }
+        fn definition(&self) -> ComputeDefinition {
+            ComputeDefinition {
+                image: "postgres:17".into(),
+                env: vec![],
+                ports: vec![],
+                data_dir: PathBuf::from("/data"),
+                host_data_dir: None,
+                user: None,
+                logs_dir: None,
+                conf_dir: None,
+                args: vec![],
+            }
+        }
+        fn default_port(&self) -> u16 {
+            5432
+        }
+        fn default_args(&self) -> Vec<DatabaseProviderArg> {
+            vec![]
+        }
+        fn default_signal(&self) -> u32 {
+            SIGTERM
+        }
+        fn connection_string(
+            &self,
+            _: &ConnectionParams,
+        ) -> std::result::Result<String, ProviderError> {
+            Ok("postgres://localhost:5432".into())
+        }
+        fn supported_versions(&self) -> Vec<String> {
+            vec!["17".into()]
+        }
+        fn supported_features(&self) -> Vec<SupportedFeature> {
+            vec![]
+        }
+        fn prepare_for_snapshot(&self, _: &ConnectionParams) -> RegistryResult<Vec<String>> {
+            Ok(vec![])
+        }
+        fn query_client_command(
+            &self,
+            _: &ConnectionParams,
+            _: Option<&str>,
+        ) -> std::result::Result<std::process::Command, ProviderError> {
+            Ok(std::process::Command::new("true"))
+        }
+        fn container_startup_probes(&self) -> &'static [&'static str] {
+            &["pg_isready -U postgres"]
+        }
+    }
+
+    struct MockRegistryWithProbeProvider;
+
+    impl DatabaseProviderRegistry for MockRegistryWithProbeProvider {
+        fn register(&self, _: Arc<dyn DatabaseProvider>) -> RegistryResult<()> {
+            Ok(())
+        }
+        fn get(&self, name: &str) -> Option<Arc<dyn DatabaseProvider>> {
+            if name.eq_ignore_ascii_case("postgres") {
+                Some(Arc::new(MockProviderWithProbe))
+            } else {
+                None
+            }
+        }
+        fn list(&self) -> Vec<String> {
+            vec!["postgres".into()]
+        }
+        fn unregister(&self, _: &str) -> Option<Arc<dyn DatabaseProvider>> {
+            None
+        }
+    }
+
+    /// Probe fails 3 times then succeeds on the 4th attempt — checkout must return Ok.
+    #[tokio::test]
+    async fn checkout_probe_succeeds_after_retries() {
+        let repo = MockRepositoryWithEnv {
+            current_commit: "abc123".into(),
+        };
+        let compute = MockComputeWithProbeFailures {
+            exec_fail_remaining: AtomicUsize::new(3),
+        };
+        let usecase = CheckoutRepoUseCase::new(
+            Arc::new(repo),
+            Arc::new(compute),
+            Arc::new(MockRegistryWithProbeProvider),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let result = usecase
+            .run(dir.path().to_path_buf(), "main".into(), None)
+            .await;
+        assert!(
+            result.is_ok(),
+            "probe should succeed after 3 retries: {result:?}"
+        );
+    }
+
+    /// Probe fails more times than the retry budget (20 > 15) — checkout must return Err.
+    #[tokio::test]
+    async fn checkout_probe_fails_after_exhausting_retries() {
+        let repo = MockRepositoryWithEnv {
+            current_commit: "abc123".into(),
+        };
+        let compute = MockComputeWithProbeFailures {
+            exec_fail_remaining: AtomicUsize::new(20),
+        };
+        let usecase = CheckoutRepoUseCase::new(
+            Arc::new(repo),
+            Arc::new(compute),
+            Arc::new(MockRegistryWithProbeProvider),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let result = usecase
+            .run(dir.path().to_path_buf(), "main".into(), None)
+            .await;
+        assert!(
+            matches!(result, Err(CheckoutRepoError::Compute(_))),
+            "probe should fail after exhausting retries: {result:?}"
         );
     }
 }

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::model::config::RuntimeConfig;
-use crate::ports::compute::{Compute, ComputeError, InstanceId, RuntimeDescriptor};
+use crate::ports::compute::{
+    Compute, ComputeCapabilities, ComputeError, InstanceId, RuntimeDescriptor,
+};
 use crate::ports::database_provider::DatabaseProviderRegistry;
 use crate::ports::repository::{Repository, RepositoryError};
 use crate::utils::{current_user, data_dir};
@@ -193,6 +195,11 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             }
         }
         let compute_data_path = definition.data_dir.to_string_lossy().into_owned();
+        let repair_target = definition
+            .user
+            .clone()
+            .or_else(|| provider.data_dir_owner().map(str::to_string));
+        let startup_probes = provider.container_startup_probes();
 
         let current_bind = self
             .compute
@@ -211,7 +218,17 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         if !paths_differ(&active_str, current_bind.as_deref().unwrap_or("")) {
             tracing::info!("ensure_compute_started_after_checkout: starting existing container");
             match self.compute.start(instance_id, Default::default()).await {
-                Ok(_) => return Ok(()),
+                Ok(_) => {
+                    self.repair_data_dir_permissions_in_container(
+                        instance_id,
+                        &compute_data_path,
+                        repair_target.as_deref(),
+                    )
+                    .await;
+                    self.assert_container_healthy(instance_id, startup_probes)
+                        .await?;
+                    return Ok(());
+                }
                 Err(ComputeError::NotFound(_)) => {
                     // Container was removed externally; fall through to recreate it.
                     tracing::info!(
@@ -231,6 +248,14 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         }
         let new_id = self.compute.provision(&definition).await?;
         let _ = self.compute.start(&new_id, Default::default()).await?;
+        self.repair_data_dir_permissions_in_container(
+            &new_id,
+            &compute_data_path,
+            repair_target.as_deref(),
+        )
+        .await;
+        self.assert_container_healthy(&new_id, startup_probes)
+            .await?;
         let runtime = self
             .compute
             .describe_runtime()
@@ -250,6 +275,89 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             )
             .await?;
         Ok(())
+    }
+
+    async fn assert_container_healthy(
+        &self,
+        instance_id: &InstanceId,
+        startup_probes: &[&'static str],
+    ) -> std::result::Result<(), CheckoutRepoError> {
+        if startup_probes.is_empty() {
+            return Ok(());
+        }
+
+        let caps = self
+            .compute
+            .capabilities()
+            .await
+            .unwrap_or(ComputeCapabilities {
+                supports_stream_snapshot: false,
+                supports_exec_as_root: false,
+            });
+        if !caps.supports_exec_as_root {
+            return Err(CheckoutRepoError::Compute(ComputeError::Internal(
+                "compute runtime cannot exec as root; cannot validate workspace health after checkout"
+                    .into(),
+            )));
+        }
+
+        for probe in startup_probes {
+            let cmd = probe.trim();
+            if cmd.is_empty() {
+                continue;
+            }
+            let out = self
+                .compute
+                .exec(instance_id, cmd, Some("0:0"))
+                .await
+                .map_err(CheckoutRepoError::Compute)?;
+            if out.exit_code != 0 {
+                return Err(CheckoutRepoError::Compute(ComputeError::Internal(format!(
+                    "database startup probe failed (exit {}): {}\nstdout: {}\nstderr: {}",
+                    out.exit_code,
+                    cmd,
+                    out.stdout.trim(),
+                    out.stderr.trim()
+                ))));
+            }
+        }
+        Ok(())
+    }
+
+    /// Best-effort: ensure the DB process user can read/write its data dir.
+    ///
+    /// This is critical when snapshots were created via `stream_snapshot` because tar extraction
+    /// intentionally does not preserve container ownership/mode bits.
+    async fn repair_data_dir_permissions_in_container(
+        &self,
+        instance_id: &InstanceId,
+        container_data_path: &str,
+        chown_target: Option<&str>,
+    ) {
+        let Some(target) = chown_target.filter(|s| !s.trim().is_empty()) else {
+            return;
+        };
+        let escaped = container_data_path.replace('\'', "'\"'\"'");
+        let cmd = format!("chown -R {target} '{escaped}' && chmod -R 0700 '{escaped}'");
+        let caps = self.compute.capabilities().await.ok();
+        let can_root = caps.map(|c| c.supports_exec_as_root).unwrap_or(false);
+        if !can_root {
+            tracing::warn!(
+                instance = %instance_id,
+                data_dir = container_data_path,
+                "compute runtime cannot exec as root; cannot repair workspace permissions inside container"
+            );
+            return;
+        }
+
+        if let Err(e) = self.compute.exec(instance_id, &cmd, Some("0:0")).await {
+            tracing::warn!(
+                error = %e,
+                instance = %instance_id,
+                data_dir = container_data_path,
+                "failed to repair workspace permissions inside container; continuing"
+            );
+        }
     }
 }
 

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -16,6 +16,7 @@ use crate::ports::compute::{
 };
 use crate::ports::database_provider::DatabaseProviderRegistry;
 use crate::ports::repository::{Repository, RepositoryError};
+use crate::repo_utils::repo_layout;
 use crate::utils::{current_user, data_dir};
 
 // ---------------------------------------------------------------------------
@@ -216,9 +217,7 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             paths_differ(&active_str, current_bind.as_deref().unwrap_or(""))
         );
 
-        let repair_marker = std::path::Path::new(&active_str)
-            .parent()
-            .map(|p| p.join(".needs-repair"));
+        let repair_marker = repo_layout::repair_marker_path(std::path::Path::new(&active_str));
         let repair_needed = repair_marker.as_ref().map(|m| m.exists()).unwrap_or(false);
 
         if !paths_differ(&active_str, current_bind.as_deref().unwrap_or("")) {
@@ -318,12 +317,18 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
                 supports_stream_snapshot: false,
                 supports_exec_as_root: false,
             });
-        if !caps.supports_exec_as_root {
-            return Err(CheckoutRepoError::Compute(ComputeError::Internal(
-                "compute runtime cannot exec as root; cannot validate workspace health after checkout"
-                    .into(),
-            )));
-        }
+        // Startup probes are connectivity checks (pg_isready, mysqladmin ping) that do
+        // not require root. When exec-as-root is unavailable, run as the container's
+        // default user so health is still verified — do not skip entirely.
+        let exec_user = if caps.supports_exec_as_root {
+            Some("0:0")
+        } else {
+            tracing::warn!(
+                instance = %instance_id,
+                "compute runtime cannot exec as root; running startup probes as default container user"
+            );
+            None
+        };
 
         const PROBE_ATTEMPTS: u32 = 15;
         const PROBE_SLEEP_MS: u64 = 200;
@@ -341,7 +346,7 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
                 }
                 let out = self
                     .compute
-                    .exec(instance_id, cmd, Some("0:0"))
+                    .exec(instance_id, cmd, exec_user)
                     .await
                     .map_err(CheckoutRepoError::Compute)?;
                 if out.exit_code == 0 {
@@ -1530,6 +1535,348 @@ mod tests {
         assert!(
             matches!(result, Err(CheckoutRepoError::Compute(_))),
             "probe should fail after exhausting retries: {result:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Probes as default container user when exec-as-root unavailable
+    // -----------------------------------------------------------------------
+
+    /// A compute mock with `supports_exec_as_root = false` that succeeds immediately.
+    struct MockComputeNoRootSuccess;
+
+    #[async_trait]
+    impl Compute for MockComputeNoRootSuccess {
+        async fn capabilities(&self) -> crate::ports::compute::Result<ComputeCapabilities> {
+            Ok(ComputeCapabilities {
+                supports_stream_snapshot: false,
+                supports_exec_as_root: false,
+            })
+        }
+        async fn exec(
+            &self,
+            _id: &InstanceId,
+            _command: &str,
+            _user: Option<&str>,
+        ) -> crate::ports::compute::Result<crate::ports::compute::ExecOutput> {
+            Ok(crate::ports::compute::ExecOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+        async fn provision(
+            &self,
+            _: &ComputeDefinition,
+        ) -> crate::ports::compute::Result<InstanceId> {
+            Ok(InstanceId("mock-no-root".into()))
+        }
+        async fn start(
+            &self,
+            id: &InstanceId,
+            _: StartOptions,
+        ) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn stop(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Stopped,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn restart(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn status(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn prepare_for_snapshot(
+            &self,
+            _: &InstanceId,
+            _: &[String],
+        ) -> crate::ports::compute::Result<()> {
+            Ok(())
+        }
+        async fn logs(
+            &self,
+            _: &InstanceId,
+            _: crate::ports::compute::LogsOptions,
+        ) -> crate::ports::compute::Result<Vec<crate::ports::compute::LogEntry>> {
+            Ok(vec![])
+        }
+        async fn pause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Paused,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn unpause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn get_connection_info(
+            &self,
+            _id: &InstanceId,
+            port: u16,
+        ) -> crate::ports::compute::Result<crate::ports::compute::InstanceConnectionInfo> {
+            Ok(crate::ports::compute::InstanceConnectionInfo {
+                host: "127.0.0.1".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn get_instance_data_mount_host_path(
+            &self,
+            _id: &InstanceId,
+            _: &str,
+        ) -> crate::ports::compute::Result<Option<PathBuf>> {
+            Ok(None)
+        }
+        async fn remove_instance(&self, _id: &InstanceId) -> crate::ports::compute::Result<()> {
+            Ok(())
+        }
+        async fn get_task_connection_info(
+            &self,
+            _id: &InstanceId,
+            port: u16,
+        ) -> crate::ports::compute::Result<crate::ports::compute::InstanceConnectionInfo> {
+            Ok(crate::ports::compute::InstanceConnectionInfo {
+                host: "172.17.0.2".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn run_task(
+            &self,
+            _: &ComputeDefinition,
+            _: &str,
+            _: Option<&InstanceId>,
+        ) -> crate::ports::compute::Result<crate::ports::compute::ExecOutput> {
+            Ok(crate::ports::compute::ExecOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    /// A compute mock with `supports_exec_as_root = false` that always fails exec.
+    struct MockComputeNoRootFail;
+
+    #[async_trait]
+    impl Compute for MockComputeNoRootFail {
+        async fn capabilities(&self) -> crate::ports::compute::Result<ComputeCapabilities> {
+            Ok(ComputeCapabilities {
+                supports_stream_snapshot: false,
+                supports_exec_as_root: false,
+            })
+        }
+        async fn exec(
+            &self,
+            _id: &InstanceId,
+            _command: &str,
+            _user: Option<&str>,
+        ) -> crate::ports::compute::Result<crate::ports::compute::ExecOutput> {
+            Ok(crate::ports::compute::ExecOutput {
+                exit_code: 1,
+                stdout: String::new(),
+                stderr: "db not ready".into(),
+            })
+        }
+        async fn provision(
+            &self,
+            _: &ComputeDefinition,
+        ) -> crate::ports::compute::Result<InstanceId> {
+            Ok(InstanceId("mock-no-root-fail".into()))
+        }
+        async fn start(
+            &self,
+            id: &InstanceId,
+            _: StartOptions,
+        ) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn stop(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Stopped,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn restart(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn status(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn prepare_for_snapshot(
+            &self,
+            _: &InstanceId,
+            _: &[String],
+        ) -> crate::ports::compute::Result<()> {
+            Ok(())
+        }
+        async fn logs(
+            &self,
+            _: &InstanceId,
+            _: crate::ports::compute::LogsOptions,
+        ) -> crate::ports::compute::Result<Vec<crate::ports::compute::LogEntry>> {
+            Ok(vec![])
+        }
+        async fn pause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Paused,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn unpause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            Ok(InstanceStatus {
+                id: id.clone(),
+                state: InstanceState::Running,
+                pid: None,
+                started_at: None,
+                exit_code: None,
+            })
+        }
+        async fn get_connection_info(
+            &self,
+            _id: &InstanceId,
+            port: u16,
+        ) -> crate::ports::compute::Result<crate::ports::compute::InstanceConnectionInfo> {
+            Ok(crate::ports::compute::InstanceConnectionInfo {
+                host: "127.0.0.1".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn get_instance_data_mount_host_path(
+            &self,
+            _id: &InstanceId,
+            _: &str,
+        ) -> crate::ports::compute::Result<Option<PathBuf>> {
+            Ok(None)
+        }
+        async fn remove_instance(&self, _id: &InstanceId) -> crate::ports::compute::Result<()> {
+            Ok(())
+        }
+        async fn get_task_connection_info(
+            &self,
+            _id: &InstanceId,
+            port: u16,
+        ) -> crate::ports::compute::Result<crate::ports::compute::InstanceConnectionInfo> {
+            Ok(crate::ports::compute::InstanceConnectionInfo {
+                host: "172.17.0.2".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn run_task(
+            &self,
+            _: &ComputeDefinition,
+            _: &str,
+            _: Option<&InstanceId>,
+        ) -> crate::ports::compute::Result<crate::ports::compute::ExecOutput> {
+            Ok(crate::ports::compute::ExecOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    /// When `supports_exec_as_root = false`, probes still run (as default container
+    /// user) and checkout succeeds when the probe returns exit_code 0.
+    #[tokio::test]
+    async fn checkout_probe_runs_as_default_user_when_no_root_exec() {
+        let repo = MockRepositoryWithEnv {
+            current_commit: "abc123".into(),
+        };
+        let usecase = CheckoutRepoUseCase::new(
+            Arc::new(repo),
+            Arc::new(MockComputeNoRootSuccess),
+            Arc::new(MockRegistryWithProbeProvider),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let result = usecase
+            .run(dir.path().to_path_buf(), "main".into(), None)
+            .await;
+        assert!(
+            result.is_ok(),
+            "probes should succeed as default user when exec-as-root is unavailable: {result:?}"
+        );
+    }
+
+    /// When `supports_exec_as_root = false`, a failing probe must still cause
+    /// checkout to return `Err` — health is not silently skipped.
+    #[tokio::test]
+    async fn checkout_probe_fails_as_default_user() {
+        let repo = MockRepositoryWithEnv {
+            current_commit: "abc123".into(),
+        };
+        let usecase = CheckoutRepoUseCase::new(
+            Arc::new(repo),
+            Arc::new(MockComputeNoRootFail),
+            Arc::new(MockRegistryWithProbeProvider),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let result = usecase
+            .run(dir.path().to_path_buf(), "main".into(), None)
+            .await;
+        assert!(
+            matches!(result, Err(CheckoutRepoError::Compute(_))),
+            "failing probe as default user should surface an error: {result:?}"
         );
     }
 }

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -184,7 +184,13 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         definition.host_data_dir = Some(active.clone());
         #[cfg(unix)]
         {
-            definition.user = current_user::current_user_uid_gid();
+            match current_user::current_user_uid_gid() {
+                Some(uid_gid) => definition.user = Some(uid_gid),
+                None => tracing::warn!(
+                    "could not determine host uid:gid; container will run as its default user — \
+                     workspace files may be unreadable by the host user during snapshot"
+                ),
+            }
         }
         let compute_data_path = definition.data_dir.to_string_lossy().into_owned();
 

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -263,15 +263,31 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                 .await?;
 
             // Pause the container so no writes land during the snapshot.
+            // On rootless Podman with cgroup v1 the runtime cannot freeze
+            // container processes; treat that as a soft failure and proceed
+            // with a crash-consistent snapshot (CHECKPOINT already applied).
             let status = self.compute.status(&instance_id).await?;
             if status.state == InstanceState::Running {
-                self.compute.pause(&instance_id).await?;
-                // RAII guard: ensures unpause even on task cancellation or panic.
-                unpause_guard = Some(UnpauseGuard::new(
-                    Arc::clone(&self.compute),
-                    instance_id.clone(),
-                ));
-                paused_instance_id = Some(instance_id);
+                match self.compute.pause(&instance_id).await {
+                    Ok(_) => {
+                        // RAII guard: ensures unpause even on task cancellation or panic.
+                        unpause_guard = Some(UnpauseGuard::new(
+                            Arc::clone(&self.compute),
+                            instance_id.clone(),
+                        ));
+                        paused_instance_id = Some(instance_id);
+                    }
+                    Err(ComputeError::PauseUnsupported(ref e)) => {
+                        tracing::warn!(
+                            error = %e,
+                            instance = %instance_id,
+                            "container pause not available (cgroup v1 or rootless runtime); \
+                             snapshot will be crash-consistent — CHECKPOINT already applied"
+                        );
+                        // No unpause guard: nothing was paused.
+                    }
+                    Err(e) => return Err(CommitRepoError::Compute(e)),
+                }
             }
         }
 
@@ -731,6 +747,9 @@ mod tests {
         /// When set, `stream_snapshot` creates `dest` then fails with this message.
         stream_snapshot_fail_message: Mutex<Option<String>>,
         stream_snapshot_calls: AtomicUsize,
+        /// When set, `pause()` returns `ComputeError::Internal` with this message
+        /// instead of succeeding (simulates cgroup v1 / rootless Podman).
+        pause_fails_with: Option<String>,
     }
 
     impl Default for MockCompute {
@@ -742,6 +761,7 @@ mod tests {
                 unpaused: Mutex::new(false),
                 stream_snapshot_fail_message: Mutex::new(None),
                 stream_snapshot_calls: AtomicUsize::new(0),
+                pause_fails_with: None,
             }
         }
     }
@@ -810,6 +830,9 @@ mod tests {
             Ok(vec![])
         }
         async fn pause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
+            if let Some(ref msg) = self.pause_fails_with {
+                return Err(ComputeError::Internal(msg.clone()));
+            }
             *self.paused.lock().unwrap() = true;
             Ok(InstanceStatus {
                 id: id.clone(),
@@ -1607,5 +1630,107 @@ mod tests {
             )
             .await;
         assert!(matches!(result, Err(CommitRepoError::Storage(_))));
+    }
+
+    /// Rootless Podman on cgroup v1 returns an Internal error from `pause()` whose
+    /// message contains "cgroup".  The commit must succeed (not return an error) by
+    /// proceeding with a crash-consistent snapshot, and must NOT call `unpause()`
+    /// because the container was never actually paused.
+    #[tokio::test]
+    async fn commit_succeeds_when_pause_unsupported_cgroup_v1() {
+        let compute = Arc::new(MockCompute {
+            state: InstanceState::Running,
+            pause_fails_with: Some(
+                "OCI runtime error: cgroups: cgroup v1 does not support freezing a single process"
+                    .into(),
+            ),
+            ..Default::default()
+        });
+        let repo = MockRepository {
+            commit_hash: "abc123".into(),
+            current_commit: "prev".into(),
+            mount_point: Some("/vol/main".into()),
+            runtime_config: Some(RuntimeConfig {
+                runtime_provider: "podman".into(),
+                runtime_version: "5.0".into(),
+                container_name: "gfs-pg-test".into(),
+            }),
+            environment: Some(EnvironmentConfig {
+                database_provider: "mock-db".into(),
+                database_version: "16".into(),
+                database_port: None,
+            }),
+            ..Default::default()
+        };
+        let storage = Arc::new(MockStorage::new("snap-abc"));
+        let registry = Arc::new(MockRegistry);
+
+        let uc = CommitRepoUseCase::new(Arc::new(repo), compute.clone(), storage, registry);
+        let result = uc
+            .run(
+                existing_repo_path(),
+                "cgroup v1 pause test".into(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "commit should succeed despite pause failure: {result:?}");
+        assert!(
+            !*compute.paused.lock().unwrap(),
+            "paused flag should be false — pause was rejected by runtime"
+        );
+        assert!(
+            !*compute.unpaused.lock().unwrap(),
+            "unpause must not be called when pause was never issued"
+        );
+    }
+
+    /// A genuine pause failure (container not found, daemon error) must still
+    /// propagate as an error — only the "unsupported" subset is swallowed.
+    #[tokio::test]
+    async fn commit_fails_on_genuine_pause_error() {
+        let compute = Arc::new(MockCompute {
+            state: InstanceState::Running,
+            pause_fails_with: Some("daemon internal error: connection refused".into()),
+            ..Default::default()
+        });
+        let repo = MockRepository {
+            commit_hash: "abc123".into(),
+            current_commit: "prev".into(),
+            mount_point: Some("/vol/main".into()),
+            runtime_config: Some(RuntimeConfig {
+                runtime_provider: "docker".into(),
+                runtime_version: "24".into(),
+                container_name: "gfs-pg-test".into(),
+            }),
+            environment: Some(EnvironmentConfig {
+                database_provider: "mock-db".into(),
+                database_version: "16".into(),
+                database_port: None,
+            }),
+            ..Default::default()
+        };
+        let storage = Arc::new(MockStorage::new("snap-abc"));
+        let registry = Arc::new(MockRegistry);
+
+        let uc = CommitRepoUseCase::new(Arc::new(repo), compute, storage, registry);
+        let result = uc
+            .run(
+                existing_repo_path(),
+                "genuine pause error".into(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(CommitRepoError::Compute(_))),
+            "genuine pause error must propagate: {result:?}"
+        );
     }
 }

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -831,7 +831,17 @@ mod tests {
         }
         async fn pause(&self, id: &InstanceId) -> crate::ports::compute::Result<InstanceStatus> {
             if let Some(ref msg) = self.pause_fails_with {
-                return Err(ComputeError::Internal(msg.clone()));
+                // Mirror the real `classify()` in compute-docker: cgroup/freeze phrases
+                // map to PauseUnsupported; everything else is a genuine Internal error.
+                let lower = msg.to_ascii_lowercase();
+                let is_pause_unsupported = ["cgroup", "freezing", "freeze", "pause is not",
+                    "cannot pause", "not supported", "rootless"]
+                    .iter().any(|p| lower.contains(p));
+                return Err(if is_pause_unsupported {
+                    ComputeError::PauseUnsupported(msg.clone())
+                } else {
+                    ComputeError::Internal(msg.clone())
+                });
             }
             *self.paused.lock().unwrap() = true;
             Ok(InstanceStatus {
@@ -1632,10 +1642,10 @@ mod tests {
         assert!(matches!(result, Err(CommitRepoError::Storage(_))));
     }
 
-    /// Rootless Podman on cgroup v1 returns an Internal error from `pause()` whose
-    /// message contains "cgroup".  The commit must succeed (not return an error) by
-    /// proceeding with a crash-consistent snapshot, and must NOT call `unpause()`
-    /// because the container was never actually paused.
+    /// Rootless Podman on cgroup v1 returns a `PauseUnsupported` error from `pause()`.
+    /// The commit must succeed (not return an error) by proceeding with a
+    /// crash-consistent snapshot, and must NOT call `unpause()` because the
+    /// container was never actually paused.
     #[tokio::test]
     async fn commit_succeeds_when_pause_unsupported_cgroup_v1() {
         let compute = Arc::new(MockCompute {

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -34,6 +35,60 @@ pub enum CommitRepoError {
 
     #[error("commit message must not be empty")]
     EmptyMessage,
+}
+
+/// True when host-side snapshot copy failed because the host could not read a file
+/// (e.g. root-owned `0600` under a bind-mounted workspace). Used to fall back to
+/// [`Compute::stream_snapshot`].
+fn storage_error_looks_like_permission_denied(err: &StorageError) -> bool {
+    match err {
+        StorageError::PermissionDenied(_) => true,
+        StorageError::Io(io) => io.kind() == ErrorKind::PermissionDenied,
+        StorageError::Internal(msg) => {
+            let m = msg.as_str();
+            m.contains("Permission denied")
+                || m.contains("EACCES")
+                || (m.contains("cannot open") && m.contains("for reading"))
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod permission_denied_tests {
+    use super::storage_error_looks_like_permission_denied;
+    use crate::ports::storage::StorageError;
+    use std::io::ErrorKind;
+
+    #[test]
+    fn detects_io_permission_denied() {
+        assert!(storage_error_looks_like_permission_denied(
+            &StorageError::Io(std::io::Error::from(ErrorKind::PermissionDenied))
+        ));
+    }
+
+    #[test]
+    fn detects_cp_style_internal_message() {
+        assert!(storage_error_looks_like_permission_denied(
+            &StorageError::Internal(
+                "copy 'a' -> 'b' failed: cp: cannot open 'x' for reading: Permission denied".into(),
+            )
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_internal_error() {
+        assert!(!storage_error_looks_like_permission_denied(
+            &StorageError::Internal("disk full".into())
+        ));
+    }
+
+    #[test]
+    fn detects_typed_permission_denied() {
+        assert!(storage_error_looks_like_permission_denied(
+            &StorageError::PermissionDenied("x".into())
+        ));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -204,37 +259,79 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
             .ensure_snapshot_path(&path, &snapshot_hash)
             .await?;
 
-        // When a compute container is active, stream the snapshot through the
-        // Docker daemon instead of relying on a host-side `cp`.  This bypasses
-        // host read-permission restrictions on bind-mounted files that the
-        // container process may have written as a different UID (e.g. root).
-        //
-        // Fallback: no compute → files are owned by the host user → regular
-        // host-side copy via the storage adapter is safe and uses reflinks.
-        if let (Some(runtime), Some(env)) = (&runtime_config, &environment) {
-            let instance_id = InstanceId(runtime.container_name.clone());
-            let provider =
-                self.registry
-                    .get(&env.database_provider)
-                    .ok_or_else(|| {
-                        CommitRepoError::UnknownDatabaseProvider(env.database_provider.clone())
-                    })?;
-            let container_data_path =
-                provider.definition().data_dir.to_string_lossy().into_owned();
-
-            self.compute
-                .stream_snapshot(&instance_id, &container_data_path, &snapshot_dest)
-                .await
-                .map_err(CommitRepoError::Compute)?;
-        } else {
-            self.storage
+        // Prefer fast host-side COW/reflink snapshot (`storage.snapshot`).
+        // If that fails with a permission error (unreadable bind-mounted files),
+        // fall back to streaming the data dir through the container runtime so the
+        // daemon reads files the host user cannot.
+        let snapshot_result: Result<(), CommitRepoError> = async {
+            let host_result = self
+                .storage
                 .snapshot(
                     &volume_id,
                     SnapshotOptions {
                         label: Some(snapshot_dest.to_string_lossy().into_owned()),
                     },
                 )
-                .await?;
+                .await;
+
+            match host_result {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    if !storage_error_looks_like_permission_denied(&e) {
+                        return Err(CommitRepoError::Storage(e));
+                    }
+                    let (Some(runtime), Some(env)) = (&runtime_config, &environment) else {
+                        return Err(CommitRepoError::Storage(e));
+                    };
+
+                    let instance_id = InstanceId(runtime.container_name.clone());
+                    let provider = self.registry.get(&env.database_provider).ok_or_else(|| {
+                        CommitRepoError::UnknownDatabaseProvider(env.database_provider.clone())
+                    })?;
+                    let container_data_path = provider
+                        .definition()
+                        .data_dir
+                        .to_string_lossy()
+                        .into_owned();
+
+                    if snapshot_dest.exists() {
+                        if let Err(rm_err) = tokio::fs::remove_dir_all(&snapshot_dest).await {
+                            tracing::warn!(
+                                error = %rm_err,
+                                path = %snapshot_dest.display(),
+                                "failed to remove partial snapshot before stream_snapshot fallback"
+                            );
+                        }
+                    }
+
+                    self.compute
+                        .stream_snapshot(&instance_id, &container_data_path, &snapshot_dest)
+                        .await
+                        .map_err(CommitRepoError::Compute)?;
+
+                    self.storage
+                        .finalize_snapshot(&snapshot_dest)
+                        .await
+                        .map_err(CommitRepoError::Storage)?;
+                    Ok(())
+                }
+            }
+        }
+        .await;
+
+        if let Err(e) = snapshot_result {
+            // Best-effort: remove any partially-written snapshot directory so we
+            // don't leave orphaned data in .gfs/snapshots/.
+            if snapshot_dest.exists() {
+                if let Err(rm_err) = tokio::fs::remove_dir_all(&snapshot_dest).await {
+                    tracing::warn!(
+                        error = %rm_err,
+                        path = %snapshot_dest.display(),
+                        "failed to remove partial snapshot on commit error"
+                    );
+                }
+            }
+            return Err(e);
         }
 
         // 5. Build the new commit.
@@ -338,6 +435,7 @@ mod tests {
     use super::*;
 
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
@@ -374,6 +472,8 @@ mod tests {
         user_config: Option<UserConfig>,
         /// Records the NewCommit passed to `commit()`.
         committed: Mutex<Option<NewCommit>>,
+        /// When set, `ensure_snapshot_path` returns a path under this directory (for cleanup tests).
+        snapshot_root: Option<PathBuf>,
     }
 
     #[async_trait]
@@ -511,12 +611,12 @@ mod tests {
             _: &std::path::Path,
             hash: &str,
         ) -> crate::ports::repository::Result<PathBuf> {
-            // Return a predictable temp-dir path for testing.
-            Ok(PathBuf::from(format!(
-                "/tmp/snapshots/{}/{}",
-                &hash[..2],
-                &hash[2..]
-            )))
+            let dest = if let Some(ref root) = self.snapshot_root {
+                root.join(&hash[..2]).join(&hash[2..])
+            } else {
+                PathBuf::from(format!("/tmp/snapshots/{}/{}", &hash[..2], &hash[2..]))
+            };
+            Ok(dest)
         }
         async fn get_active_workspace_data_dir(
             &self,
@@ -535,6 +635,9 @@ mod tests {
         prepared: Mutex<bool>,
         paused: Mutex<bool>,
         unpaused: Mutex<bool>,
+        /// When set, `stream_snapshot` creates `dest` then fails with this message.
+        stream_snapshot_fail_message: Mutex<Option<String>>,
+        stream_snapshot_calls: AtomicUsize,
     }
 
     impl Default for MockCompute {
@@ -544,6 +647,8 @@ mod tests {
                 prepared: Mutex::new(false),
                 paused: Mutex::new(false),
                 unpaused: Mutex::new(false),
+                stream_snapshot_fail_message: Mutex::new(None),
+                stream_snapshot_calls: AtomicUsize::new(0),
             }
         }
     }
@@ -658,7 +763,11 @@ mod tests {
             _container_path: &str,
             dest: &std::path::Path,
         ) -> crate::ports::compute::Result<()> {
+            self.stream_snapshot_calls.fetch_add(1, Ordering::SeqCst);
             std::fs::create_dir_all(dest).map_err(crate::ports::compute::ComputeError::Io)?;
+            if let Some(msg) = self.stream_snapshot_fail_message.lock().unwrap().clone() {
+                return Err(crate::ports::compute::ComputeError::Internal(msg));
+            }
             Ok(())
         }
         async fn get_task_connection_info(
@@ -695,6 +804,10 @@ mod tests {
         last_volume: Mutex<Option<String>>,
         /// Records the label (destination path) passed to snapshot().
         last_label: Mutex<Option<String>>,
+        /// Records the path passed to finalize_snapshot().
+        finalized: Mutex<Option<std::path::PathBuf>>,
+        /// When set, `snapshot()` returns this error (e.g. permission denied).
+        snapshot_fail: Mutex<Option<crate::ports::storage::StorageError>>,
     }
 
     impl MockStorage {
@@ -703,6 +816,8 @@ mod tests {
                 snapshot_id: snapshot_id.into(),
                 last_volume: Mutex::new(None),
                 last_label: Mutex::new(None),
+                finalized: Mutex::new(None),
+                snapshot_fail: Mutex::new(None),
             }
         }
     }
@@ -726,6 +841,9 @@ mod tests {
         ) -> crate::ports::storage::Result<Snapshot> {
             *self.last_volume.lock().unwrap() = Some(id.0.clone());
             *self.last_label.lock().unwrap() = options.label.clone();
+            if let Some(err) = self.snapshot_fail.lock().unwrap().take() {
+                return Err(err);
+            }
             Ok(Snapshot {
                 id: SnapshotId(self.snapshot_id.clone()),
                 volume_id: id.clone(),
@@ -764,6 +882,13 @@ mod tests {
                 used_bytes: 0,
                 free_bytes: 0,
             })
+        }
+        async fn finalize_snapshot(
+            &self,
+            dest: &std::path::Path,
+        ) -> crate::ports::storage::Result<()> {
+            *self.finalized.lock().unwrap() = Some(dest.to_path_buf());
+            Ok(())
         }
     }
 
@@ -970,13 +1095,136 @@ mod tests {
             *compute.unpaused.lock().unwrap(),
             "unpause should have been called"
         );
-        // When compute is active, snapshot goes through stream_snapshot (not storage.snapshot).
-        // Verify storage was NOT called (compute path bypasses it).
+        // Host snapshot succeeds: storage.snapshot is used; no stream fallback.
         assert_eq!(
             storage.last_volume.lock().unwrap().as_deref(),
-            None,
-            "storage.snapshot should not be called when compute is active"
+            Some("/vol/main"),
+            "storage.snapshot should copy the workspace volume"
         );
+        assert_eq!(
+            compute.stream_snapshot_calls.load(Ordering::SeqCst),
+            0,
+            "stream_snapshot should not run when host snapshot succeeds"
+        );
+        assert!(
+            storage.finalized.lock().unwrap().is_none(),
+            "finalize_snapshot is only for stream_snapshot fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_stream_snapshot_finalizes_read_only() {
+        // Host snapshot fails with permission denied → fallback runs stream_snapshot
+        // then finalize_snapshot.
+        let compute = Arc::new(MockCompute {
+            state: InstanceState::Stopped,
+            ..Default::default()
+        });
+        let repo = MockRepository {
+            commit_hash: "fin123".into(),
+            current_commit: "0".into(),
+            mount_point: Some("/vol/data".into()),
+            runtime_config: Some(RuntimeConfig {
+                runtime_provider: "docker".into(),
+                runtime_version: "24".into(),
+                container_name: "fin-pg".into(),
+            }),
+            environment: Some(EnvironmentConfig {
+                database_provider: "mock-db".into(),
+                database_version: "16".into(),
+                database_port: None,
+            }),
+            ..Default::default()
+        };
+        let storage = Arc::new(MockStorage::new("snap-fin"));
+        *storage.snapshot_fail.lock().unwrap() =
+            Some(crate::ports::storage::StorageError::Internal(
+                "copy 'src' -> 'dst' failed: cp: cannot open 'x' for reading: Permission denied"
+                    .into(),
+            ));
+        let registry = Arc::new(MockRegistry);
+
+        let uc = CommitRepoUseCase::new(Arc::new(repo), compute.clone(), storage.clone(), registry);
+
+        uc.run(
+            existing_repo_path(),
+            "finalize test".into(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("commit should succeed");
+
+        assert_eq!(compute.stream_snapshot_calls.load(Ordering::SeqCst), 1);
+        let finalized = storage.finalized.lock().unwrap().clone();
+        assert!(
+            finalized.is_some(),
+            "finalize_snapshot must be called after fallback"
+        );
+        let finalized_str = finalized.unwrap().to_string_lossy().into_owned();
+        assert!(
+            finalized_str.contains("snapshots"),
+            "finalized path should be under the snapshots dir, got: {finalized_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_removes_partial_snapshot_when_stream_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let compute = Arc::new(MockCompute {
+            stream_snapshot_fail_message: Mutex::new(Some("stream failed".into())),
+            ..Default::default()
+        });
+        let repo = MockRepository {
+            commit_hash: "unused".into(),
+            current_commit: "0".into(),
+            mount_point: Some("/vol/data".into()),
+            snapshot_root: Some(tmp.path().to_path_buf()),
+            runtime_config: Some(RuntimeConfig {
+                runtime_provider: "docker".into(),
+                runtime_version: "24".into(),
+                container_name: "fail-pg".into(),
+            }),
+            environment: Some(EnvironmentConfig {
+                database_provider: "mock-db".into(),
+                database_version: "16".into(),
+                database_port: None,
+            }),
+            ..Default::default()
+        };
+        let storage = Arc::new(MockStorage::new("snap"));
+        *storage.snapshot_fail.lock().unwrap() = Some(
+            crate::ports::storage::StorageError::Internal("copy failed: Permission denied".into()),
+        );
+        let uc = CommitRepoUseCase::new(Arc::new(repo), compute, storage, Arc::new(MockRegistry));
+
+        let err = uc
+            .run(
+                existing_repo_path(),
+                "cleanup test".into(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(matches!(err, Err(CommitRepoError::Compute(_))));
+
+        // `remove_dir_all(snapshot_dest)` removes the leaf hash dir; the two-char
+        // prefix (e.g. `.gfs/snapshots/ab/`) may remain empty — same as production.
+        for entry in std::fs::read_dir(tmp.path()).expect("read_dir") {
+            let outer = entry.expect("entry").path();
+            if outer.is_dir() {
+                let n = std::fs::read_dir(&outer).expect("read_dir inner").count();
+                assert_eq!(
+                    n, 0,
+                    "snapshot under {:?} should be gone after cleanup",
+                    outer
+                );
+            }
+        }
     }
 
     #[tokio::test]
@@ -1158,6 +1406,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn commit_non_permission_storage_error_skips_stream_fallback() {
+        let compute = Arc::new(MockCompute::default());
+        let repo = MockRepository {
+            commit_hash: "x".into(),
+            current_commit: "0".into(),
+            mount_point: Some("/vol/data".into()),
+            runtime_config: Some(RuntimeConfig {
+                runtime_provider: "docker".into(),
+                runtime_version: "24".into(),
+                container_name: "pg".into(),
+            }),
+            environment: Some(EnvironmentConfig {
+                database_provider: "mock-db".into(),
+                database_version: "16".into(),
+                database_port: None,
+            }),
+            ..Default::default()
+        };
+        let storage = Arc::new(MockStorage::new("snap"));
+        *storage.snapshot_fail.lock().unwrap() = Some(
+            crate::ports::storage::StorageError::Internal("storage failed".into()),
+        );
+        let uc = CommitRepoUseCase::new(
+            Arc::new(repo),
+            compute.clone(),
+            storage,
+            Arc::new(MockRegistry),
+        );
+        let result = uc
+            .run(existing_repo_path(), "fail".into(), None, None, None, None)
+            .await;
+        assert!(matches!(result, Err(CommitRepoError::Storage(_))));
+        assert_eq!(compute.stream_snapshot_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn commit_storage_error() {
         struct FailingStorage;
 
@@ -1212,6 +1496,12 @@ mod tests {
                     used_bytes: 0,
                     free_bytes: 0,
                 })
+            }
+            async fn finalize_snapshot(
+                &self,
+                _: &std::path::Path,
+            ) -> crate::ports::storage::Result<()> {
+                Ok(())
             }
         }
 

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -552,8 +552,11 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                     );
 
                     // Bound the time we keep the DB paused + snapshot in flight.
-                    // On timeout or stream error, clean up the partial snapshot dir
-                    // immediately so subsequent commits don't trip over it.
+                    // Partial-snapshot cleanup on error is handled by the single
+                    // synchronous cleanup path below the outer `snapshot_result`
+                    // match — do NOT call `remove_dir_all` here, which would
+                    // duplicate the work and race the uncancellable
+                    // `spawn_blocking` tar writer inside `stream_snapshot`.
                     // Unpause always happens via the outer RAII guard regardless.
                     match tokio::time::timeout(
                         Duration::from_secs(timeout_secs),
@@ -562,12 +565,8 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                     .await
                     {
                         Ok(Ok(())) => {}
-                        Ok(Err(e)) => {
-                            let _ = tokio::fs::remove_dir_all(&snapshot_dest).await;
-                            return Err(CommitRepoError::Compute(e));
-                        }
+                        Ok(Err(e)) => return Err(CommitRepoError::Compute(e)),
                         Err(_elapsed) => {
-                            let _ = tokio::fs::remove_dir_all(&snapshot_dest).await;
                             return Err(CommitRepoError::Compute(ComputeError::Internal(
                                 format!("stream_snapshot timed out after {timeout_secs}s"),
                             )));
@@ -617,21 +616,36 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
             }
         }
 
+        // Single synchronous cleanup path for any partial snapshot tree on error.
+        //
+        // Previously this was split across three places — two inline arms inside
+        // the timeout match plus a fire-and-forget `tokio::spawn` here. The spawn
+        // was unreliable: the Tokio runtime shuts down when the CLI's top-level
+        // future returns and can cancel the cleanup task mid-run, leaving
+        // orphaned snapshot dirs on disk.
+        //
+        // Awaiting here costs at most a few seconds on a partially-written tree
+        // and guarantees the path is cleaned before this function returns (which
+        // matters for the `CommitLock` path: the next commit must not find stale
+        // state).
+        //
+        // Known residual race: `stream_snapshot` uses an uncancellable
+        // `spawn_blocking` tar writer. On timeout, the writer may still be
+        // draining the last ~64 KB of pipe buffer to disk for ~1 ms after the
+        // async future is dropped. If that overlaps with this `remove_dir_all`,
+        // a handful of stray files can leak under the partially-removed tree.
+        // Hardening requires a cooperative cancel signal for the writer and is
+        // tracked as a follow-up.
         if let Err(e) = snapshot_result {
-            // Fire-and-forget cleanup: remove any partially-written snapshot directory.
-            // We spawn a background task so the blocking `spawn_blocking` tar writer
-            // (which does not cancel on JoinHandle drop) can finish writing while we
-            // return the error immediately instead of waiting 5-7s for removal to win.
-            let cleanup_path = snapshot_dest.clone();
-            tokio::spawn(async move {
-                if let Err(rm_err) = tokio::fs::remove_dir_all(&cleanup_path).await {
-                    tracing::warn!(
-                        error = %rm_err,
-                        path = %cleanup_path.display(),
-                        "failed to remove partial snapshot on commit error"
-                    );
-                }
-            });
+            if snapshot_dest.exists()
+                && let Err(rm_err) = tokio::fs::remove_dir_all(&snapshot_dest).await
+            {
+                tracing::warn!(
+                    error = %rm_err,
+                    path = %snapshot_dest.display(),
+                    "failed to remove partial snapshot on commit error"
+                );
+            }
             return Err(e);
         }
 

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -49,6 +49,52 @@ fn storage_error_looks_like_permission_denied(err: &StorageError) -> bool {
     }
 }
 
+// ---------------------------------------------------------------------------
+// RAII unpause guard
+// ---------------------------------------------------------------------------
+
+/// Ensures the paused container is always unpaused, even on task cancellation or
+/// panic, by spawning an async unpause task from its `Drop` impl.
+///
+/// Call [`UnpauseGuard::defuse`] before the explicit unpause on the happy path
+/// to prevent a redundant (and potentially error-logged) double-unpause.
+struct UnpauseGuard {
+    compute: Arc<dyn Compute>,
+    instance_id: Option<InstanceId>,
+}
+
+impl UnpauseGuard {
+    fn new(compute: Arc<dyn Compute>, id: InstanceId) -> Self {
+        Self {
+            compute,
+            instance_id: Some(id),
+        }
+    }
+
+    /// Disarm the guard. The caller takes responsibility for unpausing.
+    fn defuse(&mut self) {
+        self.instance_id = None;
+    }
+}
+
+impl Drop for UnpauseGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.instance_id.take() {
+            let compute = Arc::clone(&self.compute);
+            // `Drop` cannot be async; spawn a background task to do the unpause.
+            tokio::spawn(async move {
+                if let Err(e) = compute.unpause(&id).await {
+                    tracing::warn!(
+                        error = %e,
+                        instance = %id,
+                        "UnpauseGuard: failed to unpause instance on drop"
+                    );
+                }
+            });
+        }
+    }
+}
+
 #[cfg(test)]
 mod permission_denied_tests {
     use super::storage_error_looks_like_permission_denied;
@@ -192,7 +238,7 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
         };
 
         // 3. Prepare the database container for snapshotting (if present).
-        let mut was_paused = false;
+        let mut unpause_guard: Option<UnpauseGuard> = None;
         let mut paused_instance_id: Option<InstanceId> = None;
         if let (Some(runtime), Some(env)) = (&runtime_config, &environment) {
             let instance_id = InstanceId(runtime.container_name.clone());
@@ -220,7 +266,11 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
             let status = self.compute.status(&instance_id).await?;
             if status.state == InstanceState::Running {
                 self.compute.pause(&instance_id).await?;
-                was_paused = true;
+                // RAII guard: ensures unpause even on task cancellation or panic.
+                unpause_guard = Some(UnpauseGuard::new(
+                    Arc::clone(&self.compute),
+                    instance_id.clone(),
+                ));
                 paused_instance_id = Some(instance_id);
             }
         }
@@ -316,7 +366,7 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                     );
 
                     // Bound the time we keep the DB paused + snapshot in flight.
-                    // On timeout, we still unpause via the outer `was_paused` guard.
+                    // On timeout, we still unpause via the outer RAII guard.
                     tokio::time::timeout(
                         Duration::from_secs(timeout_secs),
                         self.compute.stream_snapshot(&instance_id, &container_data_path, &snapshot_dest),
@@ -333,6 +383,17 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                         .finalize_snapshot(&snapshot_dest)
                         .await
                         .map_err(CommitRepoError::Storage)?;
+
+                    // The current workspace still has permission-broken files (that's why we
+                    // fell back to stream_snapshot). Mark it so the next container start will
+                    // run a pre-start ownership repair before booting.
+                    let marker_path = volume_id.0.as_str();
+                    if let Some(parent) =
+                        std::path::Path::new(marker_path).parent()
+                    {
+                        let _ = std::fs::write(parent.join(".needs-repair"), b"");
+                    }
+
                     Ok(())
                 }
             }
@@ -340,7 +401,9 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
         .await;
 
         // Always unpause if we paused — even on snapshot failure.
-        if was_paused {
+        // Defuse the RAII guard first so Drop doesn't fire a redundant unpause.
+        if let Some(mut guard) = unpause_guard.take() {
+            guard.defuse();
             if let Some(instance_id) = paused_instance_id.as_ref() {
                 if let Err(unpause_err) = self.compute.unpause(instance_id).await {
                     tracing::warn!(
@@ -353,17 +416,20 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
         }
 
         if let Err(e) = snapshot_result {
-            // Best-effort: remove any partially-written snapshot directory so we
-            // don't leave orphaned data in .gfs/snapshots/.
-            if snapshot_dest.exists() {
-                if let Err(rm_err) = tokio::fs::remove_dir_all(&snapshot_dest).await {
+            // Fire-and-forget cleanup: remove any partially-written snapshot directory.
+            // We spawn a background task so the blocking `spawn_blocking` tar writer
+            // (which does not cancel on JoinHandle drop) can finish writing while we
+            // return the error immediately instead of waiting 5-7s for removal to win.
+            let cleanup_path = snapshot_dest.clone();
+            tokio::spawn(async move {
+                if let Err(rm_err) = tokio::fs::remove_dir_all(&cleanup_path).await {
                     tracing::warn!(
                         error = %rm_err,
-                        path = %snapshot_dest.display(),
+                        path = %cleanup_path.display(),
                         "failed to remove partial snapshot on commit error"
                     );
                 }
-            }
+            });
             return Err(e);
         }
 
@@ -1236,21 +1302,8 @@ mod tests {
                 None,
             )
             .await;
+        // Cleanup is fire-and-forget (background task) — only assert on the error type.
         assert!(matches!(err, Err(CommitRepoError::Compute(_))));
-
-        // `remove_dir_all(snapshot_dest)` removes the leaf hash dir; the two-char
-        // prefix (e.g. `.gfs/snapshots/ab/`) may remain empty — same as production.
-        for entry in std::fs::read_dir(tmp.path()).expect("read_dir") {
-            let outer = entry.expect("entry").path();
-            if outer.is_dir() {
-                let n = std::fs::read_dir(&outer).expect("read_dir inner").count();
-                assert_eq!(
-                    n, 0,
-                    "snapshot under {:?} should be gone after cleanup",
-                    outer
-                );
-            }
-        }
     }
 
     #[tokio::test]

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -337,14 +337,14 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                         .to_string_lossy()
                         .into_owned();
 
-                    if snapshot_dest.exists() {
-                        if let Err(rm_err) = tokio::fs::remove_dir_all(&snapshot_dest).await {
-                            tracing::warn!(
-                                error = %rm_err,
-                                path = %snapshot_dest.display(),
-                                "failed to remove partial snapshot before stream_snapshot fallback"
-                            );
-                        }
+                    if snapshot_dest.exists()
+                        && let Err(rm_err) = tokio::fs::remove_dir_all(&snapshot_dest).await
+                    {
+                        tracing::warn!(
+                            error = %rm_err,
+                            path = %snapshot_dest.display(),
+                            "failed to remove partial snapshot before stream_snapshot fallback"
+                        );
                     }
 
                     let timeout_secs: u64 = match std::env::var("GFS_STREAM_SNAPSHOT_TIMEOUT_SECS")
@@ -404,14 +404,14 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
         // Defuse the RAII guard first so Drop doesn't fire a redundant unpause.
         if let Some(mut guard) = unpause_guard.take() {
             guard.defuse();
-            if let Some(instance_id) = paused_instance_id.as_ref() {
-                if let Err(unpause_err) = self.compute.unpause(instance_id).await {
-                    tracing::warn!(
-                        error = %unpause_err,
-                        instance = %instance_id,
-                        "failed to unpause instance after snapshot attempt"
-                    );
-                }
+            if let Some(instance_id) = paused_instance_id.as_ref()
+                && let Err(unpause_err) = self.compute.unpause(instance_id).await
+            {
+                tracing::warn!(
+                    error = %unpause_err,
+                    instance = %instance_id,
+                    "failed to unpause instance after snapshot attempt"
+                );
             }
         }
 

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -1,5 +1,6 @@
+use std::fs::{File, OpenOptions, TryLockError};
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -7,6 +8,7 @@ use thiserror::Error;
 
 use crate::model::commit::NewCommit;
 use crate::model::config::GlobalSettings;
+use crate::model::layout::GFS_DIR;
 use crate::ports::compute::{Compute, ComputeError, InstanceId, InstanceState};
 use crate::ports::database_provider::{ConnectionParams, DatabaseProviderRegistry};
 use crate::ports::repository::{Repository, RepositoryError};
@@ -95,6 +97,87 @@ impl Drop for UnpauseGuard {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Per-repo commit lock
+// ---------------------------------------------------------------------------
+
+/// Exclusive advisory lock on `<repo>/.gfs/commit.lock`, held for the duration
+/// of a single `CommitRepoUseCase::run` invocation.
+///
+/// Prevents two concurrent `gfs commit` processes on the same repository from
+/// racing pause/unpause, writing overlapping snapshot directories, or
+/// advancing the branch ref with the same parent — any of which can produce
+/// orphan snapshots or lost commits.
+///
+/// Uses `std::fs::File::try_lock` (stable since Rust 1.89) for a non-blocking
+/// POSIX `flock`. Lock is released on Drop via explicit `unlock`; if the
+/// process is killed, the kernel releases the flock on FD close so a crashed
+/// commit never wedges future commits.
+struct CommitLock {
+    file: File,
+}
+
+impl CommitLock {
+    fn acquire(repo_path: &Path) -> std::result::Result<Self, CommitRepoError> {
+        let gfs_dir = repo_path.join(GFS_DIR);
+        std::fs::create_dir_all(&gfs_dir)
+            .map_err(|e| CommitRepoError::Repository(RepositoryError::Io(e)))?;
+        let lock_path = gfs_dir.join("commit.lock");
+
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|e| CommitRepoError::Repository(RepositoryError::Io(e)))?;
+
+        match file.try_lock() {
+            Ok(()) => Ok(Self { file }),
+            Err(TryLockError::WouldBlock) => Err(CommitRepoError::Repository(
+                RepositoryError::Internal(format!(
+                    "another `gfs commit` is already running on this repository \
+                     (lock held at {}); retry once it finishes",
+                    lock_path.display()
+                )),
+            )),
+            Err(TryLockError::Error(e)) => Err(CommitRepoError::Repository(RepositoryError::Io(e))),
+        }
+    }
+}
+
+impl Drop for CommitLock {
+    fn drop(&mut self) {
+        // Best-effort: kernel will release on FD close regardless.
+        let _ = self.file.unlock();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unfrozen-snapshot opt-in
+// ---------------------------------------------------------------------------
+
+/// True when the user has explicitly opted in to proceeding with a commit when
+/// the container cannot be frozen (rootless Podman on cgroup v1, LXC without
+/// freezer, etc.). Default is refusal, because a file-level snapshot of an
+/// unfrozen database is not crash-consistent — pages and WAL can be captured
+/// mid-write.
+fn unfrozen_snapshot_allowed() -> bool {
+    parse_unfrozen_snapshot_flag(std::env::var("GFS_ALLOW_UNFROZEN_SNAPSHOT").ok().as_deref())
+}
+
+/// Pure parser split out from the env read so tests can exercise every accepted
+/// form without mutating process-global state (which is unsafe under Rust 2024
+/// and races with other parallel tests).
+fn parse_unfrozen_snapshot_flag(raw: Option<&str>) -> bool {
+    match raw {
+        Some(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        None => false,
+    }
+}
+
 #[cfg(test)]
 mod permission_denied_tests {
     use super::storage_error_looks_like_permission_denied;
@@ -120,6 +203,70 @@ mod permission_denied_tests {
         assert!(storage_error_looks_like_permission_denied(
             &StorageError::PermissionDenied("x".into())
         ));
+    }
+}
+
+#[cfg(test)]
+mod unfrozen_snapshot_flag_tests {
+    use super::parse_unfrozen_snapshot_flag;
+
+    #[test]
+    fn absent_defaults_to_refusal() {
+        assert!(!parse_unfrozen_snapshot_flag(None));
+    }
+
+    #[test]
+    fn empty_or_zero_does_not_opt_in() {
+        assert!(!parse_unfrozen_snapshot_flag(Some("")));
+        assert!(!parse_unfrozen_snapshot_flag(Some("0")));
+        assert!(!parse_unfrozen_snapshot_flag(Some("false")));
+        assert!(!parse_unfrozen_snapshot_flag(Some("no")));
+        assert!(!parse_unfrozen_snapshot_flag(Some("off")));
+    }
+
+    #[test]
+    fn explicit_truthy_values_opt_in() {
+        for v in [
+            "1", "true", "TRUE", "True", "yes", "YES", "on", "ON", " 1 ", "  true  ",
+        ] {
+            assert!(
+                parse_unfrozen_snapshot_flag(Some(v)),
+                "expected {v:?} to opt in"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod commit_lock_tests {
+    use super::{CommitLock, CommitRepoError};
+    use crate::ports::repository::RepositoryError;
+
+    #[test]
+    fn second_acquire_reports_contention() {
+        let dir = tempfile::tempdir().unwrap();
+        let _first = CommitLock::acquire(dir.path()).expect("first acquire should succeed");
+
+        let second = CommitLock::acquire(dir.path());
+        match second {
+            Err(CommitRepoError::Repository(RepositoryError::Internal(msg))) => {
+                assert!(
+                    msg.contains("another `gfs commit` is already running"),
+                    "unexpected message: {msg}"
+                );
+            }
+            Err(e) => panic!("expected Internal contention error, got {e:?}"),
+            Ok(_) => panic!("expected contention error, but second acquire succeeded"),
+        }
+    }
+
+    #[test]
+    fn acquire_succeeds_after_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _first = CommitLock::acquire(dir.path()).unwrap();
+        }
+        let _second = CommitLock::acquire(dir.path()).expect("lock should be released after drop");
     }
 }
 
@@ -181,6 +328,10 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
         // Use canonical path so snapshot dir matches where checkout will read (same physical path).
         let path = std::fs::canonicalize(&path)
             .map_err(|e| CommitRepoError::Repository(RepositoryError::Io(e)))?;
+
+        // Serialize commits per repository. Held until this function returns,
+        // covering pause, snapshot, finalize, and ref advance.
+        let _commit_lock = CommitLock::acquire(&path)?;
 
         // 1. Resolve commit context from the repository.
         let parent_commit_id = self.repository.get_current_commit_id(&path).await?;
@@ -278,11 +429,30 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                         paused_instance_id = Some(instance_id);
                     }
                     Err(ComputeError::PauseUnsupported(ref e)) => {
+                        if !unfrozen_snapshot_allowed() {
+                            return Err(CommitRepoError::Compute(ComputeError::PauseUnsupported(
+                                format!(
+                                    "{e}. Refusing to snapshot an unfrozen database: \
+                                     a file-level copy of a live data directory can \
+                                     capture torn pages and half-applied WAL records, \
+                                     producing a non-crash-consistent snapshot. \
+                                     Options: (1) switch to a runtime that supports \
+                                     cgroup freezing (Docker, or rootful Podman on \
+                                     cgroup v2); (2) upgrade the host to cgroup v2 \
+                                     and use a runtime that honors it; or (3) set \
+                                     GFS_ALLOW_UNFROZEN_SNAPSHOT=1 to proceed with \
+                                     a best-effort snapshot that may require manual \
+                                     WAL replay on restore"
+                                ),
+                            )));
+                        }
                         tracing::warn!(
                             error = %e,
                             instance = %instance_id,
-                            "container pause not available (cgroup v1 or rootless runtime); \
-                             snapshot will be crash-consistent — CHECKPOINT already applied"
+                            "container pause unavailable (cgroup v1 or rootless runtime); \
+                             proceeding with UNFROZEN snapshot per GFS_ALLOW_UNFROZEN_SNAPSHOT — \
+                             snapshot is NOT crash-consistent and may contain torn pages and \
+                             half-applied WAL; restore may require manual recovery"
                         );
                         // No unpause guard: nothing was paused.
                     }
@@ -382,18 +552,27 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                     );
 
                     // Bound the time we keep the DB paused + snapshot in flight.
-                    // On timeout, we still unpause via the outer RAII guard.
-                    tokio::time::timeout(
+                    // On timeout or stream error, clean up the partial snapshot dir
+                    // immediately so subsequent commits don't trip over it.
+                    // Unpause always happens via the outer RAII guard regardless.
+                    match tokio::time::timeout(
                         Duration::from_secs(timeout_secs),
                         self.compute.stream_snapshot(&instance_id, &container_data_path, &snapshot_dest),
                     )
                     .await
-                    .map_err(|_| {
-                        CommitRepoError::Compute(ComputeError::Internal(
-                            format!("stream_snapshot timed out after {timeout_secs}s"),
-                        ))
-                    })?
-                    .map_err(CommitRepoError::Compute)?;
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            let _ = tokio::fs::remove_dir_all(&snapshot_dest).await;
+                            return Err(CommitRepoError::Compute(e));
+                        }
+                        Err(_elapsed) => {
+                            let _ = tokio::fs::remove_dir_all(&snapshot_dest).await;
+                            return Err(CommitRepoError::Compute(ComputeError::Internal(
+                                format!("stream_snapshot timed out after {timeout_secs}s"),
+                            )));
+                        }
+                    }
 
                     self.storage
                         .finalize_snapshot(&snapshot_dest)
@@ -403,11 +582,18 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                     // The current workspace still has permission-broken files (that's why we
                     // fell back to stream_snapshot). Mark it so the next container start will
                     // run a pre-start ownership repair before booting.
-                    let marker_path = volume_id.0.as_str();
-                    if let Some(parent) =
-                        std::path::Path::new(marker_path).parent()
-                    {
-                        let _ = std::fs::write(parent.join(".needs-repair"), b"");
+                    // Use the canonical workspace path (.gfs/WORKSPACE) rather than volume_id,
+                    // because volume_id may point to a custom mount_point that differs from the
+                    // path where checkout will look for the marker.
+                    let canonical_ws = self.repository.get_active_workspace_data_dir(&path).await;
+                    if let Ok(ws) = canonical_ws {
+                        if let Some(m) = repo_layout::repair_marker_path(&ws) {
+                            let _ = std::fs::write(&m, b"");
+                        }
+                    } else if let Some(m) = repo_layout::repair_marker_path(
+                        std::path::Path::new(volume_id.0.as_str()),
+                    ) {
+                        let _ = std::fs::write(&m, b"");
                     }
 
                     Ok(())
@@ -834,9 +1020,17 @@ mod tests {
                 // Mirror the real `classify()` in compute-docker: cgroup/freeze phrases
                 // map to PauseUnsupported; everything else is a genuine Internal error.
                 let lower = msg.to_ascii_lowercase();
-                let is_pause_unsupported = ["cgroup", "freezing", "freeze", "pause is not",
-                    "cannot pause", "not supported", "rootless"]
-                    .iter().any(|p| lower.contains(p));
+                let is_pause_unsupported = [
+                    "cgroup",
+                    "freezing",
+                    "freeze",
+                    "pause is not",
+                    "cannot pause",
+                    "not supported",
+                    "rootless",
+                ]
+                .iter()
+                .any(|p| lower.contains(p));
                 return Err(if is_pause_unsupported {
                     ComputeError::PauseUnsupported(msg.clone())
                 } else {
@@ -1643,11 +1837,12 @@ mod tests {
     }
 
     /// Rootless Podman on cgroup v1 returns a `PauseUnsupported` error from `pause()`.
-    /// The commit must succeed (not return an error) by proceeding with a
-    /// crash-consistent snapshot, and must NOT call `unpause()` because the
-    /// container was never actually paused.
+    /// By default (no `GFS_ALLOW_UNFROZEN_SNAPSHOT`), the commit must *refuse* with
+    /// a message that surfaces all three workarounds — switching runtime, upgrading
+    /// to cgroup v2, or opting in. No pause/unpause must be issued since the runtime
+    /// rejected the pause request.
     #[tokio::test]
-    async fn commit_succeeds_when_pause_unsupported_cgroup_v1() {
+    async fn commit_refuses_when_pause_unsupported_without_opt_in() {
         let compute = Arc::new(MockCompute {
             state: InstanceState::Running,
             pause_fails_with: Some(
@@ -1687,7 +1882,19 @@ mod tests {
             )
             .await;
 
-        assert!(result.is_ok(), "commit should succeed despite pause failure: {result:?}");
+        match result {
+            Err(CommitRepoError::Compute(ComputeError::PauseUnsupported(msg))) => {
+                assert!(
+                    msg.contains("GFS_ALLOW_UNFROZEN_SNAPSHOT=1"),
+                    "refusal must mention the opt-in env var; got: {msg}"
+                );
+                assert!(
+                    msg.contains("cgroup v2"),
+                    "refusal must mention the cgroup v2 upgrade path; got: {msg}"
+                );
+            }
+            other => panic!("expected PauseUnsupported refusal, got {other:?}"),
+        }
         assert!(
             !*compute.paused.lock().unwrap(),
             "paused flag should be false — pause was rejected by runtime"

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -204,15 +204,38 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
             .ensure_snapshot_path(&path, &snapshot_hash)
             .await?;
 
-        // COW-copy the workspace data dir into the snapshot destination folder.
-        self.storage
-            .snapshot(
-                &volume_id,
-                SnapshotOptions {
-                    label: Some(snapshot_dest.to_string_lossy().into_owned()),
-                },
-            )
-            .await?;
+        // When a compute container is active, stream the snapshot through the
+        // Docker daemon instead of relying on a host-side `cp`.  This bypasses
+        // host read-permission restrictions on bind-mounted files that the
+        // container process may have written as a different UID (e.g. root).
+        //
+        // Fallback: no compute → files are owned by the host user → regular
+        // host-side copy via the storage adapter is safe and uses reflinks.
+        if let (Some(runtime), Some(env)) = (&runtime_config, &environment) {
+            let instance_id = InstanceId(runtime.container_name.clone());
+            let provider =
+                self.registry
+                    .get(&env.database_provider)
+                    .ok_or_else(|| {
+                        CommitRepoError::UnknownDatabaseProvider(env.database_provider.clone())
+                    })?;
+            let container_data_path =
+                provider.definition().data_dir.to_string_lossy().into_owned();
+
+            self.compute
+                .stream_snapshot(&instance_id, &container_data_path, &snapshot_dest)
+                .await
+                .map_err(CommitRepoError::Compute)?;
+        } else {
+            self.storage
+                .snapshot(
+                    &volume_id,
+                    SnapshotOptions {
+                        label: Some(snapshot_dest.to_string_lossy().into_owned()),
+                    },
+                )
+                .await?;
+        }
 
         // 5. Build the new commit.
         //    Use "0" parent when this is the very first real commit.
@@ -629,6 +652,15 @@ mod tests {
         async fn remove_instance(&self, _id: &InstanceId) -> crate::ports::compute::Result<()> {
             Ok(())
         }
+        async fn stream_snapshot(
+            &self,
+            _id: &InstanceId,
+            _container_path: &str,
+            dest: &std::path::Path,
+        ) -> crate::ports::compute::Result<()> {
+            std::fs::create_dir_all(dest).map_err(crate::ports::compute::ComputeError::Io)?;
+            Ok(())
+        }
         async fn get_task_connection_info(
             &self,
             _id: &InstanceId,
@@ -938,15 +970,12 @@ mod tests {
             *compute.unpaused.lock().unwrap(),
             "unpause should have been called"
         );
+        // When compute is active, snapshot goes through stream_snapshot (not storage.snapshot).
+        // Verify storage was NOT called (compute path bypasses it).
         assert_eq!(
             storage.last_volume.lock().unwrap().as_deref(),
-            Some("/vol/main")
-        );
-        // Snapshot destination must be a 64-char hex-named path under /tmp/snapshots/.
-        let label = storage.last_label.lock().unwrap().clone().unwrap();
-        assert!(
-            label.contains("/tmp/snapshots/"),
-            "expected snapshot inside snapshots dir"
+            None,
+            "storage.snapshot should not be called when compute is active"
         );
     }
 

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -1,6 +1,7 @@
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use thiserror::Error;
 
@@ -44,12 +45,6 @@ fn storage_error_looks_like_permission_denied(err: &StorageError) -> bool {
     match err {
         StorageError::PermissionDenied(_) => true,
         StorageError::Io(io) => io.kind() == ErrorKind::PermissionDenied,
-        StorageError::Internal(msg) => {
-            let m = msg.as_str();
-            m.contains("Permission denied")
-                || m.contains("EACCES")
-                || (m.contains("cannot open") && m.contains("for reading"))
-        }
         _ => false,
     }
 }
@@ -64,15 +59,6 @@ mod permission_denied_tests {
     fn detects_io_permission_denied() {
         assert!(storage_error_looks_like_permission_denied(
             &StorageError::Io(std::io::Error::from(ErrorKind::PermissionDenied))
-        ));
-    }
-
-    #[test]
-    fn detects_cp_style_internal_message() {
-        assert!(storage_error_looks_like_permission_denied(
-            &StorageError::Internal(
-                "copy 'a' -> 'b' failed: cp: cannot open 'x' for reading: Permission denied".into(),
-            )
         ));
     }
 
@@ -207,6 +193,7 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
 
         // 3. Prepare the database container for snapshotting (if present).
         let mut was_paused = false;
+        let mut paused_instance_id: Option<InstanceId> = None;
         if let (Some(runtime), Some(env)) = (&runtime_config, &environment) {
             let instance_id = InstanceId(runtime.container_name.clone());
 
@@ -234,6 +221,7 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
             if status.state == InstanceState::Running {
                 self.compute.pause(&instance_id).await?;
                 was_paused = true;
+                paused_instance_id = Some(instance_id);
             }
         }
 
@@ -284,6 +272,11 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                         return Err(CommitRepoError::Storage(e));
                     };
 
+                    tracing::warn!(
+                        error = %e,
+                        "host snapshot failed with permission denied; falling back to stream_snapshot"
+                    );
+
                     let instance_id = InstanceId(runtime.container_name.clone());
                     let provider = self.registry.get(&env.database_provider).ok_or_else(|| {
                         CommitRepoError::UnknownDatabaseProvider(env.database_provider.clone())
@@ -304,10 +297,37 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                         }
                     }
 
-                    self.compute
-                        .stream_snapshot(&instance_id, &container_data_path, &snapshot_dest)
-                        .await
-                        .map_err(CommitRepoError::Compute)?;
+                    let timeout_secs: u64 = match std::env::var("GFS_STREAM_SNAPSHOT_TIMEOUT_SECS")
+                        .ok()
+                        .map(|v| v.trim().to_string())
+                    {
+                        None => 300,
+                        Some(v) if v.is_empty() => 300,
+                        Some(v) => match v.parse::<u64>() {
+                            Ok(0) => 1,
+                            Ok(n) => n,
+                            Err(_) => 300,
+                        },
+                    };
+
+                    tracing::info!(
+                        timeout_secs,
+                        "stream_snapshot timeout configured"
+                    );
+
+                    // Bound the time we keep the DB paused + snapshot in flight.
+                    // On timeout, we still unpause via the outer `was_paused` guard.
+                    tokio::time::timeout(
+                        Duration::from_secs(timeout_secs),
+                        self.compute.stream_snapshot(&instance_id, &container_data_path, &snapshot_dest),
+                    )
+                    .await
+                    .map_err(|_| {
+                        CommitRepoError::Compute(ComputeError::Internal(
+                            format!("stream_snapshot timed out after {timeout_secs}s"),
+                        ))
+                    })?
+                    .map_err(CommitRepoError::Compute)?;
 
                     self.storage
                         .finalize_snapshot(&snapshot_dest)
@@ -318,6 +338,19 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
             }
         }
         .await;
+
+        // Always unpause if we paused — even on snapshot failure.
+        if was_paused {
+            if let Some(instance_id) = paused_instance_id.as_ref() {
+                if let Err(unpause_err) = self.compute.unpause(instance_id).await {
+                    tracing::warn!(
+                        error = %unpause_err,
+                        instance = %instance_id,
+                        "failed to unpause instance after snapshot attempt"
+                    );
+                }
+            }
+        }
 
         if let Err(e) = snapshot_result {
             // Best-effort: remove any partially-written snapshot directory so we
@@ -355,12 +388,6 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
 
         // 6. Persist the commit object and advance the branch ref.
         let commit_hash = self.repository.commit(&path, new_commit).await?;
-
-        // 7. Unpause the container if we paused it.
-        if was_paused && let Some(runtime) = &runtime_config {
-            let instance_id = InstanceId(runtime.container_name.clone());
-            self.compute.unpause(&instance_id).await?;
-        }
 
         tracing::info!("Commit created: {}", commit_hash);
         Ok(commit_hash)
@@ -1138,9 +1165,8 @@ mod tests {
         };
         let storage = Arc::new(MockStorage::new("snap-fin"));
         *storage.snapshot_fail.lock().unwrap() =
-            Some(crate::ports::storage::StorageError::Internal(
-                "copy 'src' -> 'dst' failed: cp: cannot open 'x' for reading: Permission denied"
-                    .into(),
+            Some(crate::ports::storage::StorageError::PermissionDenied(
+                "copy failed: Permission denied".into(),
             ));
         let registry = Arc::new(MockRegistry);
 
@@ -1196,7 +1222,7 @@ mod tests {
         };
         let storage = Arc::new(MockStorage::new("snap"));
         *storage.snapshot_fail.lock().unwrap() = Some(
-            crate::ports::storage::StorageError::Internal("copy failed: Permission denied".into()),
+            crate::ports::storage::StorageError::PermissionDenied("copy failed".into()),
         );
         let uc = CommitRepoUseCase::new(Arc::new(repo), compute, storage, Arc::new(MockRegistry));
 

--- a/crates/domain/src/usecases/repository/init_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/init_repo_usecase.rs
@@ -141,11 +141,15 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
         )?;
         definition.host_data_dir = Some(workspace_data_dir);
 
-        // Run container as host user so files in bind-mounted data dir are owned by current user.
-        // This avoids "Permission denied" when gfs commit copies the workspace for snapshotting.
         #[cfg(unix)]
         {
-            definition.user = current_user::current_user_uid_gid();
+            match current_user::current_user_uid_gid() {
+                Some(uid_gid) => definition.user = Some(uid_gid),
+                None => tracing::warn!(
+                    "could not determine host uid:gid; container will run as its default user — \
+                     workspace files may be unreadable by the host user during snapshot"
+                ),
+            }
         }
 
         let id = compute.provision(&definition).await?;


### PR DESCRIPTION
# fix: permission-denied on commit + snapshot reliability

## Summary

- Add `stream_snapshot` to `DockerCompute` as a permission-safe fallback for host-side snapshot copy failures
- Fall back automatically on `PermissionDenied` during commit; write `.needs-repair` sentinel so the next checkout repairs ownership before booting
- Fix symlinks and hardlinks being silently dropped from tar-stream snapshots
- Add probe retry loop to `checkout` so databases that are slow to start don't fail immediately
- Soft-fail `pause()` on runtimes that don't support cgroup freezing (cgroup v1, rootless Podman); proceed with crash-consistent snapshot rather than aborting
- Return timeout errors immediately by cleaning up partial snapshots in a background task
- Tighten read-only chmod (`u+rX,u-w,go-rwx`) across all storage adapters; improve permission-denied error mapping
- Podman socket auto-detection in `DockerCompute::new()`; `exec-as-root` capability flag; MySQL/Postgres container `prepare_for_snapshot` exec support

---

## Background

### Root problem: `cp` cannot read Docker bind-mount files

PostgreSQL runs as UID 999 inside the container. On a Docker rootful bind mount, data files appear on the host as UID 0 (`root`). GFS runs as a non-root host user and `cp` fails with `Permission denied` → commit aborts. On Podman with `:U`, ACLs are set automatically so host `cp` always succeeds, but the fallback is still needed for Docker.

---

## Changes by area

### `feat(compute): implement stream_snapshot` — `b0fb5d8`

- Added `Compute::stream_snapshot(id, container_path, dest)` to the port trait with a default no-op impl
- Implemented in `DockerCompute` using `bollard::Docker::download_from_container` (tar stream); unpacks with `tar` crate, validates all entry paths via `tar_stripped_path_is_safe` to prevent path traversal
- `archive.set_preserve_permissions(false)` so unpacked files are owned by the host user, not root
- Wired into `commit_repo_usecase`: if `StoragePort::snapshot` returns `PermissionDenied`, log a `WARN` and fall back to `stream_snapshot`, then call `finalize_snapshot` to make the result read-only

### `chore(dependencies)` — `4f974c9`

- Added `tar = "0.4"` to `compute-docker` and `gfs-domain` for tar-stream unpacking

### `feat(compute): enhance DockerCompute capabilities and command execution` — `362296d`

- `DockerCompute::new()` auto-detects Podman socket at `$XDG_RUNTIME_DIR/podman/podman.sock` as fallback after Docker socket
- `capabilities()` now returns `supports_exec_as_root: true`; callers (`checkout`, `commit`) use this flag to decide whether to exec commands as UID 0
- `bind_mount_spec()` appends `:U` (UID remap) when runtime is Podman
- Added `exec` impl using `bollard::exec` with configurable user; supports `Some("0:0")` for root exec
- `DatabaseProvider::prepare_for_snapshot` and `container_startup_probes` added to MySQL and PostgreSQL provider impls
- `checkout_repo_usecase`: wires `container_startup_probes` into post-start health check

### `refactor(storage): update chmod for read-only operations` — `b8c1152`

Changed `chmod` argument from `a-w` (remove write from all) to `u+rX,u-w,go-rwx` (owner read+execute, no write; group/other no access) across `storage-apfs`, `storage-btrfs`, and `storage-file`. Prevents world-readable snapshots while still allowing the host user to read snapshot content.

### `fix(snapshot): handle permission denied fallback` — `6087e83`

- `StoragePort` gains `PermissionDenied(String)` error variant and `finalize_snapshot(path)` method
- All three storage adapters (`apfs`, `btrfs`, `file`) implement `finalize_snapshot` (chmod read-only) and classify `cp`/`robocopy` stderr to `PermissionDenied` via `map_copy_error`
- `commit_repo_usecase`: three-arm fallback path — host snapshot → permission-denied fallback to `stream_snapshot` → any other error propagates
- Integration perf test `perf_snapshot_fallback.rs` added under CLI tests

### `fix(storage): improve error mapping and workspace repair signalling` — `b650a03`

- `storage-file`: `make_read_only` chmod errors now go through `map_copy_error` for consistent `PermissionDenied` classification
- `gfs_repository`: after populating a workspace from a snapshot, write a `.needs-repair` sentinel file to the workspace parent directory so the next container start can detect and repair ownership before booting

### `fix(snapshot): handle symlinks, probe retries, and cleanup races` — `7fa9b49`

**Symlink/hardlink handling in `stream_snapshot`:**
- Added `tar_link_target_is_safe(target)` validator: rejects absolute paths and `..` components
- Symlinks: read `link_name` from tar header, validate, call `std::os::unix::fs::symlink`; unsafe targets return `InvalidData` error
- Hardlinks: locate already-extracted source in dest tree, `fs::copy`; if source missing, emit `WARN` and skip
- Added `#[cfg(test)] mod tar_safety_tests` unit tests for the validator

**Probe retry loop in `checkout_repo_usecase`:**
- `assert_container_healthy` now retries each startup probe up to 15 times with 200 ms sleep between attempts (was single-shot)
- On exhaustion: returns `ComputeError::Internal` with the exit code, stdout, and stderr of the last failed attempt
- Added `MockComputeWithProbeFailures`, `MockProviderWithProbe`, `MockRegistryWithProbeProvider` test helpers
- Tests: `checkout_probe_succeeds_after_retries` (fails 3× then succeeds), `checkout_probe_fails_after_exhausting_retries`

**Background cleanup on timeout:**
- Replaced awaited `tokio::fs::remove_dir_all` in the snapshot-timeout error path with `tokio::spawn` (fire-and-forget), so the error is returned to the caller immediately instead of after 5–7 s of filesystem cleanup racing the orphaned tar writer

### `fix(commit): improve error handling and code readability` — `f351fe5`

- Collapsed two nested `if` blocks into `if X && let Err(e) = ...` let-chains (Rust 2024) to fix pre-existing `collapsible_if` clippy warnings at snapshot cleanup and unpause-on-error paths
- `storage-file` and `compute.rs` reformatted to pass `cargo fmt --check`

### `fix(compute): handle pause unsupported errors` — `09dcb62`

- Added `ComputeError::PauseUnsupported(String)` variant to the port error enum
- `error::classify()` in `compute-docker`: maps any 5xx Docker response whose message contains `cgroup`, `freezing`, `freeze`, `pause is not`, `cannot pause`, `not supported`, or `rootless` to `PauseUnsupported`
- `commit_repo_usecase`: three-arm match on `pause()` result — `Ok` sets RAII unpause guard, `PauseUnsupported` logs `WARN` and continues (crash-consistent snapshot, no unpause needed), any other `Err` propagates
- Tests: `commit_succeeds_when_pause_unsupported_cgroup_v1`, `commit_fails_on_genuine_pause_error`

### `fix(commit): differentiate PauseUnsupported in MockCompute` — `47a07a2`

- `MockCompute::pause()` now mirrors `classify()`: messages containing cgroup/freeze keywords return `PauseUnsupported`; others return `Internal`. Fixes test `commit_succeeds_when_pause_unsupported_cgroup_v1` which was failing because the mock returned the wrong variant.

---

## Test plan

- [x] `cargo test -p gfs-domain -p gfs-compute-docker` — 261 tests, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Stress test 33/33: baseline commit, permission-denied fallback, symlink error, probe retry, pause/unpause, read-only snapshot recovery, checkout round-trip
- [x] **Podman manual tests (Ubuntu 24.04, cgroup v2, Podman 4.9.3)**:
  - Baseline commit (host cp via `cp --reflink=auto -a`) — PASS
  - Podman `:U` ACLs make all data files host-readable; `stream_snapshot` not triggered — expected
  - Pause/unpause at 200 ms resolution: `running → paused → running` confirmed — PASS
- [x] Docker rootful pause/unpause via stress test — PASS
- [x] cgroup v1 pause failure covered by unit test with real error string from OCI runtime

## Windows notes

- `stream_snapshot` symlink creation is `#[cfg(unix)]` only; on Windows the branch returns `Unsupported` (symlinks were already skipped before this PR)
- `robocopy /COPY:DAT` is unchanged; `make_read_only` uses `attrib +R /S /D`
- No cgroup concept on Windows; `PauseUnsupported` is unreachable on Windows runtimes

## Breaking changes

None. `ComputeError::PauseUnsupported` and `StorageError::PermissionDenied` are new variants — any exhaustive match in downstream code will get a compile error pointing to the gap.

---