### PR TITLE
Fix/clone issues 107 108 109

### DIFF
--- a/crates/adapters/compute-docker/src/containers/clone_bootstrap.sql
+++ b/crates/adapters/compute-docker/src/containers/clone_bootstrap.sql
@@ -242,6 +242,211 @@ BEGIN
 END
 $fn$;
 
+-- Replicate each local sequence's CURRENT POSITION from the source. The faithful
+-- schema replay (`pg_dump --schema-only`) emits `CREATE SEQUENCE` but NOT the
+-- sequence position (`setval` lives in pg_dump's data section, which a schema-only
+-- dump omits), so every local sequence restarts at its initial value (typically 1).
+-- A source serial/identity/standalone sequence advanced past its start would then
+-- hand out values that COLLIDE with rows already materialized on the clone. For
+-- each local sequence (relkind='S' — catches serial-owned, identity-owned, and
+-- standalone sequences) we read the matching source sequence's `last_value` and
+-- `is_called` straight off the sequence relation via dblink (NOT pg_sequences,
+-- whose last_value is NULL/permission-sensitive) and setval() the local one to
+-- match. Per-sequence failures warn loudly rather than abort: a clone with one
+-- un-synced sequence is recoverable; an aborted clone is not. A sequence absent on
+-- the source (local-only) is simply skipped.
+CREATE OR REPLACE FUNCTION gfs_sync.replicate_sequences(p_conn text, p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  seqrec record;
+  src    record;
+  fq     text;
+BEGIN
+  FOR seqrec IN
+    SELECT n.nspname::text AS nsp, c.relname::text AS seq
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'S' AND n.nspname = ANY (p_schemas)
+  LOOP
+    fq := format('%I.%I', seqrec.nsp, seqrec.seq);
+    BEGIN
+      -- Read the source sequence's current state directly off the relation. A
+      -- regclass cast on the source guards a sequence that exists locally but not
+      -- remotely: dblink raises, we catch and skip below.
+      SELECT * INTO src FROM dblink(p_conn, format(
+          'SELECT last_value, is_called FROM %s', fq))
+        AS r(last_value bigint, is_called boolean);
+      IF src.last_value IS NOT NULL THEN
+        PERFORM setval(fq::regclass, src.last_value, src.is_called);
+      END IF;
+    EXCEPTION WHEN others THEN
+      RAISE WARNING 'gfs: could not replicate sequence value for % (%): inserts on the clone may collide with materialized rows', fq, SQLERRM;
+    END;
+  END LOOP;
+END
+$fn$;
+
+-- Safeguard: a partitioned table must NEVER be silently dropped from the clone.
+-- A partitioned PARENT (relkind='p') holds no rows and is skipped by the table
+-- enumeration and the copy-on-read registration (both relkind='r'); it needs no
+-- registration of its own because the faithful replay re-creates it and a query on
+-- the parent prunes to its leaf partitions. Each LEAF partition (relkind='r') is an
+-- ordinary table that the relkind='r' path above imports and registers like any
+-- other table — that is how copy-on-read is wired for partitions. The risk is a
+-- leaf that does NOT round-trip: it has no usable unique key (so the keycol query
+-- skips it), or it failed to import / replay. The current code would leave that
+-- leaf as an empty, unregistered local heap and the clone would silently return no
+-- rows for that slice of the partitioned table. This function enumerates the
+-- SOURCE's partitioned tables and their leaf partitions (pg_partition_tree, so it
+-- also covers multi-level subpartitions), then asserts every leaf is locally
+-- present AND registered as a copy-on-read clone. Any gap RAISEs (fatal under
+-- ON_ERROR_STOP) naming the offending partitioned table, so a partitioned table is
+-- never silently dropped — it either round-trips fully or fails the clone loudly.
+CREATE OR REPLACE FUNCTION gfs_sync.verify_partitions(p_conn text, p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  schlist  text;
+  leaf     record;
+  leaf_fq  text;
+  problems text[] := ARRAY[]::text[];
+BEGIN
+  schlist := (SELECT string_agg(quote_literal(x), ', ') FROM unnest(p_schemas) AS x);
+
+  FOR leaf IN SELECT * FROM dblink(p_conn, format($q$
+      SELECT pn.nspname::text AS parent_nsp, pc.relname::text AS parent_tab,
+             ln.nspname::text AS leaf_nsp,   lc.relname::text AS leaf_tab
+      FROM pg_class pc
+      JOIN pg_namespace pn ON pn.oid = pc.relnamespace
+      CROSS JOIN LATERAL pg_partition_tree(pc.oid) pt
+      JOIN pg_class lc     ON lc.oid = pt.relid AND pt.isleaf
+      JOIN pg_namespace ln ON ln.oid = lc.relnamespace
+      WHERE pc.relkind = 'p' AND pn.nspname IN (%s)
+    $q$, schlist)) AS r(parent_nsp text, parent_tab text, leaf_nsp text, leaf_tab text)
+  LOOP
+    leaf_fq := format('%I.%I', leaf.leaf_nsp, leaf.leaf_tab);
+    IF to_regclass(leaf_fq) IS NULL THEN
+      problems := problems || format('%I.%I (partition %s missing locally)',
+                    leaf.parent_nsp, leaf.parent_tab, leaf_fq);
+    ELSIF NOT EXISTS (
+      SELECT 1 FROM gfs.clone_source WHERE relid = leaf_fq::regclass
+    ) THEN
+      problems := problems || format('%I.%I (partition %s not registered for copy-on-read; it likely lacks a usable unique key)',
+                    leaf.parent_nsp, leaf.parent_tab, leaf_fq);
+    END IF;
+  END LOOP;
+
+  IF array_length(problems, 1) > 0 THEN
+    RAISE EXCEPTION 'gfs: partitioned table(s) did not fully round-trip onto the clone: %. Refusing to leave them silently empty.',
+      array_to_string(problems, '; ');
+  END IF;
+END
+$fn$;
+
+-- Bug B safeguard: a source table with no usable unique key is skipped by the keycol
+-- query in clone() (it needs a unique, non-partial, non-expression index), so it is
+-- never registered for copy-on-read and would be a SILENT empty heap on the clone
+-- (data loss, no error). Assert every ordinary (non-partition) source table is locally
+-- present AND registered; any gap RAISEs (fatal under ON_ERROR_STOP), naming the table.
+-- Leaf partitions are covered by verify_partitions. NOTE: until keyless whole-table
+-- hydration lands in the gfs extension, a primary-key-less table fails the clone loudly
+-- here rather than silently losing its rows.
+CREATE OR REPLACE FUNCTION gfs_sync.verify_tables_registered(p_conn text, p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  schlist  text;
+  t        record;
+  fq       text;
+  problems text[] := ARRAY[]::text[];
+BEGIN
+  schlist := (SELECT string_agg(quote_literal(x), ', ') FROM unnest(p_schemas) AS x);
+  FOR t IN SELECT * FROM dblink(p_conn, format($q$
+      SELECT n.nspname::text AS nsp, c.relname::text AS tab
+      FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'r' AND NOT c.relispartition AND n.nspname IN (%s)
+    $q$, schlist)) AS r(nsp text, tab text)
+  LOOP
+    fq := format('%I.%I', t.nsp, t.tab);
+    IF to_regclass(fq) IS NULL THEN
+      problems := problems || format('%s (missing locally)', fq);
+    ELSIF NOT EXISTS (SELECT 1 FROM gfs.clone_source WHERE relid = fq::regclass) THEN
+      problems := problems || format('%s (no usable unique key -> not registered for copy-on-read; would silently return no rows)', fq);
+    END IF;
+  END LOOP;
+  IF array_length(problems, 1) > 0 THEN
+    RAISE EXCEPTION 'gfs: source table(s) did not register for copy-on-read onto the clone: %. Refusing to leave them silently empty.',
+      array_to_string(problems, '; ');
+  END IF;
+END
+$fn$;
+
+-- Bug C: the faithful pg_dump replay re-creates materialized views but leaves them
+-- unpopulated, so reading one errors "has not been populated". Refresh each local
+-- matview now that its base tables are registered for copy-on-read (the refresh reads
+-- the base tables, hydrating them). Two passes so a matview defined over another matview
+-- can still populate; a final failure warns rather than aborting the clone.
+CREATE OR REPLACE FUNCTION gfs_sync.refresh_matviews(p_schemas text[])
+RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  mv       record;
+  base     record;
+  pass     int := 0;
+  progress boolean := true;
+BEGIN
+  -- Progress-based multi-pass (bounded): a matview built on another matview
+  -- populates on a later pass once its dependency has. Stop as soon as a pass
+  -- populates nothing new; cap at 20 as a termination backstop. (A fixed 2 passes
+  -- only covers a single level of matview-on-matview; the progress loop covers
+  -- arbitrarily deep chains.)
+  WHILE progress AND pass < 20 LOOP
+    progress := false;
+    pass := pass + 1;
+    FOR mv IN
+      SELECT schemaname, matviewname,
+             format('%I.%I', schemaname, matviewname)::regclass AS oid
+      FROM pg_matviews
+      WHERE schemaname = ANY(p_schemas) AND NOT ispopulated
+    LOOP
+      BEGIN
+        -- A matview on a lazy clone reads copy-on-read base tables that are not yet
+        -- materialized at bootstrap, so a bare REFRESH populates it from ZERO rows
+        -- (ispopulated=t but empty -- silently wrong). Fully materialize every
+        -- registered clone table this matview depends on (gfs.warm = committed FDW
+        -- copy; covers direct bases AND partition leaves) BEFORE the REFRESH so it
+        -- computes over real data.
+        FOR base IN
+          SELECT DISTINCT cs.relid::regclass AS rel
+          FROM pg_depend d
+          JOIN pg_rewrite rw ON rw.oid = d.objid AND rw.ev_class = mv.oid
+          JOIN gfs.clone_source cs
+            ON cs.relid = d.refobjid
+            OR cs.relid IN (SELECT inhrelid FROM pg_inherits WHERE inhparent = d.refobjid)
+          WHERE d.refclassid = 'pg_class'::regclass AND d.refobjid <> mv.oid
+        LOOP
+          PERFORM gfs.warm(base.rel);
+        END LOOP;
+        EXECUTE format('REFRESH MATERIALIZED VIEW %I.%I', mv.schemaname, mv.matviewname);
+        progress := true;   -- populated one; a later pass may now unblock a dependent
+      EXCEPTION WHEN OTHERS THEN
+        NULL;  -- not yet (e.g. a dependency matview still empty); retried next pass
+      END;
+    END LOOP;
+  END LOOP;
+  -- Anything still unpopulated after the loop warns loudly (base unavailable or the
+  -- definition failed) but does NOT abort the clone -- that matview just keeps the
+  -- pre-fix "REFRESH it manually" behavior.
+  FOR mv IN
+    SELECT schemaname, matviewname FROM pg_matviews
+    WHERE schemaname = ANY(p_schemas) AND NOT ispopulated
+  LOOP
+    RAISE WARNING 'gfs: could not populate materialized view %.% (REFRESH it manually)', mv.schemaname, mv.matviewname;
+  END LOOP;
+END
+$fn$;
+
 CREATE OR REPLACE FUNCTION gfs_sync.clone(p_conn text, p_schemas text[])
 RETURNS void
 LANGUAGE plpgsql AS $fn$
@@ -292,6 +497,25 @@ BEGIN
     -- aborted.
     PERFORM gfs_sync.build_clone(rec.nsp, rec.tab, rec.keycols);
   END LOOP;
+
+  -- Inherit each local sequence's current position from the source so the clone
+  -- does not restart serial/identity/standalone sequences at 1 and collide with
+  -- already-materialized rows. Runs after the tables (and their owned sequences)
+  -- exist from the faithful replay.
+  PERFORM gfs_sync.replicate_sequences(p_conn, target_schemas);
+
+  -- Bug B safeguard: every ordinary source table must register for copy-on-read; a
+  -- table with no usable unique key would otherwise be a silent empty heap. Fail loud.
+  PERFORM gfs_sync.verify_tables_registered(p_conn, target_schemas);
+
+  -- Fail loudly if any partitioned table did not fully round-trip (a leaf missing
+  -- locally or not registered for copy-on-read), so a partitioned table is never
+  -- silently dropped from the clone. Runs last, after every table is registered.
+  PERFORM gfs_sync.verify_partitions(p_conn, target_schemas);
+
+  -- Bug C: populate materialized views (created empty by the faithful replay) now that
+  -- their base tables are registered for copy-on-read.
+  PERFORM gfs_sync.refresh_matviews(target_schemas);
 END
 $fn$;
 

--- a/crates/adapters/compute-docker/src/containers/clone_bootstrap.sql
+++ b/crates/adapters/compute-docker/src/containers/clone_bootstrap.sql
@@ -345,7 +345,8 @@ END
 $fn$;
 
 -- Bug B safeguard: a source table with no usable unique key is skipped by the keycol
--- query in clone() (it needs a unique, non-partial, non-expression index), so it is
+-- query in clone() (it needs a unique, non-deferrable, non-partial, non-expression
+-- index -- a DEFERRABLE-only table cannot arbitrate the hydration inserts), so it is
 -- never registered for copy-on-read and would be a SILENT empty heap on the clone
 -- (data loss, no error). Assert every ordinary (non-partition) source table is locally
 -- present AND registered; any gap RAISEs (fatal under ON_ERROR_STOP), naming the table.
@@ -372,7 +373,7 @@ BEGIN
     IF to_regclass(fq) IS NULL THEN
       problems := problems || format('%s (missing locally)', fq);
     ELSIF NOT EXISTS (SELECT 1 FROM gfs.clone_source WHERE relid = fq::regclass) THEN
-      problems := problems || format('%s (no usable unique key -> not registered for copy-on-read; would silently return no rows)', fq);
+      problems := problems || format('%s (no usable unique key -- needs a unique, non-deferrable, non-partial, non-expression index -> not registered for copy-on-read; would silently return no rows)', fq);
     END IF;
   END LOOP;
   IF array_length(problems, 1) > 0 THEN
@@ -486,7 +487,7 @@ BEGIN
         JOIN pg_class c     ON c.oid = i.indrelid
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname IN (%s) AND c.relkind = 'r'
-          AND i.indisunique AND i.indpred IS NULL AND 0 <> ALL (i.indkey::int[])
+          AND i.indisunique AND i.indimmediate AND i.indpred IS NULL AND 0 <> ALL (i.indkey::int[])
       ) s WHERE rn = 1
     $q$, schlist)) AS r(nsp text, tab text, keycols text[])
   LOOP

