### PR TITLE
fix: correct opencode.json MCP configuration format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - fix: Windows snapshot/clone use `robocopy /E /COPY:DAT` instead of `/COPYALL` so commits do not require copying audit (SACL) information, which failed on Windows 11 ([issue #34](https://github.com/Guepard-Corp/gfs/issues/34))
+- fix: Correct opencode.json MCP configuration format to use command array with type: local for proper OpenCode integration
 
 ## [0.2.0] - 2026-03-23
 

--- a/crates/applications/website/install
+++ b/crates/applications/website/install
@@ -604,7 +604,7 @@ inject_ai_tools() {
 
     # GFS MCP config JSON fragment
     local gfs_mcp_json="\"gfs\": {\"command\": \"$INSTALL_DIR/gfs\", \"args\": [\"mcp\"]}"
-    local gfs_mcp_opencode_json="\"gfs\": {\"command\": \"$INSTALL_DIR/gfs\", \"args\": [\"mcp\"], \"enabled\": true}"
+    local gfs_mcp_opencode_json="\"gfs\": {\"type\": \"local\", \"command\": [\"$INSTALL_DIR/gfs\", \"mcp\"], \"enabled\": true}"
 
     for tool in "${detected[@]}"; do
         case "$tool" in
@@ -660,7 +660,7 @@ inject_ai_tools() {
                     if [[ ! -f "$opencode_config" ]]; then
                         echo "{\"mcp\": {$gfs_mcp_opencode_json}}" | jq . > "$opencode_config" 2>/dev/null || echo "{\"mcp\": {$gfs_mcp_opencode_json}}" > "$opencode_config"
                     else
-                        jq --arg cmd "$INSTALL_DIR/gfs" '.mcp.gfs = {"command": $cmd, "args": ["mcp"], "enabled": true}' "$opencode_config" > "$opencode_config.tmp" 2>/dev/null && mv "$opencode_config.tmp" "$opencode_config"
+                        jq --arg cmd "$INSTALL_DIR/gfs" '.mcp.gfs = {"type": "local", "command": [$cmd, "mcp"], "enabled": true}' "$opencode_config" > "$opencode_config.tmp" 2>/dev/null && mv "$opencode_config.tmp" "$opencode_config"
                     fi
                     mcp_configured+=("OpenCode")
                 else


### PR DESCRIPTION
# fix: correct opencode.json MCP configuration format

I ran into this issue when launching the latest 'opencode' and it refuses to launch and reports an MCP error. I changed it to command: [] and removed 'args' to fix it.

The OpenCode MCP configuration requires 'command' to be an array ['/path/to/binary', 'arg1'] with 'type: local', not separate 'command' and 'args' fields.
Changes:
1. Updated gfs_mcp_opencode_json variable to use array format
2. Added 'type: local' field as required by OpenCode schema
3. Updated jq command for modifying existing configs
This fixes the issue where OpenCode would not properly recognize the GFS MCP server configuration.
## Related Issue
<!-- 
Link the issue this PR addresses. If no issue exists, consider creating one first.
Closes #(issue number)
-->
No existing issue - discovered during testing of OpenCode integration.
## What
The GFS installer script was generating incorrect MCP configuration for OpenCode. OpenCode expects MCP server configurations to use a specific format where `command` is an array like `["/path/to/binary", "arg1"]` with an additional `type: "local"` field. The script was using separate `command` and `args` fields which OpenCode doesn't recognize, preventing proper MCP server integration.
## How
Updated the `install` script in two places:
1. Modified the `gfs_mcp_opencode_json` variable to use array format for command and add `type: "local"`
2. Updated the jq command for modifying existing OpenCode configs to match the new format
Key decisions:
- Only changed OpenCode configuration - other MCP clients (Cursor, Claude) continue to use separate `command` and `args` fields as they follow different specifications
- Maintained backward compatibility by updating existing configs correctly
- Preserved the `enabled: true` field required by OpenCode
## Review Guide
1. Start with `crates/applications/website/install` lines 607 and 663 - main logic changes
2. The changes are minimal (2 lines) and focused on the OpenCode-specific configuration
## Testing
- [x] Manual testing performed with simulated install scenarios
- [x] Verified bash variable interpolation works correctly
- [x] Tested JSON format generation produces correct OpenCode-compatible output
- [x] Verified jq command syntax is correct
- [x] Confirmed fallback case (no jq available) also works
## Documentation
- [x] Code comments added for complex logic (not needed - changes are straightforward)
- [ ] README or docs updated if needed (not needed - installation docs remain accurate)
- [ ] CHANGELOG.md updated (if applicable) (will update in separate PR)
## User Impact
- **Improvement**: OpenCode users will now have proper GFS MCP server integration
- **No breaking changes**: Existing OpenCode configs will be updated to correct format
- **No side effects**: Other MCP clients (Cursor, Claude) unaffected
- **End result**: Users installing GFS with OpenCode will get working MCP configuration
## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (bash -n install passes, no syntax errors)
- [x] Clippy passes (N/A - bash script)
- [x] Format check passes (N/A - bash script)
- [x] This PR can be safely reverted if needed