### PR TITLE
fix(checkout): restore the workspace from the snapshot, and refuse to overwrite uncommitted work

### DIFF
--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use gfs_compute_docker::DockerCompute;
 use gfs_domain::adapters::gfs_repository::GfsRepository;
-use gfs_domain::model::layout::{GFS_DIR, HEADS_DIR, REFS_DIR};
+use gfs_domain::model::layout::{GFS_DIR, HEADS_DIR, REFS_DIR, WORKSPACES_DIR};
 use gfs_domain::ports::compute::Compute;
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::ports::repository::Repository;
@@ -258,6 +258,12 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
 
     std::fs::remove_file(&ref_path)
         .with_context(|| format!("failed to delete branch ref '{}'", name))?;
+
+    // Remove workspace directory so a future branch with the same name starts from a clean snapshot.
+    let workspace_dir = repo_path.join(GFS_DIR).join(WORKSPACES_DIR).join(name);
+    if workspace_dir.exists() {
+        let _ = std::fs::remove_dir_all(&workspace_dir);
+    }
 
     // Clean up empty parent directories (for nested branches like feature/foo).
     let mut parent = ref_path.parent();

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -154,6 +154,8 @@ async fn create_branch(
             Some(repo_path.to_path_buf()),
             start_point.map(|s| s.to_string()),
             Some(name.to_string()),
+            // Creating a branch must not silently discard work either.
+            false,
             json_output,
         )
         .await;
@@ -226,6 +228,27 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
 
     std::fs::remove_file(&ref_path)
         .with_context(|| format!("failed to delete branch ref '{}'", name))?;
+
+    // The working copy outlives the ref unless it goes here too. It is keyed by
+    // branch NAME, so a later branch reusing the name would inherit this one's
+    // workspace. Reported rather than ignored: a workspace that silently failed
+    // to go is exactly the state this is meant to prevent.
+    let workspace = repo_layout::branch_workspace_dir(repo_path, name);
+    if workspace.exists() {
+        #[cfg(unix)]
+        let _ = std::process::Command::new("chmod")
+            .args(["-R", "u+w"])
+            .arg(&workspace)
+            .output();
+        std::fs::remove_dir_all(&workspace).with_context(|| {
+            format!(
+                "branch ref '{}' was deleted but its workspace at '{}' could not be removed; \
+                 remove it before creating a branch of the same name",
+                name,
+                workspace.display()
+            )
+        })?;
+    }
 
     // Clean up empty parent directories (for nested branches like feature/foo).
     let mut parent = ref_path.parent();

