### PR TITLE
fix(clone): honor delete tombstones on the federate path

### DIFF
--- a/crates/extensions/gfs/src/catalog.rs
+++ b/crates/extensions/gfs/src/catalog.rs
@@ -16,6 +16,34 @@ pub(crate) unsafe fn spi_text(p: *mut c_char) -> Option<String> {
     }
 }
 
+/// True iff this clone table has any copy-on-write DELETE tombstones. A federated
+/// swap runs the query at the SOURCE over the foreign tables, which cannot see the
+/// local `gfs.tombstone` table, so a row deleted on the clone would reappear in the
+/// result. The router therefore must NOT federate a table that has tombstones; it
+/// falls back to a tombstone-aware whole-own hydration instead (do_hydrate excludes
+/// them). Zero-cost lookup; the no-deletes case (the norm) returns false at once.
+pub(crate) unsafe fn relation_has_tombstones(relid: pg_sys::Oid) -> bool {
+    if pg_sys::SPI_connect() != pg_sys::SPI_OK_CONNECT as i32 {
+        return false;
+    }
+    let q = CString::new(format!(
+        "SELECT EXISTS(SELECT 1 FROM gfs.tombstone WHERE relid::oid = {})::int::text",
+        u32::from(relid)
+    ))
+    .unwrap();
+    let mut has = false;
+    if pg_sys::SPI_execute(q.as_ptr(), true, 1) == pg_sys::SPI_OK_SELECT as i32
+        && pg_sys::SPI_processed == 1
+    {
+        let tt = pg_sys::SPI_tuptable;
+        let row = *(*tt).vals;
+        let td = (*tt).tupdesc;
+        has = spi_text(pg_sys::SPI_getvalue(row, td, 1)).as_deref() == Some("1");
+    }
+    pg_sys::SPI_finish();
+    has
+}
+
 pub(crate) unsafe fn gfs_lookup_clone(relid: pg_sys::Oid) -> Option<CloneInfo> {
     if pg_sys::SPI_connect() != pg_sys::SPI_OK_CONNECT as i32 {
         return None;

--- a/crates/extensions/gfs/src/route.rs
+++ b/crates/extensions/gfs/src/route.rs
@@ -11,7 +11,7 @@ use crate::base_plan;
 use crate::catalog::{
     bump_access, gfs_enqueue_copy, gfs_enqueue_partial, gfs_is_covered, gfs_lookup_clone,
     gfs_note_pred_seen, gfs_pred_count, gfs_pred_state, gfs_set_no_partial, gfs_throttle,
-    gfs_time_queued, gfs_whole_queued,
+    gfs_time_queued, gfs_whole_queued, relation_has_tombstones,
 };
 use crate::federate::swap_clone_rtes_to_foreign;
 use crate::hydrate::do_hydrate;
@@ -66,7 +66,22 @@ pub(crate) unsafe fn gfs_route(
     // e.g. an exotic shape): own those tables whole — NEVER serve a local
     // incomplete result.
     if !ctx.federate_targets.is_empty() {
-        if !is_write && !parse_copy.is_null() && swap_clone_rtes_to_foreign(parse_copy) > 0 {
+        // A federated swap runs the query at the SOURCE over the foreign tables, which
+        // cannot see local DELETE tombstones -> a row deleted on the clone would
+        // reappear in the result. If any target table has tombstones, do NOT swap;
+        // fall through to the tombstone-aware whole-own hydration below (do_hydrate
+        // excludes tombstoned rows), so local deletes are honored on the federate path.
+        // (Optimization TODO: inject a `NOT EXISTS gfs.tombstone` anti-join into the
+        // federated query instead of owning the table whole.)
+        let any_tombstoned = ctx
+            .federate_targets
+            .iter()
+            .any(|t| unsafe { relation_has_tombstones(t.relid) });
+        if !is_write
+            && !any_tombstoned
+            && !parse_copy.is_null()
+            && swap_clone_rtes_to_foreign(parse_copy) > 0
+        {
             gfs_throttle(); // rate-limit source contact (the federated query hits prod)
             return base_plan(parse_copy, qs, cursor, params);
         }


### PR DESCRIPTION
## Related Issue
Closes #97

## What
A row deleted on a GFS lazy clone could reappear in query results. Deletes are recorded as tombstones (`gfs.tombstone`) and are correctly hidden when the clone answers from its own local store, but the **federate path** (running the query at the source over the foreign tables) did not apply the tombstone. The source still has the row, so the clone relayed it back. The result a query returned therefore depended on which route the router picked: a locally-deleted row was hidden on local/copy reads but visible on federated reads (aggregates, joins, unseen or overflowed predicates). The source is never modified, so this is a clone-read divergence-correctness bug, not data loss. It is a blocker for the v3 integration.

## How
- `catalog.rs`: add `relation_has_tombstones(relid)` — a cheap `EXISTS` lookup against `gfs.tombstone` (zero-cost when a table has no local deletes, which is the norm).
- `route.rs`: before taking the federate swap (`swap_clone_rtes_to_foreign`), check whether any target table has tombstones. If so, **skip the swap** and fall through to the existing **tombstone-aware whole-own hydration** (`do_hydrate` already excludes tombstoned rows via `NOT EXISTS ... to_jsonb(row) @> tb.pk`), then serve local. So local deletes are honored regardless of route.

**Key decision / trade-off:** this reuses proven, tombstone-safe code paths instead of hand-building a `NOT EXISTS` anti-join into the live planner tree (risky AST surgery to ship without CI). The cost: a federated query over a table that has *any* local delete now owns that table locally rather than federating (correct, but heavier than ideal). The optimal follow-up — inject the tombstone anti-join into the federated query so it stays federated *and* respects deletes — is left as a documented `TODO` in `route.rs`.

## Review Guide
1. `crates/extensions/gfs/src/route.rs` — the gate: `any_tombstoned` check before the federate swap (the actual fix).
2. `crates/extensions/gfs/src/catalog.rs` — the `relation_has_tombstones` helper.

## Testing
Built `gfs-postgres:16` with the fix and validated on **TPC-H SF=2** (lineitem = 11,997,996 rows, ~2944 MB) via `examples/benchmark-explorer`.

- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

Reproduction of #97, before vs after the fix:

| | before | after |
|---|---|---|
| clone read `WHERE l_orderkey=2` (after deleting line 1) | returns the deleted row | empty |
| clone `count(*)` | 11997996 (= source, wrong) | 11997995 |
| route of the read | tombstone-blind federate (`federate_calls +1`) | tombstone-aware whole-own (`rows_fetched` +~12M, `federate_calls` flat) |

Regression: the full differential suite (correctness clone == source, all routes, async convergence, join convergence) is **14/0** on the fixed image, with unchanged metrics (the change only affects behavior when a table actually has local deletes).

## Documentation
- [x] Code comments explaining the gate and the documented follow-up TODO
- [ ] README / CHANGELOG (n/a)

## User Impact
- A row deleted on a clone now stays deleted on every read path, including federated queries. Divergence is consistent regardless of route.
- The source database is never touched (deletes apply only to the clone).
- Side effect: a federated query over a table that has local deletes will own that table locally on first access (a one-time copy, correct but heavier). No impact on tables without local deletes.

## Checklist
- [x] Code follows project style guidelines (mirrors the existing SPI-helper and routing patterns)
- [x] Self-review completed
- [ ] Tests pass locally (`cargo test`) — not run locally (no pgrx toolchain on this machine); the change compiles via the release image build and was validated with the SF=2 differential suite + the #97 reproduction. Please run in CI.
- [ ] Clippy (`cargo clippy --all-targets --all-features -- -D warnings`) — please run in CI.
- [ ] Format check (`cargo fmt --check`) — please run in CI.
- [x] This PR can be safely reverted if needed (additive helper + a guarded condition; only changes behavior when tombstones exist)
