### PR TITLE
fix(clone): carry stateful objects onto lazy clones + fail loud on ke…

### DIFF
--- a/crates/adapters/compute-docker/src/containers/clone_bootstrap.sql
+++ b/crates/adapters/compute-docker/src/containers/clone_bootstrap.sql
@@ -242,6 +242,211 @@ BEGIN
 END
 $fn$;
 
+-- Replicate each local sequence's CURRENT POSITION from the source. The faithful
+-- schema replay (`pg_dump --schema-only`) emits `CREATE SEQUENCE` but NOT the
+-- sequence position (`setval` lives in pg_dump's data section, which a schema-only
+-- dump omits), so every local sequence restarts at its initial value (typically 1).
+-- A source serial/identity/standalone sequence advanced past its start would then
+-- hand out values that COLLIDE with rows already materialized on the clone. For
+-- each local sequence (relkind='S' — catches serial-owned, identity-owned, and
+-- standalone sequences) we read the matching source sequence's `last_value` and
+-- `is_called` straight off the sequence relation via dblink (NOT pg_sequences,
+-- whose last_value is NULL/permission-sensitive) and setval() the local one to
+-- match. Per-sequence failures warn loudly rather than abort: a clone with one
+-- un-synced sequence is recoverable; an aborted clone is not. A sequence absent on
+-- the source (local-only) is simply skipped.
+CREATE OR REPLACE FUNCTION gfs_sync.replicate_sequences(p_conn text, p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  seqrec record;
+  src    record;
+  fq     text;
+BEGIN
+  FOR seqrec IN
+    SELECT n.nspname::text AS nsp, c.relname::text AS seq
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'S' AND n.nspname = ANY (p_schemas)
+  LOOP
+    fq := format('%I.%I', seqrec.nsp, seqrec.seq);
+    BEGIN
+      -- Read the source sequence's current state directly off the relation. A
+      -- regclass cast on the source guards a sequence that exists locally but not
+      -- remotely: dblink raises, we catch and skip below.
+      SELECT * INTO src FROM dblink(p_conn, format(
+          'SELECT last_value, is_called FROM %s', fq))
+        AS r(last_value bigint, is_called boolean);
+      IF src.last_value IS NOT NULL THEN
+        PERFORM setval(fq::regclass, src.last_value, src.is_called);
+      END IF;
+    EXCEPTION WHEN others THEN
+      RAISE WARNING 'gfs: could not replicate sequence value for % (%): inserts on the clone may collide with materialized rows', fq, SQLERRM;
+    END;
+  END LOOP;
+END
+$fn$;
+
+-- Safeguard: a partitioned table must NEVER be silently dropped from the clone.
+-- A partitioned PARENT (relkind='p') holds no rows and is skipped by the table
+-- enumeration and the copy-on-read registration (both relkind='r'); it needs no
+-- registration of its own because the faithful replay re-creates it and a query on
+-- the parent prunes to its leaf partitions. Each LEAF partition (relkind='r') is an
+-- ordinary table that the relkind='r' path above imports and registers like any
+-- other table — that is how copy-on-read is wired for partitions. The risk is a
+-- leaf that does NOT round-trip: it has no usable unique key (so the keycol query
+-- skips it), or it failed to import / replay. The current code would leave that
+-- leaf as an empty, unregistered local heap and the clone would silently return no
+-- rows for that slice of the partitioned table. This function enumerates the
+-- SOURCE's partitioned tables and their leaf partitions (pg_partition_tree, so it
+-- also covers multi-level subpartitions), then asserts every leaf is locally
+-- present AND registered as a copy-on-read clone. Any gap RAISEs (fatal under
+-- ON_ERROR_STOP) naming the offending partitioned table, so a partitioned table is
+-- never silently dropped — it either round-trips fully or fails the clone loudly.
+CREATE OR REPLACE FUNCTION gfs_sync.verify_partitions(p_conn text, p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  schlist  text;
+  leaf     record;
+  leaf_fq  text;
+  problems text[] := ARRAY[]::text[];
+BEGIN
+  schlist := (SELECT string_agg(quote_literal(x), ', ') FROM unnest(p_schemas) AS x);
+
+  FOR leaf IN SELECT * FROM dblink(p_conn, format($q$
+      SELECT pn.nspname::text AS parent_nsp, pc.relname::text AS parent_tab,
+             ln.nspname::text AS leaf_nsp,   lc.relname::text AS leaf_tab
+      FROM pg_class pc
+      JOIN pg_namespace pn ON pn.oid = pc.relnamespace
+      CROSS JOIN LATERAL pg_partition_tree(pc.oid) pt
+      JOIN pg_class lc     ON lc.oid = pt.relid AND pt.isleaf
+      JOIN pg_namespace ln ON ln.oid = lc.relnamespace
+      WHERE pc.relkind = 'p' AND pn.nspname IN (%s)
+    $q$, schlist)) AS r(parent_nsp text, parent_tab text, leaf_nsp text, leaf_tab text)
+  LOOP
+    leaf_fq := format('%I.%I', leaf.leaf_nsp, leaf.leaf_tab);
+    IF to_regclass(leaf_fq) IS NULL THEN
+      problems := problems || format('%I.%I (partition %s missing locally)',
+                    leaf.parent_nsp, leaf.parent_tab, leaf_fq);
+    ELSIF NOT EXISTS (
+      SELECT 1 FROM gfs.clone_source WHERE relid = leaf_fq::regclass
+    ) THEN
+      problems := problems || format('%I.%I (partition %s not registered for copy-on-read; it likely lacks a usable unique key)',
+                    leaf.parent_nsp, leaf.parent_tab, leaf_fq);
+    END IF;
+  END LOOP;
+
+  IF array_length(problems, 1) > 0 THEN
+    RAISE EXCEPTION 'gfs: partitioned table(s) did not fully round-trip onto the clone: %. Refusing to leave them silently empty.',
+      array_to_string(problems, '; ');
+  END IF;
+END
+$fn$;
+
+-- Bug B safeguard: a source table with no usable unique key is skipped by the keycol
+-- query in clone() (it needs a unique, non-partial, non-expression index), so it is
+-- never registered for copy-on-read and would be a SILENT empty heap on the clone
+-- (data loss, no error). Assert every ordinary (non-partition) source table is locally
+-- present AND registered; any gap RAISEs (fatal under ON_ERROR_STOP), naming the table.
+-- Leaf partitions are covered by verify_partitions. NOTE: until keyless whole-table
+-- hydration lands in the gfs extension, a primary-key-less table fails the clone loudly
+-- here rather than silently losing its rows.
+CREATE OR REPLACE FUNCTION gfs_sync.verify_tables_registered(p_conn text, p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  schlist  text;
+  t        record;
+  fq       text;
+  problems text[] := ARRAY[]::text[];
+BEGIN
+  schlist := (SELECT string_agg(quote_literal(x), ', ') FROM unnest(p_schemas) AS x);
+  FOR t IN SELECT * FROM dblink(p_conn, format($q$
+      SELECT n.nspname::text AS nsp, c.relname::text AS tab
+      FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'r' AND NOT c.relispartition AND n.nspname IN (%s)
+    $q$, schlist)) AS r(nsp text, tab text)
+  LOOP
+    fq := format('%I.%I', t.nsp, t.tab);
+    IF to_regclass(fq) IS NULL THEN
+      problems := problems || format('%s (missing locally)', fq);
+    ELSIF NOT EXISTS (SELECT 1 FROM gfs.clone_source WHERE relid = fq::regclass) THEN
+      problems := problems || format('%s (no usable unique key -> not registered for copy-on-read; would silently return no rows)', fq);
+    END IF;
+  END LOOP;
+  IF array_length(problems, 1) > 0 THEN
+    RAISE EXCEPTION 'gfs: source table(s) did not register for copy-on-read onto the clone: %. Refusing to leave them silently empty.',
+      array_to_string(problems, '; ');
+  END IF;
+END
+$fn$;
+
+-- Bug C: the faithful pg_dump replay re-creates materialized views but leaves them
+-- unpopulated, so reading one errors "has not been populated". Refresh each local
+-- matview now that its base tables are registered for copy-on-read (the refresh reads
+-- the base tables, hydrating them). Two passes so a matview defined over another matview
+-- can still populate; a final failure warns rather than aborting the clone.
+CREATE OR REPLACE FUNCTION gfs_sync.refresh_matviews(p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  mv       record;
+  base     record;
+  pass     int := 0;
+  progress boolean := true;
+BEGIN
+  -- Progress-based multi-pass (bounded): a matview built on another matview
+  -- populates on a later pass once its dependency has. Stop as soon as a pass
+  -- populates nothing new; cap at 20 as a termination backstop. (A fixed 2 passes
+  -- only covers a single level of matview-on-matview; the progress loop covers
+  -- arbitrarily deep chains.)
+  WHILE progress AND pass < 20 LOOP
+    progress := false;
+    pass := pass + 1;
+    FOR mv IN
+      SELECT schemaname, matviewname,
+             format('%I.%I', schemaname, matviewname)::regclass AS oid
+      FROM pg_matviews
+      WHERE schemaname = ANY(p_schemas) AND NOT ispopulated
+    LOOP
+      BEGIN
+        -- A matview on a lazy clone reads copy-on-read base tables that are not yet
+        -- materialized at bootstrap, so a bare REFRESH populates it from ZERO rows
+        -- (ispopulated=t but empty -- silently wrong). Fully materialize every
+        -- registered clone table this matview depends on (gfs.warm = committed FDW
+        -- copy; covers direct bases AND partition leaves) BEFORE the REFRESH so it
+        -- computes over real data.
+        FOR base IN
+          SELECT DISTINCT cs.relid::regclass AS rel
+          FROM pg_depend d
+          JOIN pg_rewrite rw ON rw.oid = d.objid AND rw.ev_class = mv.oid
+          JOIN gfs.clone_source cs
+            ON cs.relid = d.refobjid
+            OR cs.relid IN (SELECT inhrelid FROM pg_inherits WHERE inhparent = d.refobjid)
+          WHERE d.refclassid = 'pg_class'::regclass AND d.refobjid <> mv.oid
+        LOOP
+          PERFORM gfs.warm(base.rel);
+        END LOOP;
+        EXECUTE format('REFRESH MATERIALIZED VIEW %I.%I', mv.schemaname, mv.matviewname);
+        progress := true;   -- populated one; a later pass may now unblock a dependent
+      EXCEPTION WHEN OTHERS THEN
+        NULL;  -- not yet (e.g. a dependency matview still empty); retried next pass
+      END;
+    END LOOP;
+  END LOOP;
+  -- Anything still unpopulated after the loop warns loudly (base unavailable or the
+  -- definition failed) but does NOT abort the clone -- that matview just keeps the
+  -- pre-fix "REFRESH it manually" behavior.
+  FOR mv IN
+    SELECT schemaname, matviewname FROM pg_matviews
+    WHERE schemaname = ANY(p_schemas) AND NOT ispopulated
+  LOOP
+    RAISE WARNING 'gfs: could not populate materialized view %.% (REFRESH it manually)', mv.schemaname, mv.matviewname;
+  END LOOP;
+END
+$fn$;
+
 CREATE OR REPLACE FUNCTION gfs_sync.clone(p_conn text, p_schemas text[])
 RETURNS void
 LANGUAGE plpgsql AS $fn$
@@ -292,6 +497,25 @@ BEGIN
     -- aborted.
     PERFORM gfs_sync.build_clone(rec.nsp, rec.tab, rec.keycols);
   END LOOP;
+
+  -- Inherit each local sequence's current position from the source so the clone
+  -- does not restart serial/identity/standalone sequences at 1 and collide with
+  -- already-materialized rows. Runs after the tables (and their owned sequences)
+  -- exist from the faithful replay.
+  PERFORM gfs_sync.replicate_sequences(p_conn, target_schemas);
+
+  -- Bug B safeguard: every ordinary source table must register for copy-on-read; a
+  -- table with no usable unique key would otherwise be a silent empty heap. Fail loud.
+  PERFORM gfs_sync.verify_tables_registered(p_conn, target_schemas);
+
+  -- Fail loudly if any partitioned table did not fully round-trip (a leaf missing
+  -- locally or not registered for copy-on-read), so a partitioned table is never
+  -- silently dropped from the clone. Runs last, after every table is registered.
+  PERFORM gfs_sync.verify_partitions(p_conn, target_schemas);
+
+  -- Bug C: populate materialized views (created empty by the faithful replay) now that
+  -- their base tables are registered for copy-on-read.
+  PERFORM gfs_sync.refresh_matviews(target_schemas);
 END
 $fn$;
 

--- a/crates/extensions/gfs/src/hydrate.rs
+++ b/crates/extensions/gfs/src/hydrate.rs
@@ -55,6 +55,27 @@ unsafe fn spi_cell1() -> Option<String> {
     spi_text(pg_sys::SPI_getvalue(row, (*tt).tupdesc, 1))
 }
 
+/// `OVERRIDING SYSTEM VALUE ` when the local clone table has a GENERATED ALWAYS AS
+/// IDENTITY column, else empty. Such a column rejects an explicit value on a plain
+/// INSERT, so every hydration INSERT must carry this clause to write the SOURCE's
+/// own key value (a faithful copy keeps the source key, never a fresh local
+/// sequence value). Identity columns are `attidentity = 'a'` (always); `'d'` (by
+/// default) already accepts explicit values without the clause, so only `'a'` needs
+/// it. Caller holds an open SPI connection.
+unsafe fn overriding_clause(local_ref: &str) -> &'static str {
+    let q = CString::new(format!(
+        "SELECT EXISTS(SELECT 1 FROM pg_attribute WHERE attrelid = '{}'::regclass AND attidentity = 'a')::int::text",
+        local_ref.replace('\'', "''")
+    ))
+    .unwrap();
+    if pg_sys::SPI_execute(q.as_ptr(), true, 1) == pg_sys::SPI_OK_SELECT as i32
+        && spi_cell1().as_deref() == Some("1")
+    {
+        return "OVERRIDING SYSTEM VALUE ";
+    }
+    ""
+}
+
 /// Fan a large whole/int-range backfill over N concurrent dblink scans against the
 /// source -- CTID-block partitioning for a whole table (no usable key -> heap scan),
 /// key-range split for an int range (indexed key) -- instead of one FDW cursor. The
@@ -65,7 +86,7 @@ unsafe fn spi_cell1() -> Option<String> {
 /// ON CONFLICT DO NOTHING, so a fallback after a partial fan is idempotent/harmless.
 /// Read-only on the source; no replication slot. dblink reuses the existing FDW
 /// server `gfs_remote_srv` (+ its PUBLIC user mapping) -- no new connstr/secret.
-unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool) -> Option<i64> {
+unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str) -> Option<i64> {
     // --- knobs + source size estimate + dblink availability (one row) ---
     let q = CString::new(format!(
         "SELECT x.parallel_workers::text, x.parallel_min_pages::text, x.parallel_min_frac::text, \
@@ -202,8 +223,8 @@ unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool) -> Option<i64> {
     for k in 0..m {
         let conn = format!("gfs_bf_{}_{}", u32::from(h.relid), k);
         let ins = CString::new(format!(
-            "INSERT INTO {l} ({c}) SELECT {c} FROM dblink_get_result('{conn}') AS t({cd}) WHERE true{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, conn = conn, cd = coldef, excl = excl_t
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM dblink_get_result('{conn}') AS t({cd}) WHERE true{excl} ON CONFLICT DO NOTHING",
+            l = h.local_ref, c = h.collist, conn = conn, cd = coldef, excl = excl_t, ov = overriding
         )).unwrap();
         if pg_sys::SPI_execute(ins.as_ptr(), false, 0) == pg_sys::SPI_OK_INSERT as i32 {
             total += pg_sys::SPI_processed as i64;
@@ -256,6 +277,11 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         }
     };
 
+    // A GENERATED ALWAYS AS IDENTITY column rejects an explicit value on a plain
+    // INSERT; every materialization INSERT below carries this clause (when present)
+    // so the source's own key value is copied faithfully, not regenerated locally.
+    let overriding = overriding_clause(&h.local_ref);
+
     // PARTIAL: pull the matching slice with a HARD cap and self-validate against
     // REALITY (not an estimate). One source contact. `matched` (LIMIT cap+1) tells
     // us whether the source had MORE than the cap of matching rows: if so the slice
@@ -266,9 +292,9 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         let cap = h.partial_cap.max(0);
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
-                  ins AS (INSERT INTO {l} ({c}) SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
+                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
              SELECT (SELECT count(*) FROM picked)::int8::text, (SELECT count(*) FROM ins)::int8::text",
-            c = h.collist, s = src, w = h.where_sql, excl = excl, l = h.local_ref, lim = cap + 1
+            c = h.collist, s = src, w = h.where_sql, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding
         );
         let q = CString::new(sql).unwrap();
         let (mut matched, mut inserted) = (0i64, 0i64);
@@ -330,9 +356,9 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         let where_clause = if conds.is_empty() { "true".to_string() } else { conds.join(" AND ") };
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
-                  ins AS (INSERT INTO {l} ({c}) SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
+                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
              SELECT (SELECT count(*) FROM picked)::int8::text, (SELECT count(*) FROM ins)::int8::text",
-            c = h.collist, s = src, w = where_clause, excl = excl, l = h.local_ref, lim = cap + 1
+            c = h.collist, s = src, w = where_clause, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding
         );
         let q = CString::new(sql).unwrap();
         let (mut matched, mut inserted) = (0i64, 0i64);
@@ -359,20 +385,20 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     // split via concurrent dblink scans); fall back to one FDW statement on any
     // ineligibility or setup failure. ON CONFLICT DO NOTHING keeps both paths
     // idempotent, so a fallback after a partial fan is safe.
-    if let Some(n) = try_parallel_backfill(h, !excl.is_empty()) {
+    if let Some(n) = try_parallel_backfill(h, !excl.is_empty(), overriding) {
         record_whole_or_range(h, n);
         pg_sys::SPI_finish();
         return true;
     }
     let sql = if h.whole {
         format!(
-            "INSERT INTO {l} ({c}) SELECT {c} FROM {s} WHERE true{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src, excl = excl
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE true{excl} ON CONFLICT DO NOTHING",
+            l = h.local_ref, c = h.collist, s = src, excl = excl, ov = overriding
         )
     } else {
         format!(
-            "INSERT INTO {l} ({c}) SELECT {c} FROM {s} WHERE {k} BETWEEN {lo} AND {hi}{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src, k = h.key_col, lo = h.lo, hi = h.hi, excl = excl
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE {k} BETWEEN {lo} AND {hi}{excl} ON CONFLICT DO NOTHING",
+            l = h.local_ref, c = h.collist, s = src, k = h.key_col, lo = h.lo, hi = h.hi, excl = excl, ov = overriding
         )
     };
     let q = CString::new(sql).unwrap();

--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -280,7 +280,7 @@ $$;
 -- the source, even aggregates).
 CREATE FUNCTION gfs.warm(local regclass)
 RETURNS bigint LANGUAGE plpgsql AS $$
-DECLARE src text; cols text; n bigint;
+DECLARE src text; cols text; ov text; n bigint;
 BEGIN
     SELECT source_ref INTO src FROM gfs.clone_source WHERE relid = local;
     IF src IS NULL OR to_regclass(src) IS NULL THEN
@@ -289,12 +289,17 @@ BEGIN
     SELECT string_agg(quote_ident(attname), ', ' ORDER BY attnum) INTO cols
       FROM pg_attribute
      WHERE attrelid = local AND attnum > 0 AND NOT attisdropped AND attgenerated = '';
+    -- A GENERATED ALWAYS AS IDENTITY column rejects an explicit value on a plain
+    -- INSERT; OVERRIDING SYSTEM VALUE lets us copy the source's own key faithfully.
+    SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_attribute
+                              WHERE attrelid = local AND attidentity = 'a')
+                THEN 'OVERRIDING SYSTEM VALUE ' ELSE '' END INTO ov;
     -- Exclude locally-deleted rows so warming never resurrects a copy-on-write DELETE.
-    EXECUTE format('INSERT INTO %s (%s) SELECT %s FROM %s s
+    EXECUTE format('INSERT INTO %s (%s) %sSELECT %s FROM %s s
                     WHERE NOT EXISTS (SELECT 1 FROM gfs.tombstone tb
                                        WHERE tb.relid = %L::regclass AND to_jsonb(s) @> tb.pk)
                     ON CONFLICT DO NOTHING',
-                   local::text, cols, cols, src, local::text);
+                   local::text, cols, ov, cols, src, local::text);
     GET DIAGNOSTICS n = ROW_COUNT;
     EXECUTE format('ANALYZE %s', local::text);
     UPDATE gfs.clone_source SET whole_cached = true WHERE relid = local;


### PR DESCRIPTION
# 🐛 Fix: carry stateful objects onto lazy clones + fail loud on keyless tables

## Related Issue

Closes https://github.com/Guepard-Corp/gfs/issues/105

## What

A lazy clone replays the source schema with `pg_dump --schema-only` and copies
base-table rows on read. That correctly handles ordinary tables, but it silently
**drops several kinds of state a full copy carries**, and **silently loses tables it
cannot key**. The result: the clone looks fine on read-only exploration but breaks
the moment you write to it or touch a derived object.

Concretely, on a clone today:

- **Auto-increment inserts collide.** `SERIAL` / `IDENTITY` sequences restart at 1 while
  the rows (ids 1,2,3,…) arrive via copy-on-read, so the first `INSERT` fails with
  `duplicate key value violates unique constraint`. This breaks the primary "write to
  the clone" use case for the most common table design.
- **Materialized views error on read.** The schema replay creates them `WITH NO DATA`,
  so `SELECT` returns `materialized view "x" has not been populated`.
- **`GENERATED ALWAYS AS IDENTITY` tables error on read.** Copy-on-read inserts the
  source's key values, which such a column rejects without `OVERRIDING SYSTEM VALUE`.
- **Keyless tables return zero rows, silently.** A table with no usable unique key is
  never registered for copy-on-read and reads as an empty local heap — no error, no
  warning. This is the most dangerous case: wrong data with no signal.

## How

All changes live in the clone bootstrap (`clone_bootstrap.sql`, run against the fresh
clone) and the extension's hydration path. Four additions:

- **`replicate_sequences`** — reads each source sequence's `last_value` / `is_called`
  over the FDW and `setval`s the local sequence to match, so `SERIAL` / `IDENTITY` /
  standalone sequences resume from the source position instead of restarting at 1.
- **`refresh_matviews`** — populates each materialized view by first `gfs.warm`-ing its
  base tables (a committed FDW copy, so the `REFRESH` computes over real data rather than
  the not-yet-materialized copy-on-read heaps) then `REFRESH`ing. A **progress-based
  multi-pass** loop populates matviews built on other matviews at any chain depth.
- **`verify_tables_registered` / `verify_partitions`** — after registration, assert every
  ordinary table and every partition leaf is present **and** registered for copy-on-read.
  Any gap `RAISE`s (fatal under `ON_ERROR_STOP`), naming the offending table, so a keyless
  table **fails the clone loudly** instead of becoming a silent empty heap.
- **`hydrate` / `gfs.warm`** — emit `OVERRIDING SYSTEM VALUE` when a target column is
  `GENERATED ALWAYS AS IDENTITY`, so those rows hydrate the source's own key values
  instead of erroring.

**Design notes / trade-offs:**
- The keyless case is a deliberate *fail-loud* policy: refusing to clone beats silently
  returning no rows. Until keyless whole-table hydration lands in the extension, a
  primary-key-less table fails the clone rather than losing its rows.
- Matviews are populated eagerly at clone time (same as a `pg_dump` full restore, which
  emits `REFRESH`). For a matview over a very large fact table this warms its base tables
  at clone time; that's the cost of full-copy parity.
- `has_local_writes` (the local-writes federation guard) is preserved unchanged.

## Review Guide

1. `crates/adapters/compute-docker/src/containers/clone_bootstrap.sql` — the four new
   `gfs_sync.*` functions and their call sites at the end of `gfs_sync.clone()`. Start here.
2. `crates/extensions/gfs/src/sql/schema.sql` — `gfs.warm` gains the `OVERRIDING SYSTEM
   VALUE` clause (identity-aware).
3. `crates/extensions/gfs/src/hydrate.rs` — the same clause threaded through every
   hydration `INSERT` (partial, whole, range, parallel backfill), gated on
   `attidentity = 'a'`.

## Testing

Validated end-to-end against freshly built CLI + `gfs-postgres:16` image, source vs clone:

- [x] Manual testing performed
- [x] E2E scenarios covered:
  - Incremental inserts continue past existing ids for `SERIAL`, `GENERATED BY DEFAULT`,
    and `GENERATED ALWAYS` (all return the next id, no collision).
  - Materialized views populated at clone time and equal to source, including a 3-level
    `mv←mv←mv` chain, a selective-filter matview, and a matview over a JOIN.
  - Partitioned parents return data; keyless tables fail the clone with a clear message.
  - `GENERATED ALWAYS` tables read correctly (source key values copied).
  - Write semantics: local INSERT/UPDATE/DELETE reflected on the clone, deleted rows not
    resurrected, **source untouched** throughout.
  - Broad consistency sweep (54 checks): composite/text/uuid/bigint/unique keys, enum /
    domain / composite types, arrays, date/time, generated columns, NULLs, unicode &
    special-character data, quoted identifiers, non-public schemas, foreign keys (dropped
    by design, joins still correct), and range/selective/whole hydration — all clone == source.
- [ ] `cargo test` / `cargo clippy` / `cargo fmt --check` — to run in CI before merge.

## Documentation

- [x] Code comments added for each new function and the identity clause
- [ ] README / docs update (follow-up if we want to document clone fidelity guarantees)
- [ ] CHANGELOG.md (n/a in this repo)

## User Impact

- Writing to a clone now works for auto-increment tables (no first-insert collision).
- Materialized views and `GENERATED ALWAYS` identity tables are usable on the clone
  without a manual `REFRESH` or errors.
- A clone that would have silently lost a keyless table now fails fast with the table
  name, so data loss is caught at clone time instead of read time.
- No breaking changes for existing clones; tables without matviews/identity/keyless edge
  cases behave exactly as before. `has_local_writes` behavior is unchanged.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests pass locally (`cargo test`)
- [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [ ] Format check passes (`cargo fmt --check`)
- [x] This PR can be safely reverted if needed (additive; existing clone path unchanged)

Co-authored-by: medazizktata25 <mohamedaziz.ktata@guepard.run>
