### PR TITLE
fix: use 127.0.0.1 instead of localhost for MySQL connections

### DIFF
--- a/crates/adapters/compute-docker/src/lib.rs
+++ b/crates/adapters/compute-docker/src/lib.rs
@@ -606,7 +606,7 @@ impl Compute for DockerCompute {
             .unwrap_or_default();
 
         Ok(InstanceConnectionInfo {
-            host: "localhost".to_string(),
+            host: "127.0.0.1".to_string(),
             port: host_port,
             env,
         })


### PR DESCRIPTION
On Linux, `mysql` client treats `localhost` as a Unix socket path (`/var/run/mysqld/mysqld.sock`) even when `-P <port>` is specified. Socket doesn't exist on host (only inside Docker) → `gfs query` fails for MySQL.

## Change

`compute-docker/src/lib.rs`: `"localhost"` → `"127.0.0.1"`. Forces TCP on all platforms.