### PR TITLE
feat: SQLite provider support (superseded by #148)

### DIFF
--- a/crates/adapters/compute-docker/src/containers/mod.rs
+++ b/crates/adapters/compute-docker/src/containers/mod.rs
@@ -4,14 +4,16 @@
 pub mod clickhouse;
 pub mod mysql;
 pub mod postgresql;
+pub mod sqlite;
 
 use gfs_domain::ports::database_provider::{DatabaseProviderRegistry, Result};
 
-/// Registers all built-in database providers (e.g. postgres, mysql, clickhouse) into `registry`.
+/// Registers all built-in database providers (e.g. postgres, mysql, clickhouse, sqlite) into `registry`.
 /// Call this before looking up definitions by provider name.
 pub fn register_all(registry: &impl DatabaseProviderRegistry) -> Result<()> {
     postgresql::register(registry)?;
     mysql::register(registry)?;
     clickhouse::register(registry)?;
+    sqlite::register(registry)?;
     Ok(())
 }

--- a/crates/adapters/compute-docker/src/containers/sqlite.rs
+++ b/crates/adapters/compute-docker/src/containers/sqlite.rs
@@ -1,0 +1,269 @@
+//! SQLite provider: file-based database, no container required.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use gfs_domain::ports::compute::{ComputeDefinition, PortMapping};
+use gfs_domain::ports::database_provider::{
+    ConnectionParams, DatabaseProvider, DatabaseProviderArg, DatabaseProviderRegistry,
+    ProviderError, Result, SIGTERM, SupportedFeature,
+};
+
+const NAME: &str = "sqlite";
+
+/// Placeholder image — never pulled; SQLite runs on the host without a container.
+const DEFAULT_IMAGE: &str = "sqlite:latest";
+
+/// Filename used for the SQLite database file inside the workspace data directory.
+pub const DB_FILENAME: &str = "db.sqlite";
+
+/// Environment variable carrying the host-side absolute path to the SQLite file.
+const ENV_DB_PATH: &str = "SQLITE_DB_PATH";
+
+/// SQLite database provider.  Implements [`DatabaseProvider`] but does not
+/// require a compute instance: `requires_compute()` returns `false`.
+#[derive(Debug, Default)]
+pub struct SqliteProvider;
+
+impl SqliteProvider {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn definition_impl() -> ComputeDefinition {
+        ComputeDefinition {
+            image: DEFAULT_IMAGE.to_string(),
+            env: vec![],
+            // Port 0 signals "no port"; the port list must be non-empty for the
+            // definition to satisfy callers that iterate over ports, but the
+            // mapping is never used because `requires_compute` returns false.
+            ports: vec![PortMapping {
+                compute_port: 0,
+                host_port: None,
+            }],
+            data_dir: PathBuf::from("/data"),
+            host_data_dir: None,
+            user: None,
+            logs_dir: None,
+            conf_dir: None,
+            args: vec![],
+        }
+    }
+}
+
+impl DatabaseProvider for SqliteProvider {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn requires_compute(&self) -> bool {
+        false
+    }
+
+    fn definition(&self) -> ComputeDefinition {
+        Self::definition_impl()
+    }
+
+    fn default_port(&self) -> u16 {
+        0
+    }
+
+    fn default_args(&self) -> Vec<DatabaseProviderArg> {
+        vec![]
+    }
+
+    fn default_signal(&self) -> u32 {
+        SIGTERM
+    }
+
+    fn connection_string(
+        &self,
+        params: &ConnectionParams,
+    ) -> std::result::Result<String, ProviderError> {
+        let path = params
+            .get_env(ENV_DB_PATH)
+            .ok_or_else(|| ProviderError::MissingEnvVar(ENV_DB_PATH.to_string()))?;
+        Ok(format!("sqlite:///{}", path))
+    }
+
+    fn supported_versions(&self) -> Vec<String> {
+        vec!["3".into()]
+    }
+
+    fn supported_features(&self) -> Vec<SupportedFeature> {
+        vec![SupportedFeature {
+            id: "schema".into(),
+            description: "Schema and DDL management.".into(),
+        }]
+    }
+
+    fn prepare_for_snapshot(&self, _params: &ConnectionParams) -> Result<Vec<String>> {
+        // No container to run commands in.  SQLite WAL files (.db, .db-wal,
+        // .db-shm) are copied as a unit; WAL recovery ensures consistency on
+        // restore.  This is best-effort, not crash-consistent.
+        Ok(vec![])
+    }
+
+    fn query_client_command(
+        &self,
+        params: &ConnectionParams,
+        query: Option<&str>,
+    ) -> std::result::Result<std::process::Command, ProviderError> {
+        let path = params
+            .get_env(ENV_DB_PATH)
+            .ok_or_else(|| ProviderError::MissingEnvVar(ENV_DB_PATH.to_string()))?;
+
+        let mut cmd = std::process::Command::new("sqlite3");
+        cmd.arg(path);
+
+        if let Some(q) = query {
+            cmd.arg(q);
+        }
+
+        Ok(cmd)
+    }
+
+    fn schema_extraction_queries(&self) -> std::collections::HashMap<String, String> {
+        let mut queries = std::collections::HashMap::new();
+
+        queries.insert(
+            "version".to_string(),
+            "SELECT json_object('version', sqlite_version());".to_string(),
+        );
+
+        queries.insert(
+            "tables".to_string(),
+            "SELECT json_group_array(json_object('name', name, 'type', type)) \
+             FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+                .to_string(),
+        );
+
+        queries.insert(
+            "columns".to_string(),
+            "SELECT json_group_array(\
+               json_object('table', m.name, 'cid', p.cid, 'name', p.name, \
+                           'type', p.type, 'notnull', p.\"notnull\", \
+                           'dflt_value', p.dflt_value, 'pk', p.pk)) \
+             FROM sqlite_master m \
+             JOIN pragma_table_info(m.name) p \
+             WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%';"
+                .to_string(),
+        );
+
+        queries
+    }
+}
+
+/// Registers the SQLite provider in `registry` under the name `"sqlite"`.
+pub fn register(registry: &impl DatabaseProviderRegistry) -> Result<()> {
+    registry.register(Arc::new(SqliteProvider::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_and_default_port() {
+        let p = SqliteProvider::new();
+        assert_eq!(p.name(), "sqlite");
+        assert_eq!(p.default_port(), 0);
+    }
+
+    #[test]
+    fn requires_compute_is_false() {
+        let p = SqliteProvider::new();
+        assert!(!p.requires_compute());
+    }
+
+    #[test]
+    fn connection_string_uses_env_db_path() {
+        let p = SqliteProvider::new();
+        let params = ConnectionParams {
+            host: String::new(),
+            port: 0,
+            env: vec![("SQLITE_DB_PATH".into(), "/data/db.sqlite".into())],
+        };
+        assert_eq!(
+            p.connection_string(&params).unwrap(),
+            "sqlite:////data/db.sqlite"
+        );
+    }
+
+    #[test]
+    fn connection_string_missing_path_is_error() {
+        let p = SqliteProvider::new();
+        let params = ConnectionParams::default();
+        assert!(matches!(
+            p.connection_string(&params),
+            Err(ProviderError::MissingEnvVar(_))
+        ));
+    }
+
+    #[test]
+    fn prepare_for_snapshot_returns_empty() {
+        let p = SqliteProvider::new();
+        let params = ConnectionParams::default();
+        assert!(p.prepare_for_snapshot(&params).unwrap().is_empty());
+    }
+
+    #[test]
+    fn query_client_command_interactive() {
+        let p = SqliteProvider::new();
+        let params = ConnectionParams {
+            host: String::new(),
+            port: 0,
+            env: vec![("SQLITE_DB_PATH".into(), "/data/db.sqlite".into())],
+        };
+        let cmd = p.query_client_command(&params, None).unwrap();
+        assert_eq!(cmd.get_program(), "sqlite3");
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args, ["/data/db.sqlite"]);
+    }
+
+    #[test]
+    fn query_client_command_with_query() {
+        let p = SqliteProvider::new();
+        let params = ConnectionParams {
+            host: String::new(),
+            port: 0,
+            env: vec![("SQLITE_DB_PATH".into(), "/data/db.sqlite".into())],
+        };
+        let cmd = p.query_client_command(&params, Some("SELECT 1;")).unwrap();
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[1], "SELECT 1;");
+    }
+
+    #[test]
+    fn query_client_command_missing_path_is_error() {
+        let p = SqliteProvider::new();
+        let params = ConnectionParams::default();
+        assert!(matches!(
+            p.query_client_command(&params, None),
+            Err(ProviderError::MissingEnvVar(_))
+        ));
+    }
+
+    #[test]
+    fn schema_extraction_queries_non_empty() {
+        let p = SqliteProvider::new();
+        let queries = p.schema_extraction_queries();
+        assert!(queries.contains_key("version"));
+        assert!(queries.contains_key("tables"));
+        assert!(queries.contains_key("columns"));
+    }
+
+    #[test]
+    fn default_signal_is_sigterm() {
+        let p = SqliteProvider::new();
+        assert_eq!(p.default_signal(), SIGTERM);
+    }
+
+    #[test]
+    fn definition_has_placeholder_image() {
+        let p = SqliteProvider::new();
+        let def = p.definition();
+        assert_eq!(def.image, "sqlite:latest");
+    }
+}

--- a/crates/applications/cli/src/commands/cmd_query.rs
+++ b/crates/applications/cli/src/commands/cmd_query.rs
@@ -1,4 +1,4 @@
-//! `gfs query` — query the database using native client (psql, mysql, etc.).
+//! `gfs query` — query the database using native client (psql, mysql, sqlite3, etc.).
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -10,6 +10,7 @@ use gfs_domain::ports::compute::{Compute, InstanceId};
 use gfs_domain::ports::database_provider::{
     ConnectionParams, DatabaseProviderRegistry, InMemoryDatabaseProviderRegistry,
 };
+use gfs_domain::repo_utils::repo_layout;
 
 use crate::cli_utils::get_repo_dir;
 
@@ -19,7 +20,7 @@ use crate::cli_utils::get_repo_dir;
 /// Otherwise, executes the query and prints the results.
 ///
 /// The `database` parameter allows overriding the default database name
-/// from the container configuration.
+/// from the container configuration (ignored for file-based providers like SQLite).
 pub async fn run(
     path: Option<PathBuf>,
     database: Option<String>,
@@ -27,7 +28,7 @@ pub async fn run(
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
 
-    // Load config to get provider name and container name
+    // Load config to get provider name
     let config =
         GfsConfig::load(&repo_path).context("not a GFS repository (run gfs init first)")?;
 
@@ -36,58 +37,68 @@ pub async fn run(
         .as_ref()
         .context("no database configured (run gfs init with --database-provider)")?;
 
-    let runtime = config
-        .runtime
-        .as_ref()
-        .context("no runtime configured (run gfs init with --database-provider)")?;
-
     let provider_name = &environment.database_provider;
-    let container_name = &runtime.container_name;
 
-    // Set up compute and registry
-    let compute = Arc::new(DockerCompute::new().map_err(|e| anyhow::anyhow!("{e}"))?);
-
+    // Set up registry and resolve provider
     let registry_impl = InMemoryDatabaseProviderRegistry::new();
     gfs_compute_docker::containers::register_all(&registry_impl)
         .context("failed to register database providers")?;
     let registry: Arc<dyn DatabaseProviderRegistry> = Arc::new(registry_impl);
 
-    // Get the provider
     let provider = registry
         .get(provider_name)
         .with_context(|| format!("unknown database provider: '{}'", provider_name))?;
 
-    // Get connection info from the running container
-    let instance_id = InstanceId(container_name.clone());
-    let default_port = provider.default_port();
+    let params = if provider.requires_compute() {
+        // Container-based path (PostgreSQL, MySQL, ClickHouse, …)
+        let runtime = config
+            .runtime
+            .as_ref()
+            .context("no runtime configured (run gfs init with --database-provider)")?;
+        let container_name = &runtime.container_name;
 
-    let conn_info = compute
-        .get_connection_info(&instance_id, default_port)
-        .await
-        .context(
-            "failed to get connection info (is the database running? try 'gfs compute start')",
-        )?;
+        let compute = Arc::new(DockerCompute::new().map_err(|e| anyhow::anyhow!("{e}"))?);
+        let instance_id = InstanceId(container_name.clone());
+        let default_port = provider.default_port();
 
-    // Override database name if --database flag is provided
-    let mut env = conn_info.env;
-    if let Some(db_name) = database {
-        // Determine the database environment variable based on provider
-        let db_env_var = match provider_name.as_str() {
-            "postgres" => "POSTGRES_DB",
-            "mysql" => "MYSQL_DATABASE",
-            "clickhouse" => "CLICKHOUSE_DB",
-            _ => "DATABASE", // fallback for future providers
-        };
+        let conn_info = compute
+            .get_connection_info(&instance_id, default_port)
+            .await
+            .context(
+                "failed to get connection info (is the database running? try 'gfs compute start')",
+            )?;
 
-        // Remove existing database env var and add the override
-        env.retain(|(k, _)| k != db_env_var);
-        env.push((db_env_var.to_string(), db_name));
-    }
+        let mut env = conn_info.env;
+        if let Some(db_name) = database {
+            let db_env_var = match provider_name.as_str() {
+                "postgres" => "POSTGRES_DB",
+                "mysql" => "MYSQL_DATABASE",
+                "clickhouse" => "CLICKHOUSE_DB",
+                _ => "DATABASE",
+            };
+            env.retain(|(k, _)| k != db_env_var);
+            env.push((db_env_var.to_string(), db_name));
+        }
 
-    let params = ConnectionParams {
-        host: conn_info.host,
-        port: conn_info.port,
-        env,
+        ConnectionParams {
+            host: conn_info.host,
+            port: conn_info.port,
+            env,
+        }
+    } else {
+        // File-based path (SQLite): read database file from the active workspace data dir.
+        let workspace_data_dir = repo_layout::get_active_workspace_data_dir(&repo_path)
+            .context("failed to determine active workspace data directory")?;
+        let db_path = workspace_data_dir.join("db.sqlite");
+
+        ConnectionParams {
+            host: String::new(),
+            port: 0,
+            env: vec![(
+                "SQLITE_DB_PATH".to_string(),
+                db_path.to_string_lossy().into_owned(),
+            )],
+        }
     };
 
     // Build the query command
@@ -103,7 +114,8 @@ pub async fn run(
                 "database client '{}' not found. Install it to use 'gfs query'.\n  \
                  - PostgreSQL: install postgresql client tools (psql)\n  \
                  - MySQL: install mysql client tools\n  \
-                 - ClickHouse: install clickhouse client tools (clickhouse-client)",
+                 - ClickHouse: install clickhouse client tools (clickhouse-client)\n  \
+                 - SQLite: install sqlite3",
                 client_name
             )
         } else {

--- a/crates/domain/src/ports/database_provider.rs
+++ b/crates/domain/src/ports/database_provider.rs
@@ -181,6 +181,15 @@ pub trait DatabaseProvider: Send + Sync {
         SIGTERM
     }
 
+    /// Whether this provider requires a running compute instance (container/VM).
+    ///
+    /// File-based databases such as SQLite return `false`; all other providers
+    /// return the default `true`.  When `false`, `init` skips container
+    /// provisioning and `gfs query` reads the file directly.
+    fn requires_compute(&self) -> bool {
+        true
+    }
+
     /// Build a client connection string from host, port, and optional env (credentials, db name).
     fn connection_string(
         &self,

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -386,7 +386,7 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
 
         // 2. Extract and store schema (best-effort) while the container is still running.
         //    Must run before pausing, since schema extraction requires a live database connection.
-        let schema_hash = if runtime_config.is_some() && environment.is_some() {
+        let schema_hash = if environment.is_some() {
             self.extract_and_store_schema(&path).await.ok()
         } else {
             None
@@ -696,32 +696,54 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
             e
         })?;
 
-        // 2. Export schema DDL using ExportRepoUseCase with "schema" format.
-        let export_use_case = ExportRepoUseCase::new(self.compute.clone(), self.registry.clone());
-        let temp_dir = repo_path.join(".gfs").join("tmp").join(format!(
-            "gfs-schema-{}-{}",
-            std::process::id(),
-            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
-        ));
-        std::fs::create_dir_all(temp_dir.parent().unwrap()).map_err(|e| {
-            tracing::warn!("Failed to create temp directory: {}", e);
-            Box::new(std::io::Error::other(format!(
-                "cannot create temp directory: {}",
-                e
-            ))) as Box<dyn std::error::Error>
-        })?;
-        let export_output = export_use_case
-            .run(repo_path, Some(temp_dir.clone()), "schema")
-            .await
-            .map_err(|e| {
-                tracing::warn!("Schema DDL export failed: {}", e);
+        // 2. Get schema DDL: for file-based providers (no container) use sqlite3 .schema;
+        //    for container providers use ExportRepoUseCase as before.
+        let config = crate::model::config::GfsConfig::load(repo_path)
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Box<dyn std::error::Error>)?;
+
+        let schema_sql = if config.runtime.is_none() {
+            // File-based provider (SQLite): dump DDL with sqlite3 .schema
+            let workspace_data_dir = repo_layout::get_active_workspace_data_dir(repo_path)
+                .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Box<dyn std::error::Error>)?;
+            let db_path = workspace_data_dir.join("db.sqlite");
+            let out = std::process::Command::new("sqlite3")
+                .arg(&db_path)
+                .arg(".schema")
+                .output()
+                .map_err(|e| {
+                    tracing::warn!("sqlite3 .schema failed: {}", e);
+                    Box::new(e) as Box<dyn std::error::Error>
+                })?;
+            String::from_utf8_lossy(&out.stdout).to_string()
+        } else {
+            // Container provider: run export sidecar.
+            let export_use_case = ExportRepoUseCase::new(self.compute.clone(), self.registry.clone());
+            let temp_dir = repo_path.join(".gfs").join("tmp").join(format!(
+                "gfs-schema-{}-{}",
+                std::process::id(),
+                chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+            ));
+            std::fs::create_dir_all(temp_dir.parent().unwrap()).map_err(|e| {
+                tracing::warn!("Failed to create temp directory: {}", e);
+                Box::new(std::io::Error::other(format!(
+                    "cannot create temp directory: {}",
+                    e
+                ))) as Box<dyn std::error::Error>
+            })?;
+            let export_output = export_use_case
+                .run(repo_path, Some(temp_dir.clone()), "schema")
+                .await
+                .map_err(|e| {
+                    tracing::warn!("Schema DDL export failed: {}", e);
+                    e
+                })?;
+            let sql = std::fs::read_to_string(&export_output.file_path).map_err(|e| {
+                tracing::warn!("Failed to read exported schema DDL: {}", e);
                 e
             })?;
-
-        let schema_sql = std::fs::read_to_string(&export_output.file_path).map_err(|e| {
-            tracing::warn!("Failed to read exported schema DDL: {}", e);
-            e
-        })?;
+            let _ = std::fs::remove_dir_all(temp_dir);
+            sql
+        };
 
         // 3. Store schema object in repo.
         let schema_hash =
@@ -730,9 +752,6 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
                     tracing::warn!("Failed to write schema object: {}", e);
                     e
                 })?;
-
-        // 4. Cleanup temp directory.
-        let _ = std::fs::remove_dir_all(temp_dir);
 
         tracing::info!("Schema stored with hash: {}", schema_hash);
         Ok(schema_hash)

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -47,6 +47,10 @@ fn storage_error_looks_like_permission_denied(err: &StorageError) -> bool {
     match err {
         StorageError::PermissionDenied(_) => true,
         StorageError::Io(io) => io.kind() == ErrorKind::PermissionDenied,
+        StorageError::Internal(msg) => {
+            let lower = msg.to_ascii_lowercase();
+            lower.contains("permission denied") || lower.contains("operation not permitted")
+        }
         _ => false,
     }
 }

--- a/crates/domain/src/usecases/repository/extract_schema_usecase.rs
+++ b/crates/domain/src/usecases/repository/extract_schema_usecase.rs
@@ -344,15 +344,15 @@ impl<R: DatabaseProviderRegistry> ExtractSchemaUseCase<R> {
                 .unwrap_or(0);
 
             // Register primary key on the table struct.
-            if pk > 0 {
-                if let Some(tbl) = tables.iter_mut().find(|t| t.id == table_id) {
-                    tbl.primary_keys.push(TablePrimaryKey {
-                        table_id,
-                        name: col_name.clone(),
-                        schema: "main".to_string(),
-                        table_name: table_name.clone(),
-                    });
-                }
+            if pk > 0
+                && let Some(tbl) = tables.iter_mut().find(|t| t.id == table_id)
+            {
+                tbl.primary_keys.push(TablePrimaryKey {
+                    table_id,
+                    name: col_name.clone(),
+                    schema: "main".to_string(),
+                    table_name: table_name.clone(),
+                });
             }
 
             columns.push(Column {

--- a/crates/domain/src/usecases/repository/extract_schema_usecase.rs
+++ b/crates/domain/src/usecases/repository/extract_schema_usecase.rs
@@ -12,9 +12,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::model::config::GfsConfig;
-use crate::model::datasource::{Column, DatasourceMetadata, Schema, Table};
+use crate::model::datasource::{Column, DatasourceMetadata, Schema, Table, TablePrimaryKey};
 use crate::ports::compute::{Compute, ComputeError, InstanceId};
-use crate::ports::database_provider::{ConnectionParams, DatabaseProviderRegistry};
+use crate::ports::database_provider::{ConnectionParams, DatabaseProvider, DatabaseProviderRegistry};
+use crate::repo_utils::repo_layout;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -101,6 +102,17 @@ impl<R: DatabaseProviderRegistry> ExtractSchemaUseCase<R> {
             })?
             .to_string();
 
+        // 2. Resolve provider.
+        let provider = self
+            .registry
+            .get(&provider_name)
+            .ok_or_else(|| ExtractSchemaError::ProviderNotFound(provider_name.clone()))?;
+
+        // 3. For file-based providers (e.g. SQLite) skip the container path entirely.
+        if !provider.requires_compute() {
+            return self.run_file_based(path, &*provider).await;
+        }
+
         let container_name = config
             .runtime
             .as_ref()
@@ -112,12 +124,6 @@ impl<R: DatabaseProviderRegistry> ExtractSchemaUseCase<R> {
                 )
             })?
             .to_string();
-
-        // 2. Resolve provider.
-        let provider = self
-            .registry
-            .get(&provider_name)
-            .ok_or_else(|| ExtractSchemaError::ProviderNotFound(provider_name.clone()))?;
 
         let instance_id = InstanceId(container_name);
 
@@ -162,6 +168,221 @@ impl<R: DatabaseProviderRegistry> ExtractSchemaUseCase<R> {
             parse_schema_output(&output.stdout).map_err(ExtractSchemaError::ExtractionFailed)?;
 
         // 7. Build metadata.
+        let metadata = DatasourceMetadata {
+            version,
+            driver: provider_name,
+            schemas,
+            tables,
+            columns,
+            views: None,
+            functions: None,
+            indexes: None,
+            triggers: None,
+            materialized_views: None,
+            types: None,
+            foreign_tables: None,
+            policies: None,
+            table_privileges: None,
+            column_privileges: None,
+            config: None,
+            publications: None,
+            roles: None,
+            extensions: None,
+        };
+
+        Ok(SchemaOutput { metadata })
+    }
+
+    /// Extract schema for file-based providers (e.g. SQLite) without a compute container.
+    ///
+    /// Runs `schema_extraction_queries()` via the host `sqlite3` CLI and assembles
+    /// `Table`/`Column`/`Schema` structs from the JSON output.
+    async fn run_file_based(
+        &self,
+        repo_path: &Path,
+        provider: &dyn DatabaseProvider,
+    ) -> Result<SchemaOutput, ExtractSchemaError> {
+        let provider_name = provider.name().to_string();
+
+        let workspace_data_dir = repo_layout::get_active_workspace_data_dir(repo_path)
+            .map_err(|e| ExtractSchemaError::NotConfigured(e.to_string()))?;
+
+        let db_path = workspace_data_dir.join("db.sqlite");
+
+        let queries = provider.schema_extraction_queries();
+        if queries.is_empty() {
+            return Err(ExtractSchemaError::ExtractionFailed(format!(
+                "provider '{}' does not support schema extraction",
+                provider_name
+            )));
+        }
+
+        let run_query = |sql: &str| -> Result<String, ExtractSchemaError> {
+            let output = std::process::Command::new("sqlite3")
+                .arg(&db_path)
+                .arg(sql)
+                .output()
+                .map_err(|e| {
+                    ExtractSchemaError::QueryFailed(format!("sqlite3 not found: {}", e))
+                })?;
+            if !output.status.success() {
+                return Err(ExtractSchemaError::QueryFailed(
+                    String::from_utf8_lossy(&output.stderr).to_string(),
+                ));
+            }
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        };
+
+        // Version
+        let version_json = queries
+            .get("version")
+            .map(|q| run_query(q))
+            .transpose()?
+            .unwrap_or_default();
+        let version = if version_json.is_empty() {
+            "3".to_string()
+        } else {
+            let v: serde_json::Value = serde_json::from_str(&version_json)
+                .map_err(|e| ExtractSchemaError::JsonParsing(e.to_string()))?;
+            v.get("version")
+                .and_then(|s| s.as_str())
+                .unwrap_or("3")
+                .to_string()
+        };
+
+        // Tables: [{name, type}]
+        let tables_json = queries
+            .get("tables")
+            .map(|q| run_query(q))
+            .transpose()?
+            .unwrap_or_else(|| "[]".to_string());
+        let raw_tables: Vec<serde_json::Value> = if tables_json.is_empty() {
+            vec![]
+        } else {
+            serde_json::from_str(&tables_json)
+                .map_err(|e| ExtractSchemaError::JsonParsing(e.to_string()))?
+        };
+
+        // Columns: [{table, cid, name, type, notnull, dflt_value, pk}]
+        let columns_json = queries
+            .get("columns")
+            .map(|q| run_query(q))
+            .transpose()?
+            .unwrap_or_else(|| "[]".to_string());
+        let raw_columns: Vec<serde_json::Value> = if columns_json.is_empty() {
+            vec![]
+        } else {
+            serde_json::from_str(&columns_json)
+                .map_err(|e| ExtractSchemaError::JsonParsing(e.to_string()))?
+        };
+
+        // Build Tables with stable numeric IDs (position in list).
+        let mut tables: Vec<Table> = raw_tables
+            .iter()
+            .enumerate()
+            .map(|(idx, t)| {
+                let name = t
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Table {
+                    id: idx as i64 + 1,
+                    schema: "main".to_string(),
+                    name,
+                    rls_enabled: false,
+                    rls_forced: false,
+                    bytes: 0,
+                    size: "0 bytes".to_string(),
+                    live_rows_estimate: 0,
+                    dead_rows_estimate: 0,
+                    comment: None,
+                    primary_keys: vec![],
+                    relationships: vec![],
+                    columns: None,
+                }
+            })
+            .collect();
+
+        // Build Columns, also collecting primary key info per table.
+        let mut columns: Vec<Column> = Vec::new();
+        for raw_col in &raw_columns {
+            let table_name = raw_col
+                .get("table")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let table_id = tables
+                .iter()
+                .find(|t| t.name == table_name)
+                .map(|t| t.id)
+                .unwrap_or(0);
+            let cid = raw_col
+                .get("cid")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let col_name = raw_col
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let data_type = raw_col
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let notnull = raw_col
+                .get("notnull")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let dflt_value = raw_col.get("dflt_value").cloned().and_then(|v| {
+                if v.is_null() { None } else { Some(v) }
+            });
+            let pk = raw_col
+                .get("pk")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+
+            // Register primary key on the table struct.
+            if pk > 0 {
+                if let Some(tbl) = tables.iter_mut().find(|t| t.id == table_id) {
+                    tbl.primary_keys.push(TablePrimaryKey {
+                        table_id,
+                        name: col_name.clone(),
+                        schema: "main".to_string(),
+                        table_name: table_name.clone(),
+                    });
+                }
+            }
+
+            columns.push(Column {
+                id: format!("{}.{}", table_id, cid),
+                table_id,
+                schema: "main".to_string(),
+                table: table_name,
+                name: col_name,
+                ordinal_position: cid as i32,
+                data_type: data_type.clone(),
+                format: data_type.to_lowercase(),
+                is_identity: false,
+                identity_generation: None,
+                is_generated: false,
+                is_nullable: notnull == 0,
+                is_updatable: true,
+                is_unique: pk > 0,
+                check: None,
+                default_value: dflt_value,
+                enums: vec![],
+                comment: None,
+            });
+        }
+
+        let schemas = vec![Schema {
+            id: 1,
+            name: "main".to_string(),
+            owner: "main".to_string(),
+        }];
+
         let metadata = DatasourceMetadata {
             version,
             driver: provider_name,

--- a/crates/domain/src/usecases/repository/init_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/init_repo_usecase.rs
@@ -99,12 +99,6 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
         database_port: Option<u16>,
         credentials: DatabaseCredentials,
     ) -> std::result::Result<(), InitRepoError> {
-        let compute = self.compute.as_ref().ok_or_else(|| {
-            InitRepoError::Compute(ComputeError::Internal(
-                "database provisioning requires a compute runtime".into(),
-            ))
-        })?;
-
         let list = self.registry.list();
         let matched_name = list
             .iter()
@@ -184,6 +178,29 @@ impl<R: DatabaseProviderRegistry> InitRepositoryUseCase<R> {
                 ),
             }
         }
+
+        // File-based providers (e.g. SQLite) need no container. Write only
+        // EnvironmentConfig; leaving RuntimeConfig absent signals to commit and
+        // checkout use-cases that there is no container to manage.
+        if !provider.requires_compute() {
+            let database_version = provider.version_from_image(&definition);
+            let environment = EnvironmentConfig {
+                database_provider: provider_name,
+                database_version,
+                database_port,
+            };
+            self.repository
+                .update_environment_config(repo_path, environment)
+                .await?;
+            tracing::info!("Database configured (no container); provider: {}", provider.name());
+            return Ok(());
+        }
+
+        let compute = self.compute.as_ref().ok_or_else(|| {
+            InitRepoError::Compute(ComputeError::Internal(
+                "database provisioning requires a compute runtime".into(),
+            ))
+        })?;
 
         let id = compute.provision(&definition).await?;
         compute.start(&id, StartOptions::default()).await?;

--- a/skills/use-gfs-cli/SKILL.md
+++ b/skills/use-gfs-cli/SKILL.md
@@ -11,6 +11,7 @@ GFS brings Git-like version control to your databases. Commit database states, c
 
 - PostgreSQL (versions 13-18)
 - MySQL (versions 8.0-8.1)
+- SQLite (version 3) — file-based, no container required
 
 ## Installation
 
@@ -551,7 +552,7 @@ If schema is not captured during commit:
 4. **Check status regularly** - Understand current state and container status
 6. **Export before risky operations** - Create backups with `gfs export`
 7. **Use descriptive commit messages** - Makes history navigation easier
-8. **Container must be running** - Most operations require active database container
+8. **Container must be running** - Most operations require active database container (not needed for SQLite)
 9. **Schema as documentation** - Use `gfs schema show` to document database structure
 
 ## Environment Variables


### PR DESCRIPTION
> ### Superseded by #148 — closing
>
> This PR opened on 2026-05-04 (+642 −88 across 8 files) and is now **CONFLICTING** against `main`. **#148** replaces it with a substantially larger and better-verified implementation of the same idea, rebased on current `main`.
>
> Keeping it open is a dead review target, so it is being closed rather than rebased. The original description is preserved below for history. Nothing here is lost — everything it proposed is either in #148 or was deliberately reconsidered there.

## What #148 does differently

The core argument is unchanged and came from this PR: **SQLite must run in-process, not in a container.** GFS's correctness story for every other provider is "pause the container, then snapshot"; for SQLite that argument does not exist, because the writer is the user's own application and there is nothing to pause.

What changed since this PR:

- **Quiescing is real.** `PRAGMA wal_checkpoint(TRUNCATE)` then `BEGIN IMMEDIATE`, held across `storage.snapshot()`. Verified differentially: an unguarded plain copy produces `database disk image is malformed`; the guarded path passed 8/8.
- **`requires_compute()` is derived, not declared.** This PR added it as a trait method defaulting to `true`; #148 splits `DatabaseProvider` from `ContainerProvider` and derives the answer from which one a provider implements, so a provider cannot claim one thing and do another.
- **The advertised-but-broken cases are closed.** Export/import listed as supported while resolving to nothing; an unreachable `SQLITE_DB_PATH` override; `skills/use-gfs-mcp/SKILL.md` claiming MCP supported SQLite while every MCP tool built a Docker client before deciding whether it needed one. All fixed and exercised.
- **It is tested without a runtime.** `e2e_sqlite.rs` points `DOCKER_HOST` at a socket that cannot exist, so a passing run proves no daemon was involved.
- **Two blind audits.** The second found nineteen issues including four silent-wrong-result cases.

---

<details>
<summary>Original description (2026-05-04)</summary>

Adds SQLite as a file-based provider — no Docker required.

## Changes

**New provider** (`containers/sqlite.rs`): `requires_compute=false`, `query_client_command` → `sqlite3`, `prepare_for_snapshot` → no-op.

**`DatabaseProvider` trait** (`database_provider.rs`): add `requires_compute() -> bool` (default `true`).

**`init_repo_usecase.rs`**: look up provider before grabbing compute; early-return for file-based providers writes `EnvironmentConfig` only (no `RuntimeConfig` → existing commit/checkout container guards stay correct).

**`cmd_query.rs`**: branch on `requires_compute()` — SQLite path resolves active workspace `db.sqlite` and builds `ConnectionParams` directly; container path unchanged.

**`commit_repo_usecase.rs`** (BUG-6): remove `runtime_config` guard so schema extraction runs for all providers; add `run_file_based()` path in `ExtractSchemaUseCase` using `sqlite3` CLI.

**`containers/mod.rs`**: register SQLite provider.

## Usage

```bash
gfs init --database-provider sqlite --database-version 3
gfs query "CREATE TABLE t (id INTEGER);"
gfs commit -m "init"
```

No `gfs compute start` needed.

</details>