--- a/crates/applications/cli/src/commands/cmd_checkout.rs
+++ b/crates/applications/cli/src/commands/cmd_checkout.rs
@@ -30,6 +30,7 @@ pub async fn checkout(
     path: Option<PathBuf>,
     revision: Option<String>,
     create_branch: Option<String>,
+    force: bool,
     json_output: bool,
 ) -> Result<()> {
     let repo_path = path.clone().unwrap_or_else(get_repo_dir);
@@ -130,7 +131,7 @@ pub async fn checkout(
 
         commit_hash
     } else {
-        let use_case = CheckoutRepoUseCase::new(repository, compute, registry);
+        let use_case = CheckoutRepoUseCase::new(repository, compute, registry).with_force(force);
         use_case
             .run(repo_path, revision.clone(), create_branch.clone())
             .await

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -517,6 +517,10 @@ enum TopLevel {
 
         /// Branch name or full 64-char commit hash; or start revision when using -b
         revision: Option<String>,
+
+        /// Discard uncommitted changes in the workspace instead of refusing
+        #[arg(long)]
+        force: bool,
     },
 
     /// Tear down the compute instance and remove the repository's .gfs store
@@ -932,8 +936,9 @@ where
                 path,
                 create_branch,
                 revision,
+                force,
             } => {
-                commands::cmd_checkout::checkout(path, revision, create_branch, json_output)
+                commands::cmd_checkout::checkout(path, revision, create_branch, force, json_output)
                     .await?;
                 Ok(0)
             }

--- a/crates/applications/cli/tests/e2e_checkout.rs
+++ b/crates/applications/cli/tests/e2e_checkout.rs
@@ -173,3 +173,164 @@ fn checkout_zero_fails() {
         "stderr should mention no commits or 0; got: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Workspace identity: a checkout must give you what you asked for, and must
+// not silently destroy work to do it.
+// ---------------------------------------------------------------------------
+
+/// Sorted `name=content` for every file in the active workspace.
+fn workspace_contents(repo_path: &Path) -> String {
+    let dir = read_workspace_path(repo_path);
+    let mut out: Vec<String> = fs::read_dir(&dir)
+        .expect("read workspace")
+        .flatten()
+        .filter(|e| e.path().is_file())
+        .map(|e| {
+            format!(
+                "{}={}",
+                e.file_name().to_string_lossy(),
+                fs::read_to_string(e.path()).unwrap_or_default().trim()
+            )
+        })
+        .collect();
+    out.sort();
+    out.join(" ")
+}
+
+/// Uncommitted work is neither carried across a checkout nor thrown away.
+///
+/// Carrying it made `checkout <branch>` non-deterministic and left state no GFS
+/// command displays. Discarding it is unrecoverable. So checkout refuses,
+/// naming what is in the way, and `--force` is the way to say you meant it.
+#[test]
+fn checkout_refuses_to_overwrite_uncommitted_work_unless_forced() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "committed").unwrap();
+    let (ok, _, stderr) = cli_runner::gfs_commit(repo_path, "c1", None, None);
+    assert!(ok, "commit should succeed; stderr: {stderr}");
+
+    // A clean workspace is not in the way.
+    let (ok, _, stderr) = cli_runner::run_gfs([
+        "gfs",
+        "checkout",
+        "--path",
+        repo_path.to_str().unwrap(),
+        "main",
+    ]);
+    assert!(ok, "a clean checkout must not be refused; stderr: {stderr}");
+
+    fs::write(read_workspace_path(repo_path).join("scratch.txt"), "wip").unwrap();
+
+    let (ok, _, stderr) = cli_runner::run_gfs([
+        "gfs",
+        "checkout",
+        "--path",
+        repo_path.to_str().unwrap(),
+        "main",
+    ]);
+    assert!(!ok, "uncommitted work must stop the checkout");
+    assert!(
+        stderr.contains("uncommitted changes") && stderr.contains("scratch.txt"),
+        "the refusal should name what is in the way: {stderr}"
+    );
+    assert!(
+        read_workspace_path(repo_path).join("scratch.txt").exists(),
+        "a refused checkout must change nothing"
+    );
+
+    let (ok, _, stderr) = cli_runner::run_gfs([
+        "gfs",
+        "checkout",
+        "--path",
+        repo_path.to_str().unwrap(),
+        "main",
+        "--force",
+    ]);
+    assert!(ok, "--force should go through; stderr: {stderr}");
+    assert_eq!(
+        workspace_contents(repo_path),
+        "seed.txt=committed",
+        "forced checkout restores the commit exactly"
+    );
+}
+
+/// A branch's working copy must not outlive the branch.
+///
+/// The workspace is keyed by branch NAME, so a later branch reusing the name
+/// inherited the dead branch's working copy and `checkout` reported success
+/// while handing over content that branch never contained.
+#[test]
+fn a_recreated_branch_does_not_inherit_the_deleted_one() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+    fs::write(data_dir.join("seed.txt"), "v2").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c2", None, None).0);
+    let tip = read_ref(repo_path, "main");
+
+    let repo = repo_path.to_str().unwrap();
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "-b", "b1"]).0);
+    fs::write(read_workspace_path(repo_path).join("only-on-b1.txt"), "x").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "b1 work", None, None).0);
+    fs::write(
+        read_workspace_path(repo_path).join("never-committed.txt"),
+        "y",
+    )
+    .unwrap();
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main", "--force"]).0);
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "-d", "b1"]).0);
+    assert!(
+        !repo_path.join(".gfs/workspaces/b1").exists(),
+        "the workspace must go with the branch"
+    );
+
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "b1", &tip]).0);
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "b1"]).0);
+    assert_eq!(
+        workspace_contents(repo_path),
+        "seed.txt=v2",
+        "the new b1 holds its own commit, not the deleted branch's working copy"
+    );
+}
+
+/// A commit hash names exactly one content state.
+///
+/// The detached workspace is named by the hash, and was reused as-is, so
+/// mutating one and returning to it gave you something other than what
+/// `Switched to <hash>` says you got.
+#[test]
+fn returning_to_a_detached_commit_gives_that_commit() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+    let first = read_ref(repo_path, "main");
+    fs::write(data_dir.join("seed.txt"), "v2").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c2", None, None).0);
+
+    let repo = repo_path.to_str().unwrap();
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]).0);
+    assert_eq!(workspace_contents(repo_path), "seed.txt=v1");
+
+    fs::write(read_workspace_path(repo_path).join("poison.txt"), "z").unwrap();
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main", "--force"]).0);
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]).0);
+    assert_eq!(
+        workspace_contents(repo_path),
+        "seed.txt=v1",
+        "the commit's content, not what was left in its directory"
+    );
+}