--- a/crates/extensions/gfs/src/catalog.rs
+++ b/crates/extensions/gfs/src/catalog.rs
@@ -144,6 +144,31 @@ pub(crate) unsafe fn bump_access(relid: pg_sys::Oid) {
     pg_sys::SPI_finish();
 }
 
+/// True when `relid` is a plain-table inheritance parent (pg_inherits, relkind 'r').
+/// The clone's schema replay mirrors the source's INHERITS hierarchy, so this equals
+/// "the source table has INHERITS children". Own SPI connection (planner-hook safe).
+pub(crate) unsafe fn gfs_has_children(relid: pg_sys::Oid) -> bool {
+    if pg_sys::SPI_connect() != pg_sys::SPI_OK_CONNECT as i32 {
+        return false;
+    }
+    let q = CString::new(format!(
+        "SELECT EXISTS(SELECT 1 FROM pg_inherits i JOIN pg_class c ON c.oid = i.inhparent \
+          WHERE i.inhparent = {} AND c.relkind = 'r')::int::text",
+        u32::from(relid)
+    ))
+    .unwrap();
+    let mut has = false;
+    if pg_sys::SPI_execute(q.as_ptr(), true, 1) == pg_sys::SPI_OK_SELECT as i32
+        && pg_sys::SPI_processed == 1
+    {
+        let tt = pg_sys::SPI_tuptable;
+        let row = *(*tt).vals;
+        has = spi_text(pg_sys::SPI_getvalue(row, (*tt).tupdesc, 1)).as_deref() == Some("1");
+    }
+    pg_sys::SPI_finish();
+    has
+}
+
 pub(crate) unsafe fn gfs_source_oid(relid: pg_sys::Oid) -> Option<pg_sys::Oid> {
     if pg_sys::SPI_connect() != pg_sys::SPI_OK_CONNECT as i32 {
         return None;

--- a/crates/extensions/gfs/src/federate.rs
+++ b/crates/extensions/gfs/src/federate.rs
@@ -5,10 +5,54 @@ use core::ffi::c_char;
 use pgrx::pg_sys;
 use pgrx::PgList;
 
-use crate::catalog::{bump_federate, gfs_source_oid};
+use crate::catalog::{bump_federate, gfs_has_children, gfs_source_oid};
 
 pub(crate) unsafe fn swap_clone_rtes_to_foreign(query: *mut pg_sys::Query) -> i32 {
+    // `SELECT ... FROM ONLY parent` can never federate: postgres_fdw cannot deparse
+    // ONLY, so the remote scan would include the child rows the query explicitly
+    // excluded. Checked BEFORE any mutation (the caller re-plans this same Query
+    // after hydration, so a half-swapped tree must never leak out); on a hit the
+    // caller's fallback whole-hydrates locally, which is correct (hydration fetches
+    // ONLY-parent rows).
+    if has_only_parent_scan(query) {
+        return 0;
+    }
     swap_query(query)
+}
+
+// Does the query (or a nested subquery / CTE) scan a registered clone table with
+// `ONLY` (rte.inh = false) while that table has inheritance children?
+unsafe fn has_only_parent_scan(query: *mut pg_sys::Query) -> bool {
+    if query.is_null() {
+        return false;
+    }
+    for rte in PgList::<pg_sys::RangeTblEntry>::from_pg((*query).rtable).iter_ptr() {
+        if rte.is_null() {
+            continue;
+        }
+        match (*rte).rtekind {
+            pg_sys::RTEKind::RTE_RELATION => {
+                if !(*rte).inh
+                    && gfs_source_oid((*rte).relid).is_some()
+                    && gfs_has_children((*rte).relid)
+                {
+                    return true;
+                }
+            }
+            pg_sys::RTEKind::RTE_SUBQUERY => {
+                if has_only_parent_scan((*rte).subquery) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    for cte in PgList::<pg_sys::CommonTableExpr>::from_pg((*query).cteList).iter_ptr() {
+        if !cte.is_null() && has_only_parent_scan((*cte).ctequery as *mut pg_sys::Query) {
+            return true;
+        }
+    }
+    false
 }
 
 // Recursively rewrite clone-table RTEs -> foreign across the Query and its nested

--- a/crates/extensions/gfs/src/hydrate.rs
+++ b/crates/extensions/gfs/src/hydrate.rs
@@ -55,6 +55,27 @@ unsafe fn spi_cell1() -> Option<String> {
     spi_text(pg_sys::SPI_getvalue(row, (*tt).tupdesc, 1))
 }
 
+/// `OVERRIDING SYSTEM VALUE ` when the local clone table has a GENERATED ALWAYS AS
+/// IDENTITY column, else empty. Such a column rejects an explicit value on a plain
+/// INSERT, so every hydration INSERT must carry this clause to write the SOURCE's
+/// own key value (a faithful copy keeps the source key, never a fresh local
+/// sequence value). Identity columns are `attidentity = 'a'` (always); `'d'` (by
+/// default) already accepts explicit values without the clause, so only `'a'` needs
+/// it. Caller holds an open SPI connection.
+unsafe fn overriding_clause(local_ref: &str) -> &'static str {
+    let q = CString::new(format!(
+        "SELECT EXISTS(SELECT 1 FROM pg_attribute WHERE attrelid = '{}'::regclass AND attidentity = 'a')::int::text",
+        local_ref.replace('\'', "''")
+    ))
+    .unwrap();
+    if pg_sys::SPI_execute(q.as_ptr(), true, 1) == pg_sys::SPI_OK_SELECT as i32
+        && spi_cell1().as_deref() == Some("1")
+    {
+        return "OVERRIDING SYSTEM VALUE ";
+    }
+    ""
+}
+
 /// Fan a large whole/int-range backfill over N concurrent dblink scans against the
 /// source -- CTID-block partitioning for a whole table (no usable key -> heap scan),
 /// key-range split for an int range (indexed key) -- instead of one FDW cursor. The
@@ -65,7 +86,7 @@ unsafe fn spi_cell1() -> Option<String> {
 /// ON CONFLICT DO NOTHING, so a fallback after a partial fan is idempotent/harmless.
 /// Read-only on the source; no replication slot. dblink reuses the existing FDW
 /// server `gfs_remote_srv` (+ its PUBLIC user mapping) -- no new connstr/secret.
-unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool) -> Option<i64> {
+unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str) -> Option<i64> {
     // --- knobs + source size estimate + dblink availability (one row) ---
     let q = CString::new(format!(
         "SELECT x.parallel_workers::text, x.parallel_min_pages::text, x.parallel_min_frac::text, \
@@ -202,8 +223,8 @@ unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool) -> Option<i64> {
     for k in 0..m {
         let conn = format!("gfs_bf_{}_{}", u32::from(h.relid), k);
         let ins = CString::new(format!(
-            "INSERT INTO {l} ({c}) SELECT {c} FROM dblink_get_result('{conn}') AS t({cd}) WHERE true{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, conn = conn, cd = coldef, excl = excl_t
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM dblink_get_result('{conn}') AS t({cd}) WHERE true{excl} ON CONFLICT DO NOTHING",
+            l = h.local_ref, c = h.collist, conn = conn, cd = coldef, excl = excl_t, ov = overriding
         )).unwrap();
         if pg_sys::SPI_execute(ins.as_ptr(), false, 0) == pg_sys::SPI_OK_INSERT as i32 {
             total += pg_sys::SPI_processed as i64;
@@ -256,6 +277,11 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         }
     };
 
+    // A GENERATED ALWAYS AS IDENTITY column rejects an explicit value on a plain
+    // INSERT; every materialization INSERT below carries this clause (when present)
+    // so the source's own key value is copied faithfully, not regenerated locally.
+    let overriding = overriding_clause(&h.local_ref);
+
     // PARTIAL: pull the matching slice with a HARD cap and self-validate against
     // REALITY (not an estimate). One source contact. `matched` (LIMIT cap+1) tells
     // us whether the source had MORE than the cap of matching rows: if so the slice
@@ -266,9 +292,9 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         let cap = h.partial_cap.max(0);
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
-                  ins AS (INSERT INTO {l} ({c}) SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
+                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
              SELECT (SELECT count(*) FROM picked)::int8::text, (SELECT count(*) FROM ins)::int8::text",
-            c = h.collist, s = src, w = h.where_sql, excl = excl, l = h.local_ref, lim = cap + 1
+            c = h.collist, s = src, w = h.where_sql, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding
         );
         let q = CString::new(sql).unwrap();
         let (mut matched, mut inserted) = (0i64, 0i64);
@@ -330,9 +356,9 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         let where_clause = if conds.is_empty() { "true".to_string() } else { conds.join(" AND ") };
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
-                  ins AS (INSERT INTO {l} ({c}) SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
+                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
              SELECT (SELECT count(*) FROM picked)::int8::text, (SELECT count(*) FROM ins)::int8::text",
-            c = h.collist, s = src, w = where_clause, excl = excl, l = h.local_ref, lim = cap + 1
+            c = h.collist, s = src, w = where_clause, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding
         );
         let q = CString::new(sql).unwrap();
         let (mut matched, mut inserted) = (0i64, 0i64);
@@ -359,20 +385,20 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     // split via concurrent dblink scans); fall back to one FDW statement on any
     // ineligibility or setup failure. ON CONFLICT DO NOTHING keeps both paths
     // idempotent, so a fallback after a partial fan is safe.
-    if let Some(n) = try_parallel_backfill(h, !excl.is_empty()) {
+    if let Some(n) = try_parallel_backfill(h, !excl.is_empty(), overriding) {
         record_whole_or_range(h, n);
         pg_sys::SPI_finish();
         return true;
     }
     let sql = if h.whole {
         format!(
-            "INSERT INTO {l} ({c}) SELECT {c} FROM {s} WHERE true{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src, excl = excl
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE true{excl} ON CONFLICT DO NOTHING",
+            l = h.local_ref, c = h.collist, s = src, excl = excl, ov = overriding
         )
     } else {
         format!(
-            "INSERT INTO {l} ({c}) SELECT {c} FROM {s} WHERE {k} BETWEEN {lo} AND {hi}{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src, k = h.key_col, lo = h.lo, hi = h.hi, excl = excl
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE {k} BETWEEN {lo} AND {hi}{excl} ON CONFLICT DO NOTHING",
+            l = h.local_ref, c = h.collist, s = src, k = h.key_col, lo = h.lo, hi = h.hi, excl = excl, ov = overriding
         )
     };
     let q = CString::new(sql).unwrap();

--- a/crates/extensions/gfs/src/hydrate.rs
+++ b/crates/extensions/gfs/src/hydrate.rs
@@ -127,6 +127,53 @@ unsafe fn local_coldef(local_ref: &str) -> Option<String> {
     spi_cell1().filter(|s| !s.is_empty())
 }
 
+/// `ON CONFLICT ... DO NOTHING` clause for hydration inserts into `h.local_ref`.
+/// The target-less form asks Postgres to consider EVERY unique/exclusion constraint
+/// as a potential arbiter, and it refuses outright when any of them is DEFERRABLE
+/// ("ON CONFLICT does not support deferrable unique constraints/exclusion
+/// constraints as arbiters") -- the hydration insert would error and every read of
+/// the table would fail. For such tables, name an explicit arbiter: the columns of
+/// a non-deferrable (indimmediate), non-partial, non-expression unique index,
+/// preferring the primary key (registration guarantees one exists -- the bootstrap
+/// keycol query requires indimmediate). Hydration only needs to dedupe re-pulls of
+/// already-hydrated keys, and a re-pulled source row matches on ANY unique index,
+/// so a single arbiter suffices. Caller holds an open SPI connection.
+unsafe fn conflict_clause(h: &Hydration) -> String {
+    let lref = h.local_ref.replace('\'', "''");
+    let q = CString::new(format!(
+        "SELECT EXISTS(SELECT 1 FROM pg_constraint WHERE conrelid = '{}'::regclass \
+           AND contype IN ('p','u','x') AND condeferrable)::int::text",
+        lref
+    ))
+    .unwrap();
+    if pg_sys::SPI_execute(q.as_ptr(), true, 1) != pg_sys::SPI_OK_SELECT as i32
+        || spi_cell1().as_deref() != Some("1")
+    {
+        return "ON CONFLICT DO NOTHING".into(); // common case: nothing deferrable
+    }
+    let a = CString::new(format!(
+        "SELECT '(' || string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord) || ')' \
+           FROM pg_index i \
+           JOIN LATERAL unnest(i.indkey::int[]) WITH ORDINALITY AS k(attnum, ord) ON true \
+           JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum \
+          WHERE i.indrelid = '{}'::regclass AND i.indisunique AND i.indimmediate \
+            AND i.indpred IS NULL AND 0 <> ALL (i.indkey::int[]) \
+          GROUP BY i.indexrelid, i.indisprimary, i.indnkeyatts \
+          ORDER BY i.indisprimary DESC, i.indnkeyatts ASC, i.indexrelid LIMIT 1",
+        lref
+    ))
+    .unwrap();
+    if pg_sys::SPI_execute(a.as_ptr(), true, 1) == pg_sys::SPI_OK_SELECT as i32 {
+        if let Some(cols) = spi_cell1() {
+            return format!("ON CONFLICT {} DO NOTHING", cols);
+        }
+    }
+    pgrx::error!(
+        "gfs: {} has only DEFERRABLE unique constraints -- no usable ON CONFLICT arbiter for copy-on-read",
+        h.local_ref
+    );
+}
+
 /// FROM clause (aliased `src`) reading the source rows for `h`. Normal case: the
 /// registered foreign table (postgres_fdw pushes the caller's WHERE down). For an
 /// inheritance parent (`only`) postgres_fdw is unusable -- it cannot deparse ONLY, so
@@ -164,7 +211,7 @@ unsafe fn src_from(h: &Hydration, only: bool, remote_where: &str, remote_limit: 
 /// ON CONFLICT DO NOTHING, so a fallback after a partial fan is idempotent/harmless.
 /// Read-only on the source; no replication slot. dblink reuses the existing FDW
 /// server `gfs_remote_srv` (+ its PUBLIC user mapping) -- no new connstr/secret.
-unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str, only: bool) -> Option<i64> {
+unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str, only: bool, conflict: &str) -> Option<i64> {
     // --- knobs + source size estimate + dblink availability (one row) ---
     let q = CString::new(format!(
         "SELECT x.parallel_workers::text, x.parallel_min_pages::text, x.parallel_min_frac::text, \
@@ -278,8 +325,8 @@ unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str,
     for k in 0..m {
         let conn = format!("gfs_bf_{}_{}", u32::from(h.relid), k);
         let ins = CString::new(format!(
-            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM dblink_get_result('{conn}') AS t({cd}) WHERE true{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, conn = conn, cd = coldef, excl = excl_t, ov = overriding
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM dblink_get_result('{conn}') AS t({cd}) WHERE true{excl} {oc}",
+            l = h.local_ref, c = h.collist, conn = conn, cd = coldef, excl = excl_t, ov = overriding, oc = conflict
         )).unwrap();
         if pg_sys::SPI_execute(ins.as_ptr(), false, 0) == pg_sys::SPI_OK_INSERT as i32 {
             total += pg_sys::SPI_processed as i64;
@@ -346,6 +393,10 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     // inheritance scan would serve every child row TWICE.
     let only = local_has_children(h.relid);
 
+    // Dedup clause for every hydration insert below (explicit arbiter when the
+    // table has a DEFERRABLE unique/exclusion constraint -- see conflict_clause).
+    let conflict = conflict_clause(h);
+
     // Exclude copy-on-write DELETE tombstones so hydration never resurrects a local
     // DELETE -- only when this table has tombstones (the no-deletes case stays
     // zero-overhead). `src` aliases the source so `to_jsonb(src)` builds the row.
@@ -390,9 +441,9 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         let src = src_from(h, only, &h.where_sql, cap + 1);
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
-                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
+                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked {oc} RETURNING 1) \
              SELECT (SELECT count(*) FROM picked)::int8::text, (SELECT count(*) FROM ins)::int8::text",
-            c = h.collist, s = src, w = h.where_sql, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding
+            c = h.collist, s = src, w = h.where_sql, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding, oc = conflict
         );
         let q = CString::new(sql).unwrap();
         let (mut matched, mut inserted) = (0i64, 0i64);
@@ -456,9 +507,9 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         let src = src_from(h, only, &where_clause, cap + 1);
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
-                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
+                  ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked {oc} RETURNING 1) \
              SELECT (SELECT count(*) FROM picked)::int8::text, (SELECT count(*) FROM ins)::int8::text",
-            c = h.collist, s = src, w = where_clause, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding
+            c = h.collist, s = src, w = where_clause, excl = excl, l = h.local_ref, lim = cap + 1, ov = overriding, oc = conflict
         );
         let q = CString::new(sql).unwrap();
         let (mut matched, mut inserted) = (0i64, 0i64);
@@ -486,7 +537,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     // split via concurrent dblink scans); fall back to one FDW statement on any
     // ineligibility or setup failure. ON CONFLICT DO NOTHING keeps both paths
     // idempotent, so a fallback after a partial fan is safe.
-    if let Some(n) = try_parallel_backfill(h, !excl.is_empty(), overriding, only) {
+    if let Some(n) = try_parallel_backfill(h, !excl.is_empty(), overriding, only, &conflict) {
         record_whole_or_range(h, n);
         spi_set_repl_role(&prior_srr);
         pg_sys::SPI_finish();
@@ -494,14 +545,14 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     }
     let sql = if h.whole {
         format!(
-            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE true{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src_from(h, only, "", 0), excl = excl, ov = overriding
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE true{excl} {oc}",
+            l = h.local_ref, c = h.collist, s = src_from(h, only, "", 0), excl = excl, ov = overriding, oc = conflict
         )
     } else {
         let range_w = format!("{} BETWEEN {} AND {}", h.key_col, h.lo, h.hi);
         format!(
-            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE {w}{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src_from(h, only, &range_w, 0), w = range_w, excl = excl, ov = overriding
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE {w}{excl} {oc}",
+            l = h.local_ref, c = h.collist, s = src_from(h, only, &range_w, 0), w = range_w, excl = excl, ov = overriding, oc = conflict
         )
     };
     let q = CString::new(sql).unwrap();

--- a/crates/extensions/gfs/src/hydrate.rs
+++ b/crates/extensions/gfs/src/hydrate.rs
@@ -235,6 +235,32 @@ unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str)
     Some(total)
 }
 
+/// Read the current `session_replication_role` (origin | replica | local). Caller
+/// holds an open SPI connection.
+unsafe fn spi_repl_role() -> String {
+    let q = CString::new("SELECT current_setting('session_replication_role')").unwrap();
+    if pg_sys::SPI_execute(q.as_ptr(), true, 1) == pg_sys::SPI_OK_SELECT as i32
+        && pg_sys::SPI_processed == 1
+    {
+        let tt = pg_sys::SPI_tuptable;
+        let row = *(*tt).vals;
+        spi_text(pg_sys::SPI_getvalue(row, (*tt).tupdesc, 1)).unwrap_or_else(|| "origin".into())
+    } else {
+        "origin".into()
+    }
+}
+
+/// Set `session_replication_role`. Only the three legal enum values are accepted;
+/// anything else falls back to 'origin' (defensive). Caller holds an open SPI connection.
+unsafe fn spi_set_repl_role(v: &str) {
+    let val = match v {
+        "replica" | "local" | "origin" => v,
+        _ => "origin",
+    };
+    let q = CString::new(format!("SET session_replication_role = {}", val)).unwrap();
+    pg_sys::SPI_execute(q.as_ptr(), false, 0);
+}
+
 /// Fetch a hydration into the local table. Returns true when the slice/table is
 /// COMPLETE (safe to serve local); returns false ONLY for a PARTIAL pull that
 /// overflowed its cap (too many matches -> not selective -> caller must federate,
@@ -247,6 +273,16 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
         // failure -> safe (true).
         return h.where_sql.is_empty() && !h.time_key;
     }
+
+    // Copy-on-read replays the SOURCE's already-computed rows, so a replayed INSERT
+    // trigger must NOT fire on them again -- it would re-mutate the row (e.g. append or
+    // re-stamp) or re-run side effects (audit/cascade), diverging the clone from the
+    // source. Apply the rows in the 'replica' role -- exactly how logical replication
+    // loads data, skipping user triggers -- then restore the prior role before every
+    // return so the caller's OWN writes in the same transaction still fire their
+    // triggers normally.
+    let prior_srr = spi_repl_role();
+    spi_set_repl_role("replica");
 
     // Exclude copy-on-write DELETE tombstones so hydration never resurrects a local
     // DELETE -- only when this table has tombstones (the no-deletes case stays
@@ -336,6 +372,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
             pg_sys::SPI_execute(pr.as_ptr(), false, 0);
         }
         hydrate_finish(h, inserted);
+        spi_set_repl_role(&prior_srr);
         pg_sys::SPI_finish();
         return !overflow;
     }
@@ -377,6 +414,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
             pg_sys::SPI_execute(nr.as_ptr(), false, 0);
         }
         hydrate_finish(h, inserted);
+        spi_set_repl_role(&prior_srr);
         pg_sys::SPI_finish();
         return !overflow;
     }
@@ -387,6 +425,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     // idempotent, so a fallback after a partial fan is safe.
     if let Some(n) = try_parallel_backfill(h, !excl.is_empty(), overriding) {
         record_whole_or_range(h, n);
+        spi_set_repl_role(&prior_srr);
         pg_sys::SPI_finish();
         return true;
     }
@@ -405,6 +444,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     let rc = pg_sys::SPI_execute(q.as_ptr(), false, 0);
     let n = if rc == pg_sys::SPI_OK_INSERT as i32 { pg_sys::SPI_processed as i64 } else { 0 };
     record_whole_or_range(h, n);
+    spi_set_repl_role(&prior_srr);
     pg_sys::SPI_finish();
     true
 }

--- a/crates/extensions/gfs/src/hydrate.rs
+++ b/crates/extensions/gfs/src/hydrate.rs
@@ -76,6 +76,84 @@ unsafe fn overriding_clause(local_ref: &str) -> &'static str {
     ""
 }
 
+/// True when the local clone table is a plain-table inheritance parent (pg_inherits,
+/// relkind 'r'). The clone replays the source schema, so this equals "the SOURCE
+/// table has INHERITS children". Declarative-partition parents (relkind 'p') are
+/// excluded: they hold no rows of their own and route inserts to partitions, so they
+/// keep the existing paths. Caller holds an open SPI connection.
+unsafe fn local_has_children(relid: pg_sys::Oid) -> bool {
+    let q = CString::new(format!(
+        "SELECT EXISTS(SELECT 1 FROM pg_inherits i JOIN pg_class c ON c.oid = i.inhparent \
+          WHERE i.inhparent = {} AND c.relkind = 'r')::int::text",
+        u32::from(relid)
+    ))
+    .unwrap();
+    pg_sys::SPI_execute(q.as_ptr(), true, 1) == pg_sys::SPI_OK_SELECT as i32
+        && spi_cell1().as_deref() == Some("1")
+}
+
+/// Real source-side `schema.table` (quoted) behind the foreign table `fref`; None
+/// when `fref` is not a foreign table. Caller holds an open SPI connection.
+unsafe fn remote_qualified(fref: &str) -> Option<String> {
+    let fq = CString::new(format!(
+        "SELECT quote_ident(COALESCE((SELECT option_value FROM pg_options_to_table(ft.ftoptions) WHERE option_name = 'schema_name'), n.nspname)), \
+                quote_ident(COALESCE((SELECT option_value FROM pg_options_to_table(ft.ftoptions) WHERE option_name = 'table_name'), c.relname)) \
+           FROM pg_foreign_table ft JOIN pg_class c ON c.oid = ft.ftrelid JOIN pg_namespace n ON n.oid = c.relnamespace \
+          WHERE ft.ftrelid = '{}'::regclass",
+        fref.replace('\'', "''")
+    )).unwrap();
+    if pg_sys::SPI_execute(fq.as_ptr(), true, 1) != pg_sys::SPI_OK_SELECT as i32 || pg_sys::SPI_processed != 1 {
+        return None;
+    }
+    let tt = pg_sys::SPI_tuptable;
+    let row = *(*tt).vals;
+    let td = (*tt).tupdesc;
+    let sch = spi_text(pg_sys::SPI_getvalue(row, td, 1))?;
+    let tbl = spi_text(pg_sys::SPI_getvalue(row, td, 2))?;
+    Some(format!("{}.{}", sch, tbl))
+}
+
+/// Typed column list of `local_ref` (non-dropped, non-generated, attnum order), for
+/// use as a dblink result-set definition. Caller holds an open SPI connection.
+unsafe fn local_coldef(local_ref: &str) -> Option<String> {
+    let cq = CString::new(format!(
+        "SELECT string_agg(quote_ident(attname) || ' ' || format_type(atttypid, atttypmod), ', ' ORDER BY attnum) \
+           FROM pg_attribute WHERE attrelid = '{}'::regclass AND attnum > 0 AND NOT attisdropped AND attgenerated = ''",
+        local_ref.replace('\'', "''")
+    )).unwrap();
+    if pg_sys::SPI_execute(cq.as_ptr(), true, 1) != pg_sys::SPI_OK_SELECT as i32 {
+        return None;
+    }
+    spi_cell1().filter(|s| !s.is_empty())
+}
+
+/// FROM clause (aliased `src`) reading the source rows for `h`. Normal case: the
+/// registered foreign table (postgres_fdw pushes the caller's WHERE down). For an
+/// inheritance parent (`only`) postgres_fdw is unusable -- it cannot deparse ONLY, so
+/// its remote scan would include child rows, which the clone's own inheritance scan
+/// then reads AGAIN from the hydrated children (every child row served twice). Read
+/// through dblink with an explicit `FROM ONLY` instead, embedding the caller's
+/// predicate and cap (a dblink rowset gets no pushdown; without them a partial
+/// hydration would transfer the parent's whole own heap). The caller's local
+/// WHERE/LIMIT re-apply over the rowset, harmlessly idempotent.
+unsafe fn src_from(h: &Hydration, only: bool, remote_where: &str, remote_limit: i64) -> String {
+    if !only {
+        return format!("{} src", h.source_ref);
+    }
+    let Some(qual) = remote_qualified(&h.source_ref) else {
+        pgrx::error!("gfs: no foreign table behind {} (inheritance parent needs an ONLY-fetch)", h.local_ref);
+    };
+    let Some(coldef) = local_coldef(&h.local_ref) else {
+        pgrx::error!("gfs: no usable columns on {} (inheritance parent needs an ONLY-fetch)", h.local_ref);
+    };
+    let w = if remote_where.is_empty() { "true" } else { remote_where };
+    let lim = if remote_limit > 0 { format!(" LIMIT {}", remote_limit) } else { String::new() };
+    format!(
+        "dblink('gfs_remote_srv', $gfsq$SELECT {} FROM ONLY {} WHERE {}{}$gfsq$) AS src({})",
+        h.collist, qual, w, lim, coldef
+    )
+}
+
 /// Fan a large whole/int-range backfill over N concurrent dblink scans against the
 /// source -- CTID-block partitioning for a whole table (no usable key -> heap scan),
 /// key-range split for an int range (indexed key) -- instead of one FDW cursor. The
@@ -86,7 +164,7 @@ unsafe fn overriding_clause(local_ref: &str) -> &'static str {
 /// ON CONFLICT DO NOTHING, so a fallback after a partial fan is idempotent/harmless.
 /// Read-only on the source; no replication slot. dblink reuses the existing FDW
 /// server `gfs_remote_srv` (+ its PUBLIC user mapping) -- no new connstr/secret.
-unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str) -> Option<i64> {
+unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str, only: bool) -> Option<i64> {
     // --- knobs + source size estimate + dblink availability (one row) ---
     let q = CString::new(format!(
         "SELECT x.parallel_workers::text, x.parallel_min_pages::text, x.parallel_min_frac::text, \
@@ -124,37 +202,14 @@ unsafe fn try_parallel_backfill(h: &Hydration, has_tomb: bool, overriding: &str)
         }
     }
 
-    // --- real source-side schema.table behind the foreign table (quoted) ---
-    let fq = CString::new(format!(
-        "SELECT quote_ident(COALESCE((SELECT option_value FROM pg_options_to_table(ft.ftoptions) WHERE option_name = 'schema_name'), n.nspname)), \
-                quote_ident(COALESCE((SELECT option_value FROM pg_options_to_table(ft.ftoptions) WHERE option_name = 'table_name'), c.relname)) \
-           FROM pg_foreign_table ft JOIN pg_class c ON c.oid = ft.ftrelid JOIN pg_namespace n ON n.oid = c.relnamespace \
-          WHERE ft.ftrelid = '{}'::regclass",
-        h.source_ref.replace('\'', "''")
-    )).unwrap();
-    if pg_sys::SPI_execute(fq.as_ptr(), true, 1) != pg_sys::SPI_OK_SELECT as i32 || pg_sys::SPI_processed != 1 {
-        return None;
-    }
-    let tt = pg_sys::SPI_tuptable;
-    let row = *(*tt).vals;
-    let td = (*tt).tupdesc;
-    let sch = spi_text(pg_sys::SPI_getvalue(row, td, 1))?;
-    let tbl = spi_text(pg_sys::SPI_getvalue(row, td, 2))?;
-    let src_qual = format!("{}.{}", sch, tbl);
+    // --- real source-side schema.table behind the foreign table (quoted). An
+    // inheritance parent scans ONLY its own heap: its children backfill themselves,
+    // and both split modes stay valid (ctid ranges address the parent's own heap;
+    // key ranges filter the parent's own rows). ---
+    let src_qual = format!("{}{}", if only { "ONLY " } else { "" }, remote_qualified(&h.source_ref)?);
 
     // --- typed column list for dblink_get_result (same types as the local table) ---
-    let cq = CString::new(format!(
-        "SELECT string_agg(quote_ident(attname) || ' ' || format_type(atttypid, atttypmod), ', ' ORDER BY attnum) \
-           FROM pg_attribute WHERE attrelid = '{}'::regclass AND attnum > 0 AND NOT attisdropped AND attgenerated = ''",
-        h.local_ref.replace('\'', "''")
-    )).unwrap();
-    if pg_sys::SPI_execute(cq.as_ptr(), true, 1) != pg_sys::SPI_OK_SELECT as i32 {
-        return None;
-    }
-    let coldef = spi_cell1()?;
-    if coldef.is_empty() {
-        return None;
-    }
+    let coldef = local_coldef(&h.local_ref)?;
 
     // --- partition predicates ---
     let preds: Vec<String> = if h.whole {
@@ -284,10 +339,16 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     let prior_srr = spi_repl_role();
     spi_set_repl_role("replica");
 
+    // Inheritance parent (the schema replay mirrors the source's INHERITS
+    // hierarchy): every fetch below must read ONLY the parent's own rows -- the
+    // children hydrate themselves through their own registrations, so a fetch that
+    // included them would land child rows in the parent's heap and the clone's
+    // inheritance scan would serve every child row TWICE.
+    let only = local_has_children(h.relid);
+
     // Exclude copy-on-write DELETE tombstones so hydration never resurrects a local
     // DELETE -- only when this table has tombstones (the no-deletes case stays
     // zero-overhead). `src` aliases the source so `to_jsonb(src)` builds the row.
-    let src = format!("{} src", h.source_ref);
     let excl = {
         let q = CString::new(format!(
             "SELECT EXISTS(SELECT 1 FROM gfs.tombstone WHERE relid::oid = {})::int::text",
@@ -326,6 +387,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     // subset (no completeness is claimed for them), so they are harmless.
     if !h.where_sql.is_empty() {
         let cap = h.partial_cap.max(0);
+        let src = src_from(h, only, &h.where_sql, cap + 1);
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
                   ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
@@ -391,6 +453,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
             conds.push(format!("{} <= {}", h.key_col, time_recon(h.hi, &h.key_type)));
         }
         let where_clause = if conds.is_empty() { "true".to_string() } else { conds.join(" AND ") };
+        let src = src_from(h, only, &where_clause, cap + 1);
         let sql = format!(
             "WITH picked AS (SELECT {c} FROM {s} WHERE {w}{excl} LIMIT {lim}), \
                   ins AS (INSERT INTO {l} ({c}) {ov}SELECT {c} FROM picked ON CONFLICT DO NOTHING RETURNING 1) \
@@ -423,7 +486,7 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     // split via concurrent dblink scans); fall back to one FDW statement on any
     // ineligibility or setup failure. ON CONFLICT DO NOTHING keeps both paths
     // idempotent, so a fallback after a partial fan is safe.
-    if let Some(n) = try_parallel_backfill(h, !excl.is_empty(), overriding) {
+    if let Some(n) = try_parallel_backfill(h, !excl.is_empty(), overriding, only) {
         record_whole_or_range(h, n);
         spi_set_repl_role(&prior_srr);
         pg_sys::SPI_finish();
@@ -432,12 +495,13 @@ pub(crate) unsafe fn do_hydrate(h: &Hydration) -> bool {
     let sql = if h.whole {
         format!(
             "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE true{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src, excl = excl, ov = overriding
+            l = h.local_ref, c = h.collist, s = src_from(h, only, "", 0), excl = excl, ov = overriding
         )
     } else {
+        let range_w = format!("{} BETWEEN {} AND {}", h.key_col, h.lo, h.hi);
         format!(
-            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE {k} BETWEEN {lo} AND {hi}{excl} ON CONFLICT DO NOTHING",
-            l = h.local_ref, c = h.collist, s = src, k = h.key_col, lo = h.lo, hi = h.hi, excl = excl, ov = overriding
+            "INSERT INTO {l} ({c}) {ov}SELECT {c} FROM {s} WHERE {w}{excl} ON CONFLICT DO NOTHING",
+            l = h.local_ref, c = h.collist, s = src_from(h, only, &range_w, 0), w = range_w, excl = excl, ov = overriding
         )
     };
     let q = CString::new(sql).unwrap();

--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -280,7 +280,7 @@ $$;
 -- the source, even aggregates).
 CREATE FUNCTION gfs.warm(local regclass)
 RETURNS bigint LANGUAGE plpgsql AS $$
-DECLARE src text; cols text; ov text; n bigint;
+DECLARE src text; cols text; ov text; n bigint; old_srr text;
 BEGIN
     SELECT source_ref INTO src FROM gfs.clone_source WHERE relid = local;
     IF src IS NULL OR to_regclass(src) IS NULL THEN
@@ -294,6 +294,13 @@ BEGIN
     SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_attribute
                               WHERE attrelid = local AND attidentity = 'a')
                 THEN 'OVERRIDING SYSTEM VALUE ' ELSE '' END INTO ov;
+    -- Warming replays the SOURCE's already-computed rows, so a replayed INSERT trigger
+    -- must NOT fire on them (it would re-mutate the row or re-run side effects, diverging
+    -- the clone from the source). Copy in the 'replica' role -- how logical replication
+    -- applies rows, skipping user triggers -- then restore the prior role (SET LOCAL, so
+    -- it also resets at txn end) so later writes fire their triggers normally.
+    old_srr := current_setting('session_replication_role');
+    PERFORM set_config('session_replication_role', 'replica', true);
     -- Exclude locally-deleted rows so warming never resurrects a copy-on-write DELETE.
     EXECUTE format('INSERT INTO %s (%s) %sSELECT %s FROM %s s
                     WHERE NOT EXISTS (SELECT 1 FROM gfs.tombstone tb
@@ -301,6 +308,7 @@ BEGIN
                     ON CONFLICT DO NOTHING',
                    local::text, cols, ov, cols, src, local::text);
     GET DIAGNOSTICS n = ROW_COUNT;
+    PERFORM set_config('session_replication_role', old_srr, true);
     EXECUTE format('ANALYZE %s', local::text);
     UPDATE gfs.clone_source SET whole_cached = true WHERE relid = local;
     UPDATE gfs.clone_stats

--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -280,7 +280,7 @@ $$;
 -- the source, even aggregates).
 CREATE FUNCTION gfs.warm(local regclass)
 RETURNS bigint LANGUAGE plpgsql AS $$
-DECLARE src text; cols text; ov text; n bigint; old_srr text; srcfrom text; rqual text; cdef text;
+DECLARE src text; cols text; ov text; n bigint; old_srr text; srcfrom text; rqual text; cdef text; oc text; arb text;
 BEGIN
     SELECT source_ref INTO src FROM gfs.clone_source WHERE relid = local;
     IF src IS NULL OR to_regclass(src) IS NULL THEN
@@ -318,6 +318,28 @@ BEGIN
     SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_attribute
                               WHERE attrelid = local AND attidentity = 'a')
                 THEN 'OVERRIDING SYSTEM VALUE ' ELSE '' END INTO ov;
+    -- Target-less ON CONFLICT is refused when the table has a DEFERRABLE unique or
+    -- exclusion constraint (they cannot arbitrate) -- warming would error. Name an
+    -- explicit arbiter instead: a non-deferrable, non-partial, non-expression unique
+    -- index (primary key preferred). Re-pulled source rows match on ANY unique
+    -- index, so one arbiter is enough to keep warming idempotent.
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = local
+                AND contype IN ('p','u','x') AND condeferrable) THEN
+        SELECT '(' || string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord) || ')' INTO arb
+          FROM pg_index i
+          JOIN LATERAL unnest(i.indkey::int[]) WITH ORDINALITY AS k(attnum, ord) ON true
+          JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum
+         WHERE i.indrelid = local AND i.indisunique AND i.indimmediate
+           AND i.indpred IS NULL AND 0 <> ALL (i.indkey::int[])
+         GROUP BY i.indexrelid, i.indisprimary, i.indnkeyatts
+         ORDER BY i.indisprimary DESC, i.indnkeyatts ASC, i.indexrelid LIMIT 1;
+        IF arb IS NULL THEN
+            RAISE EXCEPTION 'gfs.warm: % has only DEFERRABLE unique constraints -- no usable ON CONFLICT arbiter', local;
+        END IF;
+        oc := format('ON CONFLICT %s DO NOTHING', arb);
+    ELSE
+        oc := 'ON CONFLICT DO NOTHING';
+    END IF;
     -- Warming replays the SOURCE's already-computed rows, so a replayed INSERT trigger
     -- must NOT fire on them (it would re-mutate the row or re-run side effects, diverging
     -- the clone from the source). Copy in the 'replica' role -- how logical replication
@@ -329,8 +351,8 @@ BEGIN
     EXECUTE format('INSERT INTO %s (%s) %sSELECT %s FROM %s
                     WHERE NOT EXISTS (SELECT 1 FROM gfs.tombstone tb
                                        WHERE tb.relid = %L::regclass AND to_jsonb(s) @> tb.pk)
-                    ON CONFLICT DO NOTHING',
-                   local::text, cols, ov, cols, srcfrom, local::text);
+                    %s',
+                   local::text, cols, ov, cols, srcfrom, local::text, oc);
     GET DIAGNOSTICS n = ROW_COUNT;
     PERFORM set_config('session_replication_role', old_srr, true);
     EXECUTE format('ANALYZE %s', local::text);

--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -280,7 +280,7 @@ $$;
 -- the source, even aggregates).
 CREATE FUNCTION gfs.warm(local regclass)
 RETURNS bigint LANGUAGE plpgsql AS $$
-DECLARE src text; cols text; ov text; n bigint; old_srr text;
+DECLARE src text; cols text; ov text; n bigint; old_srr text; srcfrom text; rqual text; cdef text;
 BEGIN
     SELECT source_ref INTO src FROM gfs.clone_source WHERE relid = local;
     IF src IS NULL OR to_regclass(src) IS NULL THEN
@@ -289,6 +289,30 @@ BEGIN
     SELECT string_agg(quote_ident(attname), ', ' ORDER BY attnum) INTO cols
       FROM pg_attribute
      WHERE attrelid = local AND attnum > 0 AND NOT attisdropped AND attgenerated = '';
+    -- Inheritance parent (mirrored from the source by the schema replay): warm ONLY
+    -- its own rows. postgres_fdw cannot deparse ONLY (the foreign scan would include
+    -- child rows, which the clone's inheritance scan then reads AGAIN from the warmed
+    -- children), so read through dblink with an explicit FROM ONLY against the real
+    -- source-side table behind the foreign table.
+    IF EXISTS (SELECT 1 FROM pg_inherits i JOIN pg_class pc ON pc.oid = i.inhparent
+                WHERE i.inhparent = local AND pc.relkind = 'r') THEN
+        SELECT format('%I.%I',
+                      COALESCE((SELECT option_value FROM pg_options_to_table(ft.ftoptions) WHERE option_name = 'schema_name'), n.nspname),
+                      COALESCE((SELECT option_value FROM pg_options_to_table(ft.ftoptions) WHERE option_name = 'table_name'), c.relname))
+          INTO rqual
+          FROM pg_foreign_table ft
+          JOIN pg_class c ON c.oid = ft.ftrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE ft.ftrelid = to_regclass(src);
+        SELECT string_agg(quote_ident(attname) || ' ' || format_type(atttypid, atttypmod), ', ' ORDER BY attnum)
+          INTO cdef
+          FROM pg_attribute
+         WHERE attrelid = local AND attnum > 0 AND NOT attisdropped AND attgenerated = '';
+        srcfrom := format('dblink(''gfs_remote_srv'', %L) AS s(%s)',
+                          format('SELECT %s FROM ONLY %s', cols, rqual), cdef);
+    ELSE
+        srcfrom := src || ' s';
+    END IF;
     -- A GENERATED ALWAYS AS IDENTITY column rejects an explicit value on a plain
     -- INSERT; OVERRIDING SYSTEM VALUE lets us copy the source's own key faithfully.
     SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_attribute
@@ -302,11 +326,11 @@ BEGIN
     old_srr := current_setting('session_replication_role');
     PERFORM set_config('session_replication_role', 'replica', true);
     -- Exclude locally-deleted rows so warming never resurrects a copy-on-write DELETE.
-    EXECUTE format('INSERT INTO %s (%s) %sSELECT %s FROM %s s
+    EXECUTE format('INSERT INTO %s (%s) %sSELECT %s FROM %s
                     WHERE NOT EXISTS (SELECT 1 FROM gfs.tombstone tb
                                        WHERE tb.relid = %L::regclass AND to_jsonb(s) @> tb.pk)
                     ON CONFLICT DO NOTHING',
-                   local::text, cols, ov, cols, src, local::text);
+                   local::text, cols, ov, cols, srcfrom, local::text);
     GET DIAGNOSTICS n = ROW_COUNT;
     PERFORM set_config('session_replication_role', old_srr, true);
     EXECUTE format('ANALYZE %s', local::text);

--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -280,7 +280,7 @@ $$;
 -- the source, even aggregates).
 CREATE FUNCTION gfs.warm(local regclass)
 RETURNS bigint LANGUAGE plpgsql AS $$
-DECLARE src text; cols text; n bigint;
+DECLARE src text; cols text; ov text; n bigint;
 BEGIN
     SELECT source_ref INTO src FROM gfs.clone_source WHERE relid = local;
     IF src IS NULL OR to_regclass(src) IS NULL THEN
@@ -289,12 +289,17 @@ BEGIN
     SELECT string_agg(quote_ident(attname), ', ' ORDER BY attnum) INTO cols
       FROM pg_attribute
      WHERE attrelid = local AND attnum > 0 AND NOT attisdropped AND attgenerated = '';
+    -- A GENERATED ALWAYS AS IDENTITY column rejects an explicit value on a plain
+    -- INSERT; OVERRIDING SYSTEM VALUE lets us copy the source's own key faithfully.
+    SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_attribute
+                              WHERE attrelid = local AND attidentity = 'a')
+                THEN 'OVERRIDING SYSTEM VALUE ' ELSE '' END INTO ov;
     -- Exclude locally-deleted rows so warming never resurrects a copy-on-write DELETE.
-    EXECUTE format('INSERT INTO %s (%s) SELECT %s FROM %s s
+    EXECUTE format('INSERT INTO %s (%s) %sSELECT %s FROM %s s
                     WHERE NOT EXISTS (SELECT 1 FROM gfs.tombstone tb
                                        WHERE tb.relid = %L::regclass AND to_jsonb(s) @> tb.pk)
                     ON CONFLICT DO NOTHING',
-                   local::text, cols, cols, src, local::text);
+                   local::text, cols, ov, cols, src, local::text);
     GET DIAGNOSTICS n = ROW_COUNT;
     EXECUTE format('ANALYZE %s', local::text);
     UPDATE gfs.clone_source SET whole_cached = true WHERE relid = local;


### PR DESCRIPTION
## Related Issue
Closes #107
Closes #108
Closes #109

## What
Three copy-on-read fidelity bugs made a lazy clone silently or loudly diverge from its source:

- **#107**: hydration inserts re-fired the source's INSERT triggers on rows the source had already computed. A `BEFORE` trigger re-mutated every hydrated row (re-stamped `updated_at`, re-appended, re-normalized) and an `AFTER` trigger re-ran side effects (audit rows, cascades). Silent data corruption on the most common trigger patterns.
- **#108**: old-style `INHERITS` hierarchies double-counted. postgres_fdw cannot deparse `FROM ONLY`, so hydrating a parent also pulled its children's rows into the parent's own heap; the clone's inheritance scan then served every child row twice (`generic,rex,rex,fido,fido` instead of `generic,rex,fido`).
- **#109**: a table with a `DEFERRABLE` unique/exclusion constraint was permanently unreadable. Hydration dedupes with target-less `ON CONFLICT DO NOTHING`, which Postgres refuses when any candidate arbiter is deferrable, so every read of the table errored.

## How
- **#107** (`hydrate.rs`, `schema.sql`): apply hydration and `gfs.warm()` inserts under `session_replication_role = 'replica'`, exactly how logical replication loads rows without firing user triggers, restoring the prior role on every exit path so the user's own writes in the same session/transaction still fire their triggers.
- **#108** (`hydrate.rs`, `schema.sql`, `federate.rs`, `catalog.rs`): when the local table is a plain-table inheritance parent (`pg_inherits`, relkind `r`; partitioned parents are excluded since they own no rows), every source fetch reads `FROM ONLY` via dblink (reusing the existing `gfs_remote_srv` server + PUBLIC mapping), with the path's predicate and cap embedded since a dblink rowset gets no pushdown. The parallel backfill prepends `ONLY` to its raw remote scans. `SELECT ... FROM ONLY parent` is refused federation (checked before any RTE is mutated) and falls back to whole-own hydration; plain inheritance scans still federate, because the source expanding the hierarchy itself is the correct total.
- **#109** (`hydrate.rs`, `schema.sql`, `clone_bootstrap.sql`): only for tables that have a deferrable unique/PK/exclusion constraint, name an explicit `ON CONFLICT (cols)` arbiter: the columns of a non-deferrable, non-partial, non-expression unique index, primary key preferred. A re-pulled source row matches on any unique index, so one arbiter keeps hydration idempotent. Unaffected tables keep the byte-identical target-less form. The bootstrap keycol query now requires `indimmediate`, so a table whose only unique key is deferrable fails the clone loudly via the existing `verify_tables_registered` safeguard instead of registering and bricking on first read.

## Review Guide
1. `crates/extensions/gfs/src/hydrate.rs`: the core changes; new helpers `conflict_clause`, `src_from`, `local_has_children`, `remote_qualified`, `local_coldef`, and the `session_replication_role` save/restore in `do_hydrate`.
2. `crates/extensions/gfs/src/sql/schema.sql`: `gfs.warm()` mirrors all three behaviors in plpgsql.
3. `crates/extensions/gfs/src/federate.rs`: `has_only_parent_scan` pre-check; note it runs before any RTE mutation because the caller re-plans the same Query after hydration.
4. `crates/extensions/gfs/src/catalog.rs`: small `gfs_has_children` helper (own SPI connection, planner-hook safe).
5. `crates/adapters/compute-docker/src/containers/clone_bootstrap.sql`: one-word tightening (`indimmediate`) of the keycol query + clearer verify message.

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [x] E2E tests exercised (existing suites)

Live side-by-side verification against fresh Dockerized sources, pre-fix vs post-fix images:
- Triggers: `v || '-x'` BEFORE INSERT trigger; clone reads `a-x,b-x,c-x` (was `a-x-x,...`); user writes on the clone still fire triggers (no role leak).
- INHERITS: parent count 3 (was 5), `FROM ONLY parent` = 1 (was 3, child rows physically in the parent heap), `gfs.warm()` on the parent copies exactly its own row.
- DEFERRABLE: `bookings(id PK, seat UNIQUE DEFERRABLE INITIALLY DEFERRED)` reads its rows (was `ERROR: ON CONFLICT does not support deferrable...` on every read); a deferred seat-swap transaction still works on the clone; `gfs.warm()` idempotent; a deferrable-only table fails the clone loudly with a message naming the requirement.
- `e2e_clone_postgres` passes. Two `e2e_clone_robustness` failures (`clone_local_writes_leave_source_untouched` seed race, `clone_range_and_temporal_hydration_elide` t0=0/t1=0) reproduce identically on the pre-fix extension: pre-existing, not introduced here (the temporal one likely dates from the async-temporal-copy change and deserves its own issue).

## Documentation
- [x] Code comments added for complex logic (each non-obvious constraint is documented at the helper that enforces it)
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact
- Clones of databases using triggers, `INHERITS` hierarchies, or deferrable constraints now return the same data as the source; previously they silently diverged (#107, #108) or errored on read (#109).
- One intentional behavior change: a table whose only unique key is DEFERRABLE now fails the clone loudly at bootstrap (it previously cloned "successfully" and then errored on first read). Consistent with the existing fail-loud policy for keyless tables.
- No changes for tables without these features; their hydration SQL is byte-identical.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`cargo test`) — see Testing for two pre-existing robustness failures reproduced on the pre-fix baseline
- [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`) — the extension crate builds only inside its Docker image (pgrx)
- [ ] Format check passes (`cargo fmt --check`) — pre-existing diffs in untouched code; new code matches surrounding style
- [x] This PR can be safely reverted if needed
