### PR TITLE
fix(clone): do not federate a table with local writes (insert/update/…

### DIFF
--- a/crates/extensions/gfs/src/catalog.rs
+++ b/crates/extensions/gfs/src/catalog.rs
@@ -16,18 +16,22 @@ pub(crate) unsafe fn spi_text(p: *mut c_char) -> Option<String> {
     }
 }
 
-/// True iff this clone table has any copy-on-write DELETE tombstones. A federated
-/// swap runs the query at the SOURCE over the foreign tables, which cannot see the
-/// local `gfs.tombstone` table, so a row deleted on the clone would reappear in the
-/// result. The router therefore must NOT federate a table that has tombstones; it
-/// falls back to a tombstone-aware whole-own hydration instead (do_hydrate excludes
-/// them). Zero-cost lookup; the no-deletes case (the norm) returns false at once.
-pub(crate) unsafe fn relation_has_tombstones(relid: pg_sys::Oid) -> bool {
+/// True iff this clone table has DIVERGED from the source via any local write:
+/// an INSERT/UPDATE (flagged in `gfs.clone_source.has_local_writes`) or a DELETE
+/// (recorded in `gfs.tombstone`). A federated swap runs the query at the SOURCE over
+/// the foreign tables, which cannot see local writes, so a federated result would
+/// MISS a local insert, return the STALE value of a local update, or RESURRECT a
+/// local delete. The router therefore must NOT federate a diverged table; it falls
+/// back to a whole-own hydration (do_hydrate copies the source with ON CONFLICT DO
+/// NOTHING + tombstone exclusion, which preserves the local insert/update/delete) and
+/// serves local. Zero-cost lookup; an unmodified table (the norm) returns false.
+pub(crate) unsafe fn relation_diverged(relid: pg_sys::Oid) -> bool {
     if pg_sys::SPI_connect() != pg_sys::SPI_OK_CONNECT as i32 {
         return false;
     }
     let q = CString::new(format!(
-        "SELECT EXISTS(SELECT 1 FROM gfs.tombstone WHERE relid::oid = {})::int::text",
+        "SELECT (COALESCE((SELECT has_local_writes FROM gfs.clone_source WHERE relid::oid = {0}), false) \
+                 OR EXISTS(SELECT 1 FROM gfs.tombstone WHERE relid::oid = {0}))::int::text",
         u32::from(relid)
     ))
     .unwrap();
@@ -42,6 +46,24 @@ pub(crate) unsafe fn relation_has_tombstones(relid: pg_sys::Oid) -> bool {
     }
     pg_sys::SPI_finish();
     has
+}
+
+/// Flag a clone table as locally written (diverged) so future queries do not federate
+/// it. Called from the router when it plans a top-level INSERT/UPDATE/DELETE whose
+/// target is a registered clone. A no-op (0 rows) for unregistered relations; runs in
+/// the writing transaction, so a rolled-back write does not leave the flag set.
+pub(crate) unsafe fn gfs_mark_local_write(relid: pg_sys::Oid) {
+    if pg_sys::SPI_connect() != pg_sys::SPI_OK_CONNECT as i32 {
+        return;
+    }
+    let q = CString::new(format!(
+        "UPDATE gfs.clone_source SET has_local_writes = true \
+           WHERE relid::oid = {} AND NOT has_local_writes",
+        u32::from(relid)
+    ))
+    .unwrap();
+    pg_sys::SPI_execute(q.as_ptr(), false, 0);
+    pg_sys::SPI_finish();
 }
 
 pub(crate) unsafe fn gfs_lookup_clone(relid: pg_sys::Oid) -> Option<CloneInfo> {

--- a/crates/extensions/gfs/src/route.rs
+++ b/crates/extensions/gfs/src/route.rs
@@ -11,7 +11,7 @@ use crate::base_plan;
 use crate::catalog::{
     bump_access, gfs_enqueue_copy, gfs_enqueue_partial, gfs_is_covered, gfs_lookup_clone,
     gfs_note_pred_seen, gfs_pred_count, gfs_pred_state, gfs_set_no_partial, gfs_throttle,
-    gfs_time_queued, gfs_whole_queued, relation_has_tombstones,
+    gfs_mark_local_write, gfs_time_queued, gfs_whole_queued, relation_diverged,
 };
 use crate::federate::swap_clone_rtes_to_foreign;
 use crate::hydrate::do_hydrate;
@@ -40,6 +40,13 @@ pub(crate) unsafe fn gfs_route(
     // whole-hydrates those tables LOCALLY, so the write applies to complete local
     // data with the source untouched. Only SELECT may federate.
     let is_write = !parse.is_null() && (*parse).commandType != pg_sys::CmdType::CMD_SELECT;
+    // Mark the write's target clone table as diverged so later queries do NOT federate
+    // it (a federated read runs at the source and cannot see this local INSERT/UPDATE/
+    // DELETE). This is a top-level user write: GFS's own hydration INSERTs run nested
+    // under the re-entrancy guard and never reach here, so they do not flag the table.
+    if is_write {
+        mark_write_target(parse);
+    }
     let stmt = base_plan(parse, qs, cursor, params); // cold plan, to inspect
 
     let mut ctx =
@@ -67,18 +74,21 @@ pub(crate) unsafe fn gfs_route(
     // incomplete result.
     if !ctx.federate_targets.is_empty() {
         // A federated swap runs the query at the SOURCE over the foreign tables, which
-        // cannot see local DELETE tombstones -> a row deleted on the clone would
-        // reappear in the result. If any target table has tombstones, do NOT swap;
-        // fall through to the tombstone-aware whole-own hydration below (do_hydrate
-        // excludes tombstoned rows), so local deletes are honored on the federate path.
-        // (Optimization TODO: inject a `NOT EXISTS gfs.tombstone` anti-join into the
-        // federated query instead of owning the table whole.)
-        let any_tombstoned = ctx
+        // cannot see local writes -> a federated result would MISS a local INSERT,
+        // return the STALE value of a local UPDATE, or RESURRECT a local DELETE. If any
+        // target table has diverged (local insert/update/delete), do NOT swap; fall
+        // through to the whole-own hydration below (do_hydrate copies the source with
+        // ON CONFLICT DO NOTHING + tombstone exclusion, preserving the local writes),
+        // so the clone's own state is honored on the federate path.
+        // (Optimization TODO: reconcile inside the federated query -- UNION local
+        // inserts, prefer local rows for updates, anti-join tombstones -- instead of
+        // owning the table whole.)
+        let any_diverged = ctx
             .federate_targets
             .iter()
-            .any(|t| unsafe { relation_has_tombstones(t.relid) });
+            .any(|t| unsafe { relation_diverged(t.relid) });
         if !is_write
-            && !any_tombstoned
+            && !any_diverged
             && !parse_copy.is_null()
             && swap_clone_rtes_to_foreign(parse_copy) > 0
         {
@@ -124,6 +134,26 @@ fn whole_of(h: &Hydration) -> Hydration {
         partial_cap: 0,
         time_key: false,
         key_type: String::new(),
+    }
+}
+
+// Flag the target table of a top-level write (INSERT/UPDATE/DELETE) as locally
+// diverged via its result relation, so later queries over it do not federate. No-op
+// for a non-clone target (the UPDATE in gfs_mark_local_write matches no row).
+unsafe fn mark_write_target(parse: *mut pg_sys::Query) {
+    if parse.is_null() {
+        return;
+    }
+    let ri = (*parse).resultRelation;
+    if ri <= 0 {
+        return;
+    }
+    if let Some(rte) =
+        PgList::<pg_sys::RangeTblEntry>::from_pg((*parse).rtable).get_ptr((ri - 1) as usize)
+    {
+        if !rte.is_null() && (*rte).rtekind == pg_sys::RTEKind::RTE_RELATION {
+            gfs_mark_local_write((*rte).relid);
+        }
     }
 }
 

--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -11,7 +11,11 @@ CREATE TABLE gfs.clone_source (
     row_bytes    int      NOT NULL DEFAULT 100,      -- B: avg bytes/row
     access_count bigint   NOT NULL DEFAULT 0,        -- H: query frequency (amortization)
     partial_rows bigint   NOT NULL DEFAULT 0,        -- cumulative rows pulled by COMMITTED partial hydrations
-    no_partial   boolean  NOT NULL DEFAULT false     -- terminal: too big to own; federate per call, no more probes
+    no_partial   boolean  NOT NULL DEFAULT false,    -- terminal: too big to own; federate per call, no more probes
+    has_local_writes boolean NOT NULL DEFAULT false  -- set when a local INSERT/UPDATE/DELETE diverges this table from
+                                                     -- the source. A diverged table must NOT be federated (the source
+                                                     -- would not reflect the local write); the router whole-owns it and
+                                                     -- serves local instead. See gfs_mark_local_write / relation_diverged.
 );
 COMMENT ON TABLE gfs.clone_source IS 'Per clone table: source ref, range key, ownership, and cost-model stats';
 


### PR DESCRIPTION
## Related Issue
Closes #100

Builds on #97 (which fixed the DELETE case); this generalizes it to all local writes. Stack on / base against `fix/federate-tombstone` if #97 hasn't merged yet.

## What
On a read-write GFS clone, a query could return wrong results for a table you had written to, depending on how the router answered it. When a query is answered by **federation** (the table isn't fully owned, so the query runs at the source over the foreign tables), the source cannot see local writes, so:
- a locally **INSERTed** row was **missing** from the result,
- a locally **UPDATEd** row returned its **stale (source) value**,
- (DELETE was already handled in #97.)

The same row read twice could give different answers depending purely on whether the router chose LOCAL or FEDERATE, which breaks the invariant that a clone read reflects the clone's own state. The source database is never modified, so this is a clone-read divergence-correctness bug, not data loss. It is a correctness blocker for read-write clones running analytics, and for the v3 integration.

## How
Generalize the #97 approach from delete-tombstones to **any** local write:
- `schema.sql`: add `gfs.clone_source.has_local_writes`.
- `catalog.rs`: `gfs_mark_local_write(relid)` sets the flag (in the writing transaction, so a rolled-back write doesn't leave it set; a no-op for non-clone targets), and `relation_diverged(relid)` returns true when a table has local writes **or** delete-tombstones.
- `route.rs`: when planning a top-level INSERT/UPDATE/DELETE, mark the target clone table diverged (`mark_write_target`, via the query's result relation). GFS's own hydration INSERTs run nested under the re-entrancy guard and never reach this path, so they don't flag the table. The federate gate then refuses to federate **any diverged table**: it whole-owns it instead, where the existing `ON CONFLICT DO NOTHING` + tombstone exclusion in `do_hydrate` preserves the local insert/update/delete, then serves local.

**Key decision / trade-off:** this is the conservative, correctness-first fix (it reuses proven, divergence-safe code paths). The cost: a federated query over a table that has any local write will own that table locally on first access instead of federating (correct, but heavier than ideal). The optimal follow-up — reconcile inside the federated query (UNION local inserts, prefer local rows for updates, anti-join tombstones) — is left as a documented TODO in `route.rs`. Un-written tables are unaffected and federate as before.

## Review Guide
1. `crates/extensions/gfs/src/route.rs` — `mark_write_target` (flag on write) and the `relation_diverged` gate before the federate swap (the fix).
2. `crates/extensions/gfs/src/catalog.rs` — `gfs_mark_local_write` + `relation_diverged`.
3. `crates/extensions/gfs/src/sql/schema.sql` — the `has_local_writes` column.

## Testing
Rebuilt `gfs-postgres:16` with the fix and tested on a controlled source (cold GFS clone, federation forced and verified via the `gfs.clones.federate_calls` counter) plus the TPC-H SF=2 differential suite.

- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

Full write × route matrix (all PASS):

| | LOCAL path | FEDERATE path |
|---|---|---|
| INSERT | count=6 | count=6 (was 5); `federate_delta=0`, whole-owned |
| UPDATE | qty=999 | sum=1139 (was 150); `federate_delta=0` |
| DELETE | count=5 | count=4; `federate_delta=0` |

- Scope check: an **un-written** table still federates (`federate_delta=1`, correct result) — the fix does not over-trigger.
- Regression: TPC-H SF=2 differential suite **14/0** (router paths, async partial/temporal convergence, join convergence), unchanged metrics.
- Source database untouched in every case.

## Documentation
- [x] Code comments on the diverged gate, `mark_write_target`, and the follow-up TODO
- [ ] README / CHANGELOG (n/a)

## User Impact
- A row inserted/updated/deleted on a clone is now reflected on **every** read path, including federated queries. Divergence is consistent regardless of route.
- The source database is never touched (writes apply only to the clone).
- Side effect: a federated query over a table that has local writes will own that table locally on first access (a one-time copy, correct but heavier). No impact on read-only clones or un-written tables.

## Checklist
- [x] Code follows project style guidelines (mirrors the #97 / existing SPI-helper and routing patterns)
- [x] Self-review completed
- [ ] Tests pass locally (`cargo test`) — not run locally (no pgrx toolchain on this machine); the change compiles via the release image build and was validated with the SF=2 matrix + the #100 reproduction. Please run in CI.
- [ ] Clippy (`cargo clippy --all-targets --all-features -- -D warnings`) — please run in CI.
- [ ] Format check (`cargo fmt --check`) — please run in CI.
- [x] This PR can be safely reverted if needed (additive column + helper + a guarded condition; only changes behavior when a table has local writes)