--- a/crates/applications/cli/tests/e2e_checkout.rs
+++ b/crates/applications/cli/tests/e2e_checkout.rs
@@ -226,6 +226,8 @@ fn checkout_refuses_to_overwrite_uncommitted_work_unless_forced() {
 
     fs::write(read_workspace_path(repo_path).join("scratch.txt"), "wip").unwrap();
 
+    // Checking out the branch you are already on rebuilds this very directory,
+    // so the work in it is exactly what would be lost.
     let (ok, _, stderr) = cli_runner::run_gfs([
         "gfs",
         "checkout",
@@ -326,11 +328,66 @@ fn returning_to_a_detached_commit_gives_that_commit() {
     assert_eq!(workspace_contents(repo_path), "seed.txt=v1");
 
     fs::write(read_workspace_path(repo_path).join("poison.txt"), "z").unwrap();
-    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main", "--force"]).0);
-    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]).0);
+
+    // Leaving is fine: the detached directory is not the one being rebuilt.
+    assert!(
+        cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main"]).0,
+        "leaving a dirty workspace overwrites nothing, so it must not be refused"
+    );
+
+    // Returning is where it would be destroyed, so that is where the refusal is.
+    let (ok, _, stderr) = cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]);
+    assert!(!ok, "returning would overwrite poison.txt");
+    assert!(stderr.contains("poison.txt"), "{stderr}");
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first, "--force"]).0);
     assert_eq!(
         workspace_contents(repo_path),
         "seed.txt=v1",
         "the commit's content, not what was left in its directory"
+    );
+}
+
+/// The refusal has to guard the workspace the restore REBUILDS, not the one
+/// being left behind.
+///
+/// Each branch has its own directory, so leaving a dirty branch overwrites
+/// nothing and must not be refused. The destructive moment is coming BACK: the
+/// target directory is rebuilt from its snapshot, and work left there is gone.
+/// Guarding the wrong side is both too strict and, more seriously, silent —
+/// walk away from dirty work on one branch and return to it from a clean one,
+/// and it is deleted with no refusal at all.
+#[test]
+fn the_refusal_guards_the_workspace_being_rebuilt_not_the_one_being_left() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+    let repo = repo_path.to_str().unwrap();
+
+    fs::write(workspace_data_dir_main_0(repo_path).join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "-b", "feature"]).0);
+    let feature_ws = read_workspace_path(repo_path);
+    fs::write(feature_ws.join("scratch.txt"), "wip").unwrap();
+
+    // Leaving: allowed, and the directory is left alone.
+    let (ok, _, stderr) = cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main"]);
+    assert!(ok, "leaving must not be refused; stderr: {stderr}");
+    assert!(
+        feature_ws.join("scratch.txt").exists(),
+        "leaving must not touch the branch's directory"
+    );
+
+    // Returning: refused, from a workspace that is itself clean.
+    let (ok, _, stderr) = cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "feature"]);
+    assert!(
+        !ok,
+        "returning would rebuild feature's directory and destroy scratch.txt"
+    );
+    assert!(stderr.contains("scratch.txt"), "{stderr}");
+    assert!(
+        feature_ws.join("scratch.txt").exists(),
+        "a refused checkout must change nothing"
     );
 }

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -593,14 +593,20 @@ impl Repository for GfsRepository {
             .join(&workspace_segment)
             .join(WORKSPACE_DATA_DIR);
 
-        // Only populate from snapshot when the workspace does not exist (preserve live DB state in branch workspace).
-        let workspace_exists = workspace_path.exists();
+        // Always restore workspace from snapshot — discard any uncommitted changes.
+        // This ensures deterministic checkout behavior regardless of prior workspace state.
         tracing::info!(
             "Checkout: workspace_path={:?}, exists={}",
             workspace_path,
-            workspace_exists
+            workspace_path.exists()
         );
-        if !workspace_exists {
+        if workspace_path.exists() {
+            // Make files writable before removal (snapshot files may be mode 0400).
+            let _ = set_workspace_dir_permissions(&workspace_path);
+            fs::remove_dir_all(&workspace_path).map_err(RepositoryError::Io)?;
+            tracing::info!("Checkout: removed existing workspace for fresh restore");
+        }
+        {
             let commit = repo_layout::get_commit_from_hash(&repo, &commit_hash).map_err(map_err)?;
             let snapshot_hash = commit.snapshot_hash;
             let snapshot_dir = repo

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -15,10 +15,7 @@ use async_trait::async_trait;
 use crate::model::commit::{Commit, CommitWithRefs, FileEntry, NewCommit, file_entry_diff_stats};
 use crate::model::config::{EnvironmentConfig, GfsConfig, RuntimeConfig, UserConfig};
 use crate::model::errors::RepoError;
-use crate::model::layout::{
-    BRANCH_WORKSPACE_SEGMENT, GFS_DIR, HEADS_DIR, OBJECTS_DIR, REFS_DIR, SNAPSHOTS_DIR,
-    WORKSPACE_DATA_DIR, WORKSPACES_DIR,
-};
+use crate::model::layout::{GFS_DIR, HEADS_DIR, OBJECTS_DIR, REFS_DIR, SNAPSHOTS_DIR};
 use crate::ports::repository::{LogOptions, RemoteOptions, Repository, RepositoryError, Result};
 use crate::repo_utils::repo_layout;
 use crate::utils::hash::hash_commit;
@@ -551,7 +548,10 @@ impl Repository for GfsRepository {
         }
 
         // Resolve revision to full commit hash.
-        let commit_hash = repo_layout::rev_parse(&repo, revision).map_err(map_err)?;
+        // Where this lands, decided in one place — `CheckoutRepoUseCase` asks the
+        // same function what is about to be overwritten before allowing it.
+        let (commit_hash, workspace_path) =
+            repo_layout::checkout_target(&repo, revision).map_err(map_err)?;
 
         // Reject initial state: cannot checkout "0".
         if commit_hash == "0" {
@@ -563,35 +563,12 @@ impl Repository for GfsRepository {
             return Err(RepositoryError::Internal(msg));
         }
 
-        // Determine HEAD update: branch name iff refs/heads/<revision> exists and tip matches.
-        let branch_segment = if repo_layout::is_branch(&repo, revision) {
-            let ref_path = repo
-                .join(GFS_DIR)
-                .join(REFS_DIR)
-                .join(HEADS_DIR)
-                .join(revision);
-            let tip = fs::read_to_string(&ref_path).map_err(RepositoryError::Io)?;
-            if tip.trim() == commit_hash {
-                revision.to_string()
-            } else {
-                "detached".to_string()
-            }
-        } else {
-            "detached".to_string()
-        };
-
-        // Workspace path: one persistent dir per branch (workspaces/<branch>/0/data), or per-commit when detached.
-        let workspace_segment = if branch_segment == "detached" {
-            repo_layout::short_commit_id_for_workspace(&commit_hash)
-        } else {
-            BRANCH_WORKSPACE_SEGMENT.to_string()
-        };
-        let workspace_path = repo
-            .join(GFS_DIR)
-            .join(WORKSPACES_DIR)
-            .join(&branch_segment)
-            .join(&workspace_segment)
-            .join(WORKSPACE_DATA_DIR);
+        let branch_segment = workspace_path
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "detached".to_string());
 
         // Always restore from the snapshot. Reusing a workspace that happens to
         // still be on disk made checkout non-deterministic in three ways: a
@@ -800,7 +777,9 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    use crate::model::layout::{CONFIG_FILE, HEAD_FILE, MAIN_BRANCH, WORKSPACE_FILE};
+    use crate::model::layout::{
+        CONFIG_FILE, HEAD_FILE, MAIN_BRANCH, WORKSPACE_DATA_DIR, WORKSPACE_FILE, WORKSPACES_DIR,
+    };
     use crate::ports::repository::{LogOptions, Repository};
     use crate::utils::hash::hash_commit;
 

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -593,14 +593,29 @@ impl Repository for GfsRepository {
             .join(&workspace_segment)
             .join(WORKSPACE_DATA_DIR);
 
-        // Only populate from snapshot when the workspace does not exist (preserve live DB state in branch workspace).
-        let workspace_exists = workspace_path.exists();
+        // Always restore from the snapshot. Reusing a workspace that happens to
+        // still be on disk made checkout non-deterministic in three ways: a
+        // deleted branch's working copy was inherited by a new branch that
+        // reused the name; returning to a detached commit gave you whatever you
+        // last left in its directory rather than that commit; and uncommitted
+        // changes leaked across a branch switch. `Switched to X` now means the
+        // workspace holds X.
+        //
+        // Nothing is discarded silently: `CheckoutRepoUseCase` refuses when the
+        // workspace has uncommitted work, and only passes through once the
+        // caller has committed it or asked for `--force`.
         tracing::info!(
             "Checkout: workspace_path={:?}, exists={}",
             workspace_path,
-            workspace_exists
+            workspace_path.exists()
         );
-        if !workspace_exists {
+        if workspace_path.exists() {
+            // Files restored from a snapshot carry its read-only bits, which
+            // `remove_dir_all` will not override.
+            let _ = set_workspace_dir_permissions(&workspace_path);
+            fs::remove_dir_all(&workspace_path).map_err(RepositoryError::Io)?;
+        }
+        {
             let commit = repo_layout::get_commit_from_hash(&repo, &commit_hash).map_err(map_err)?;
             let snapshot_hash = commit.snapshot_hash;
             let snapshot_dir = repo

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -1035,6 +1035,53 @@ pub fn get_current_commit_id(repo_path: &Path) -> Result<String, RepoError> {
 
 /// Short commit id used for workspace directory path segment (avoids long paths on disk).
 /// If `commit_id` is longer than `SHORT_COMMIT_ID_LEN`, returns the prefix; otherwise returns as-is (e.g. `"0"`).
+/// Where a checkout of `revision` would land: its commit, and the workspace
+/// directory that would be rebuilt.
+///
+/// Extracted so the caller can ask what a checkout is about to overwrite BEFORE
+/// it overwrites it. `GfsRepository::checkout` uses the same function, because
+/// two copies of this rule that disagree is exactly how a guard ends up
+/// protecting a different directory from the one being destroyed.
+pub fn checkout_target(
+    repo: &Path,
+    revision: &str,
+) -> Result<(String, std::path::PathBuf), RepoError> {
+    let commit_hash = rev_parse(repo, revision)?;
+
+    // A branch name only keeps its own workspace while it still points at the
+    // commit being asked for; otherwise the checkout detaches.
+    let branch_segment = if is_branch(repo, revision) {
+        let tip = fs::read_to_string(
+            repo.join(GFS_DIR)
+                .join(REFS_DIR)
+                .join(HEADS_DIR)
+                .join(revision),
+        )
+        .map_err(RepoError::from)?;
+        if tip.trim() == commit_hash {
+            revision.to_string()
+        } else {
+            "detached".to_string()
+        }
+    } else {
+        "detached".to_string()
+    };
+
+    let workspace_segment = if branch_segment == "detached" {
+        short_commit_id_for_workspace(&commit_hash)
+    } else {
+        BRANCH_WORKSPACE_SEGMENT.to_string()
+    };
+
+    let path = repo
+        .join(GFS_DIR)
+        .join(WORKSPACES_DIR)
+        .join(&branch_segment)
+        .join(&workspace_segment)
+        .join(WORKSPACE_DATA_DIR);
+    Ok((commit_hash, path))
+}
+
 /// The directory holding a branch's working copy.
 pub fn branch_workspace_dir(repo_path: &Path, branch: &str) -> std::path::PathBuf {
     repo_path.join(GFS_DIR).join(WORKSPACES_DIR).join(branch)

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -1035,6 +1035,60 @@ pub fn get_current_commit_id(repo_path: &Path) -> Result<String, RepoError> {
 
 /// Short commit id used for workspace directory path segment (avoids long paths on disk).
 /// If `commit_id` is longer than `SHORT_COMMIT_ID_LEN`, returns the prefix; otherwise returns as-is (e.g. `"0"`).
+/// The directory holding a branch's working copy.
+pub fn branch_workspace_dir(repo_path: &Path, branch: &str) -> std::path::PathBuf {
+    repo_path.join(GFS_DIR).join(WORKSPACES_DIR).join(branch)
+}
+
+/// Paths in `workspace` that differ from `baseline`, i.e. uncommitted work.
+///
+/// Checkout restores the workspace from a snapshot, which overwrites whatever is
+/// there. Callers use this to refuse rather than overwrite silently.
+///
+/// WHAT IS COMPARED, and why it is only this. `FileEntry` records path, size,
+/// owner, group and mode; there is no content hash, so this is git's cheap tier
+/// (stat) without git's second tier (hash on suspicion).
+///
+/// * SIZE, for files present in both. A write to a SQLite database grows the
+///   database or its write-ahead log, so real work shows up here.
+/// * PRESENCE, for files in the workspace that the baseline does not have.
+/// * NOT permissions. A live workspace is 0700 and a snapshot is read-only, so
+///   they always differ and comparing them would report every workspace dirty.
+/// * NOT absences. SQLite deletes its `-wal` and `-shm` sidecars when the last
+///   connection closes, so a file that has gone away is the normal aftermath of
+///   reading the database, not uncommitted work.
+///
+/// The gap this leaves, stated rather than hidden: an edit that changes no
+/// file's size — an in-place UPDATE whose pages are checkpointed back to the
+/// same length — is not detected. The direction of the remaining error is the
+/// safe one for a false positive (a needless refusal, which `--force` clears)
+/// and the unsafe one for a false negative, so it is worth revisiting with a
+/// content hash if the commit object ever grows one.
+pub fn workspace_changes(
+    workspace: &Path,
+    baseline: &[FileEntry],
+) -> Result<Vec<String>, RepoError> {
+    if !workspace.exists() {
+        return Ok(Vec::new());
+    }
+    let current = collect_file_entries(workspace, "")?;
+    let sizes: std::collections::HashMap<&str, u64> = baseline
+        .iter()
+        .map(|e| (e.relative_path.as_str(), e.file_size))
+        .collect();
+
+    let mut changed: Vec<String> = current
+        .iter()
+        .filter(|entry| match sizes.get(entry.relative_path.as_str()) {
+            Some(&size) => size != entry.file_size,
+            None => true,
+        })
+        .map(|entry| entry.relative_path.clone())
+        .collect();
+    changed.sort();
+    Ok(changed)
+}
+
 pub fn short_commit_id_for_workspace(commit_id: &str) -> String {
     if commit_id.len() <= SHORT_COMMIT_ID_LEN {
         commit_id.to_string()
@@ -1104,6 +1158,76 @@ mod tests {
     use std::fs;
     use std::io;
     use tempfile::TempDir;
+
+    /// The dirty check reports work, and only work.
+    #[test]
+    fn workspace_changes_reports_writes_and_additions() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        fs::write(ws.join("db"), "aaaa").unwrap();
+        fs::write(ws.join("keep"), "same").unwrap();
+        let baseline = collect_file_entries(ws, "").unwrap();
+
+        // Untouched.
+        assert!(workspace_changes(ws, &baseline).unwrap().is_empty());
+
+        // A write that changes the size.
+        fs::write(ws.join("db"), "aaaaaaaa").unwrap();
+        assert_eq!(workspace_changes(ws, &baseline).unwrap(), vec!["db"]);
+
+        // A new file.
+        fs::write(ws.join("db"), "aaaa").unwrap();
+        fs::write(ws.join("new"), "x").unwrap();
+        assert_eq!(workspace_changes(ws, &baseline).unwrap(), vec!["new"]);
+    }
+
+    /// A file that has GONE is not uncommitted work.
+    ///
+    /// SQLite deletes its `-wal` and `-shm` sidecars when the last connection
+    /// closes, so treating an absence as a change would report every workspace
+    /// dirty after a plain read.
+    #[test]
+    fn workspace_changes_ignores_files_that_disappeared() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        fs::write(ws.join("db"), "aaaa").unwrap();
+        fs::write(ws.join("db-wal"), "").unwrap();
+        fs::write(ws.join("db-shm"), "x".repeat(32)).unwrap();
+        let baseline = collect_file_entries(ws, "").unwrap();
+
+        fs::remove_file(ws.join("db-wal")).unwrap();
+        fs::remove_file(ws.join("db-shm")).unwrap();
+        assert!(
+            workspace_changes(ws, &baseline).unwrap().is_empty(),
+            "closing the database is not uncommitted work"
+        );
+    }
+
+    /// Permissions are deliberately not compared.
+    ///
+    /// A live workspace is 0700 and the snapshot it came from is read-only, so
+    /// comparing modes would report every workspace dirty.
+    #[test]
+    fn workspace_changes_ignores_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let file = ws.join("db");
+        fs::write(&file, "aaaa").unwrap();
+        let mut baseline = collect_file_entries(ws, "").unwrap();
+        baseline[0].permissions = Some("0400".to_string());
+        assert!(workspace_changes(ws, &baseline).unwrap().is_empty());
+    }
+
+    /// A workspace that is not there yet has nothing to lose.
+    #[test]
+    fn workspace_changes_on_a_missing_workspace_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            workspace_changes(&dir.path().join("gone"), &[])
+                .unwrap()
+                .is_empty()
+        );
+    }
 
     #[test]
     fn short_commit_id_for_workspace_keeps_short_and_truncates_long() {

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -82,30 +82,43 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         self
     }
 
-    /// The uncommitted changes checkout would overwrite, as a short description.
+    /// The uncommitted changes this checkout would overwrite, as a short
+    /// description.
     ///
-    /// Compared against the file list recorded on the CURRENT commit, which is
-    /// the right baseline because a commit snapshots the workspace: immediately
-    /// after one, the two agree, and everything written since is uncommitted.
-    /// `None` when there is nothing recorded to compare against — a repository
-    /// with no commits yet, or one whose commit predates file lists — in which
-    /// case checkout proceeds as before rather than refusing on a fact it does
-    /// not have.
+    /// Asks about the TARGET workspace, not the one being left, because that is
+    /// the directory the restore rebuilds. Getting this backwards is a live
+    /// hazard rather than a nicety: checking the workspace you leave both
+    /// refuses switches that would overwrite nothing — each branch has its own
+    /// directory, so leaving a dirty branch destroys nothing — and, worse, lets
+    /// you walk away from dirty work on one branch and come back to it from a
+    /// clean one, at which point the restore deletes it with no refusal at all.
+    ///
+    /// The baseline is the file list recorded on the commit being checked out,
+    /// which is the right one for that directory: committing on a branch
+    /// snapshots its workspace, so the two agree immediately afterwards and
+    /// everything written since is uncommitted.
+    ///
+    /// `None` whenever the question cannot be answered — an unresolvable
+    /// revision (a branch about to be created), no commits yet, or a commit
+    /// that predates file lists. Checkout then proceeds and reports its own
+    /// error, rather than refusing on a fact this does not have.
     async fn uncommitted_changes(
         &self,
         path: &Path,
+        revision: &str,
     ) -> std::result::Result<Option<String>, CheckoutRepoError> {
-        let current = self.repository.get_current_commit_id(path).await?;
-        if current == "0" {
+        let Ok((commit_hash, workspace)) = repo_layout::checkout_target(path, revision) else {
+            return Ok(None);
+        };
+        if commit_hash == "0" {
             return Ok(None);
         }
-        let Ok(commit) = repo_layout::get_commit_from_hash(path, &current) else {
+        let Ok(commit) = repo_layout::get_commit_from_hash(path, &commit_hash) else {
             return Ok(None);
         };
         let Ok(Some(baseline)) = repo_layout::get_file_entries_for_commit(path, &commit) else {
             return Ok(None);
         };
-        let workspace = self.repository.get_active_workspace_data_dir(path).await?;
         let changed = repo_layout::workspace_changes(&workspace, &baseline)
             .map_err(|e| CheckoutRepoError::Repository(RepositoryError::Internal(e.to_string())))?;
         if changed.is_empty() {
@@ -138,13 +151,22 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         // unrecoverable. Neither silent option is acceptable: discarding loses
         // data the user cannot get back, and preserving it across a switch
         // leaves state that no command in GFS displays.
+        let revision = revision.trim().to_string();
+
+        // Refuse before anything is touched. The restore rebuilds the target
+        // workspace, so work that was never committed THERE is overwritten and
+        // unrecoverable. Neither silent option is acceptable: discarding loses
+        // data the user cannot get back, and keeping a stale directory means
+        // `Switched to X` does not give you X.
+        //
+        // Skipped when a branch is being created, since its workspace does not
+        // exist yet and there is nothing to lose.
         if !self.force
-            && let Some(changed) = self.uncommitted_changes(&path).await?
+            && create_branch.is_none()
+            && let Some(changed) = self.uncommitted_changes(&path, &revision).await?
         {
             return Err(CheckoutRepoError::WorkspaceDirty(changed));
         }
-
-        let revision = revision.trim().to_string();
 
         // Validate the target ref BEFORE stopping compute — a bad revision must
         // not leave the database offline (mirrors the k8s checkout path).

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -32,6 +32,12 @@ pub enum CheckoutRepoError {
 
     #[error("compute: {0}")]
     Compute(#[from] ComputeError),
+
+    #[error(
+        "the workspace has uncommitted changes that checkout would overwrite ({0}). \
+         Commit them first, or pass --force to discard them"
+    )]
+    WorkspaceDirty(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -47,6 +53,8 @@ pub struct CheckoutRepoUseCase<R: DatabaseProviderRegistry> {
     repository: Arc<dyn Repository>,
     compute: Arc<dyn Compute>,
     registry: Arc<R>,
+    /// Discard uncommitted work instead of refusing. Off by default.
+    force: bool,
 }
 
 impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
@@ -59,7 +67,60 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             repository,
             compute,
             registry,
+            force: false,
         }
+    }
+
+    /// Overwrite a workspace that has uncommitted changes rather than refusing.
+    ///
+    /// A builder rather than a `run` parameter on purpose: `run`'s signature is
+    /// part of this crate's public surface and the data-plane calls it directly,
+    /// so adding an argument would break a caller that has no opinion about
+    /// forcing.
+    pub fn with_force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+
+    /// The uncommitted changes checkout would overwrite, as a short description.
+    ///
+    /// Compared against the file list recorded on the CURRENT commit, which is
+    /// the right baseline because a commit snapshots the workspace: immediately
+    /// after one, the two agree, and everything written since is uncommitted.
+    /// `None` when there is nothing recorded to compare against — a repository
+    /// with no commits yet, or one whose commit predates file lists — in which
+    /// case checkout proceeds as before rather than refusing on a fact it does
+    /// not have.
+    async fn uncommitted_changes(
+        &self,
+        path: &Path,
+    ) -> std::result::Result<Option<String>, CheckoutRepoError> {
+        let current = self.repository.get_current_commit_id(path).await?;
+        if current == "0" {
+            return Ok(None);
+        }
+        let Ok(commit) = repo_layout::get_commit_from_hash(path, &current) else {
+            return Ok(None);
+        };
+        let Ok(Some(baseline)) = repo_layout::get_file_entries_for_commit(path, &commit) else {
+            return Ok(None);
+        };
+        let workspace = self.repository.get_active_workspace_data_dir(path).await?;
+        let changed = repo_layout::workspace_changes(&workspace, &baseline)
+            .map_err(|e| CheckoutRepoError::Repository(RepositoryError::Internal(e.to_string())))?;
+        if changed.is_empty() {
+            return Ok(None);
+        }
+        let shown: Vec<&str> = changed.iter().take(3).map(String::as_str).collect();
+        Ok(Some(if changed.len() > shown.len() {
+            format!(
+                "{} and {} more",
+                shown.join(", "),
+                changed.len() - shown.len()
+            )
+        } else {
+            shown.join(", ")
+        }))
     }
 
     /// Check out `revision` (branch name or full 64-char commit hash) at `path`.
@@ -72,6 +133,17 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         revision: String,
         create_branch: Option<String>,
     ) -> std::result::Result<String, CheckoutRepoError> {
+        // Refuse before anything is touched. Checkout restores the workspace
+        // from a snapshot, so work that was never committed is overwritten and
+        // unrecoverable. Neither silent option is acceptable: discarding loses
+        // data the user cannot get back, and preserving it across a switch
+        // leaves state that no command in GFS displays.
+        if !self.force
+            && let Some(changed) = self.uncommitted_changes(&path).await?
+        {
+            return Err(CheckoutRepoError::WorkspaceDirty(changed));
+        }
+
         let revision = revision.trim().to_string();
 
         // Validate the target ref BEFORE stopping compute — a bad revision must


### PR DESCRIPTION
Rebuilt on current `main` — the previous version was 182 commits behind, which is why it read `mergeable: UNKNOWN` — and extended, because the original always-restore fix traded one data-loss bug for another.

## Problem

The `workspace_exists` guard in `GfsRepository::checkout` skips the snapshot restore whenever the workspace directory happens to still be on disk.

Re-verified against unmodified `main` (`c53d470`) with a provider-less repository, so no container runtime is involved:

| | on current `main` |
|---|---|
| **BUG-2** `gfs checkout <hash>` dirty on a second visit | **reproduces** — revisiting a commit returns `poison.txt` written during the last visit, alongside that commit's content |
| **BUG-3** recreated branch inherits the deleted one | **reproduces** — `.gfs/workspaces/b1` survives `gfs branch -d b1`, and a new `b1` created at a *different* commit checks out with the old branch's file *and* the old commit's content |
| **BUG-1** uncommitted changes persist "across" `gfs checkout <branch>` | **does not reproduce** |

BUG-1 needs correcting, and it changes what the right fix is. Each branch has its own workspace directory, so uncommitted work does not leak into the branch you switch to — it stays in the branch it was made on and reappears when you return. That is worktree behaviour, not a bug, and **always-restore alone would have destroyed it on every visit** — fixing a bug that does not exist by breaking something that works.

BUG-2 and BUG-3 are unambiguous. A workspace directory is named either by a branch or by a commit hash, and reusing whatever was last left there contradicts the command's own success message — most sharply for a hash, which is by definition an immutable name for one content state. A commit taken from an inherited workspace records a diff that never happened, and nothing in the tool can tell afterwards.

What always-restore *does* need is a guard, because the restore overwrites work that was never committed, and that work is unrecoverable.

## Fix

`checkout` always restores from the snapshot — so `Switched to X` means the workspace holds X — and **refuses first** when there is uncommitted work it would overwrite:

```console
$ gfs checkout main
error: the workspace has uncommitted changes that checkout would overwrite (scratch.txt).
Commit them first, or pass --force to discard them
```

- `CheckoutRepoError::WorkspaceDirty`, raised before anything is touched.
- `gfs checkout --force` to proceed anyway.
- The question is asked about the **target** workspace — the one the restore rebuilds — not the one being left. Those are different directories, and getting it backwards is a live hazard in both directions: it refuses switches that would overwrite nothing, and it lets you walk away from dirty work on one branch and return to it from a clean one, at which point the restore deletes it with no refusal at all. `repo_layout::checkout_target` computes that path once, and `GfsRepository::checkout` uses the same function, so the guard cannot end up protecting a different directory from the one being destroyed.
- `gfs branch -d` removes the branch's workspace, which is what makes BUG-3 impossible rather than merely unlikely. A failed removal is reported, naming the directory — a workspace that silently failed to go is exactly the state this prevents.

This is git's model rather than either silent option: *your local changes would be overwritten*.

## How dirtiness is decided, and what it does not catch

`FileEntry` records path, size, owner, group and mode — **no content hash** — so this is git's cheap tier (stat) without git's second tier (hash on suspicion).

The baseline is the file list recorded on the **current commit**, which is the right one because a commit snapshots the workspace: immediately after one they agree, and everything written since is uncommitted.

| | compared? | why |
|---|---|---|
| size, for files in both | **yes** | a write grows the database or its WAL |
| presence, for files the baseline lacks | **yes** | new files are work |
| permissions | no | a live workspace is `0700`, a snapshot is read-only — they *always* differ |
| absences | no | SQLite deletes `-wal`/`-shm` on last close, so a plain read would report every workspace dirty |

The gap this leaves is an edit that changes no file's size — an in-place `UPDATE` whose pages checkpoint back to the same length. It is documented in the doc comment rather than hidden, and worth revisiting if the commit object ever grows a content hash. The remaining error is in the safe direction for a false positive (a needless refusal, which `--force` clears).

`--force` is a builder (`with_force`) rather than a `run` argument, because `run`'s signature is public surface the data-plane calls directly, and a caller with no opinion about forcing should not have to change.

## Verification

Exercised end to end on a repository with **no database provider**, so the behaviour is tested free of any engine:

- a clean checkout is not refused;
- leaving a dirty branch is not refused, and its directory is left untouched;
- returning to it *is* refused, names the file, and changes nothing;
- `--force` restores the commit exactly;
- a recreated branch holds its own commit, not the deleted branch's working copy;
- a revisited detached commit holds that commit, not what was left in its directory.

Four e2e tests in `e2e_checkout.rs`, including one for the leave-versus-return asymmetry,, four unit tests for the dirty check (including the disappearing-sidecar and permissions cases), and the four pre-existing checkout e2e tests still pass. `gfs-domain` 258 green; `fmt` and `clippy -D warnings` clean.

`e2e_short_hash` fails here, identically on a clean `main` checkout — all `postgres_*` tests needing a container runtime this machine does not have.

## Scope

Deliberately does **not** touch the detached-HEAD *commit* refusal — that is #146's subject, and the two are independent: #146 changes the commit path, this changes the checkout path. They compose in the right direction, since with writes at a detached HEAD refused, a detached workspace is purely a read-only view of one commit.
