### PR TITLE
Fix/clone cost model 112

### DIFF
--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -272,6 +272,25 @@ BEGIN
     EXCEPTION WHEN others THEN srows := 0; sbytes := 100;
     END;
 
+    -- A remote estimate of <= 1 row almost always means the SOURCE table was never
+    -- ANALYZEd (its reltuples is stale), NOT that it is genuinely tiny. Trusting it
+    -- makes the router treat a million-row table as negligible and whole-copy it on
+    -- first read over a slow link -- the same failure class as issue #112, from stale
+    -- stats instead of a bad probe. Get the REAL size with count(*), which postgres_fdw
+    -- pushes down to the source (one round-trip, no data transfer). Bound it with a
+    -- timeout so a giant un-analyzed table cannot stall the clone; on timeout/error
+    -- assume "large" so the router federates rather than eagerly copies.
+    IF srows <= 1 THEN
+        BEGIN
+            SET LOCAL statement_timeout = '30s';
+            EXECUTE format('SELECT count(*) FROM %s', source_ref) INTO srows;
+            srows := GREATEST(srows, 0);
+            SET LOCAL statement_timeout = '0';
+        EXCEPTION WHEN others THEN
+            srows := 100000000;   -- couldn't measure -> assume large (federate, never copy on first touch)
+        END;
+    END IF;
+
     INSERT INTO gfs.clone_source(relid, source_ref, key_col, chunk_kind, source_rows, row_bytes)
          VALUES (local, source_ref, key_col, kind, srows, sbytes)
     ON CONFLICT (relid)

--- a/crates/extensions/gfs/src/sql/schema.sql
+++ b/crates/extensions/gfs/src/sql/schema.sql
@@ -100,21 +100,37 @@ BEGIN
     IF fref IS NULL THEN RETURN (SELECT c FROM gfs.cost c LIMIT 1); END IF;
     SELECT prod_load INTO pl FROM gfs.cost LIMIT 1;
 
-    t0 := clock_timestamp();
+    -- Warm the postgres_fdw connection first. The first remote call pays a one-time
+    -- connect + TLS handshake cost (often ~1s); measuring latency on it would inflate
+    -- the baseline so far that the later data probe's (duration - lat) underflows to
+    -- ~0 and the link looks free (issue #112). Discard this call's timing.
     EXECUTE format('SELECT 1 FROM %s LIMIT 1', fref);
+
+    t0 := clock_timestamp();
+    EXECUTE format('SELECT 1 FROM %s LIMIT 1', fref);   -- latency: warm round-trip
     t1 := clock_timestamp();
     lat := GREATEST(extract(epoch FROM t1 - t0), 1e-6);
 
-    t0 := clock_timestamp();                                   -- pull `sample` rows
-    EXECUTE format('SELECT count(*) FROM (SELECT * FROM %s LIMIT %s) s', fref, sample);
+    -- Pull `sample` rows of REAL column data over the link and time it. We must
+    -- reference every column or postgres_fdw column-prunes the foreign scan down to
+    -- `SELECT NULL FROM <src> LIMIT n`, transferring nothing and mismeasuring the
+    -- link as ~free (issue #112). Casting the whole row to text forces all columns
+    -- onto the wire; sum(octet_length(...)) is a cheap local sink the FDW cannot
+    -- push down past the LIMIT, so the timing reflects an actual download.
+    t0 := clock_timestamp();                                   -- pull `sample` rows (real bytes)
+    EXECUTE format('SELECT sum(octet_length(t::text)) FROM (SELECT * FROM %s LIMIT %s) t', fref, sample);
     t1 := clock_timestamp();
-    net_s := GREATEST(extract(epoch FROM t1 - t0) - lat, 1e-9) / GREATEST(sample * b, 1);
+    net_s := GREATEST(extract(epoch FROM t1 - t0) - lat, 0) / GREATEST(sample * b, 1);
+    net_s := GREATEST(net_s, 1e-10);   -- floor at a sane minimum (~10 GB/s); a degenerate
+                                       -- probe must never report the link as ~free and
+                                       -- stampede whole-table copies over a slow link.
 
     t0 := clock_timestamp();                                   -- source scans up to `sample` rows
     EXECUTE format('SELECT count(*) FROM (SELECT 1 FROM %s LIMIT %s) s', fref, sample);
     t1 := clock_timestamp();
     scanned := LEAST(sample::bigint, tr);
-    src_s := GREATEST(extract(epoch FROM t1 - t0) - lat, 1e-9) / GREATEST(scanned, 1);
+    src_s := GREATEST(extract(epoch FROM t1 - t0) - lat, 0) / GREATEST(scanned, 1);
+    src_s := GREATEST(src_s, 1e-9);    -- floor: the source never scans a row in < ~1ns.
 
     UPDATE gfs.cost SET net = net_s, source = src_s * pl, negligible = lat
       RETURNING * INTO r;


### PR DESCRIPTION
## Related Issue

Closes #112
Closes #114

## What

A GFS lazy clone answers every query one of two ways: **copy** the needed data from the source and answer locally, or **federate** (ask the source to compute it and return just the result). It chooses using a cost model that needs two measured inputs: **how fast the link is** and **how big each table is**. Both inputs were being measured wrong, and both errors push the router the same bad way, toward copying huge tables over slow links, which is exactly the worst case.

**Bug 1: the link speed was measured as "free" (#112).**
Right after cloning, the clone runs a one-time speed test: pull some rows from the source and time it. The test pulled rows with `SELECT count(*)`, but counting rows does not need the row *contents*, so postgres_fdw column-pruned it to `SELECT NULL FROM <table> LIMIT 5000` and shipped no real data. The test timed a zero-byte transfer and concluded the network was infinitely fast (`net ≈ 1e-15 sec/byte`).

> **Simple example.** The marketplace source sits behind a ~3 MB/s tunnel. Running `SELECT count(*) FROM products` (a 73 MB table) should just ask the source (~1.5 s). Instead, believing the link was free, the clone downloaded the whole table over the slow tunnel, hung for minutes, and died with `SSL error: unexpected eof while reading`.

**Bug 2: table sizes were wrong for un-`ANALYZE`d tables (#114).**
`source_rows` is taken once, at clone time, from the source's planner estimate (`reltuples`). For a table the source never `ANALYZE`d, that estimate is `~1`. The router then treats a million-row table as trivially small and copies it whole on first read.

> **Simple example.** The `reviews` table has 3,000,000 rows, but it was never analyzed on the source, so the estimate came back as "1 row." The clone believed it, and on the first read of `reviews` it copied all 3 M rows (~270 MB) over the slow link instead of asking the source. Reproduced identically on `cart_items` (real 150 k, estimated 1), `payments`/`shipments` (500 k), and others.

## How

Both fixes live in `crates/extensions/gfs/src/sql/schema.sql`.

**Bug 1 (`gfs.calibrate()`):**
- **Transfer real bytes.** Probe with `sum(octet_length(t::text))` instead of `count(*)`. Casting the whole row to text references every column, so the FDW can no longer prune the scan to `SELECT NULL`; real column data crosses the wire and the timing is honest.
- **Warm the connection first.** The first remote call pays a one-time TLS/connect cost (~1 s). Measuring latency on it polluted the baseline so badly that the data probe's `(duration - latency)` underflowed to ~0. A discarded warm-up call now precedes the latency measurement.
- **Clamp to sane minimums.** `net >= 1e-10` (about a 10 GB/s ceiling) and `source >= 1e-9`, so a degenerate probe can never again report the link as free.

**Bug 2 (`gfs.register_clone()`):**
- When the remote estimate is `<= 1` (the tell-tale sign of an un-`ANALYZE`d source table), get the real size with `count(*)`, which postgres_fdw pushes down to the source (one round-trip, no data transfer). It is bounded by a 30 s `statement_timeout`; on timeout or error it assumes "large" so the router federates rather than eagerly copies.

## Review Guide

1. `crates/extensions/gfs/src/sql/schema.sql`, the only changed file:
   - `gfs.calibrate()`: the network probe rewrite, the connection warm-up, and the `net`/`source` clamps.
   - `gfs.register_clone()`: the `IF srows <= 1 THEN count(*) ...` block with the timeout guard.
2. No router logic changed. `route.rs` (`push_by_cost`, whole-own gate) is unchanged; it just consumes the now-correct weights and sizes.

## Testing

Verified end-to-end against the real source (a ~99 GB marketplace Postgres behind a ~1.5-3 MB/s tunnel), rebuilding the pgrx extension image and cloning fresh.

- [x] Manual testing performed
- [ ] Unit tests added/updated
- [x] E2E tests exercised (live clone against the real source)

**Bug 1 (#112):**
- `EXPLAIN VERBOSE` on the probe: remote SQL went from `SELECT NULL FROM order_items` (0 real bytes) to `SELECT id, order_id, variant_id, ... FROM order_items` (all columns on the wire).
- Measured `net`: `~1e-15` (link "free") became **`~6.5e-7 sec/byte`** (about 1.5 MB/s), matching the real link and the manual workaround value.
- The issue's exact repro, `SELECT count(*) FROM products`: **32.9 s** whole-table download with the broken weight vs **1.2 s** federated with the fix; local heap after the query = **0 bytes** (nothing copied).

**Bug 2 (#114):**
- `source_rows` corrected at clone time: `reviews` 1 became **3,000,000**, `cart_items` 1 became **150,000**, `payments`/`shipments` became 500,000, etc. Genuinely small tables stayed small (`tags` 300, `categories` 200) because the count confirmed it.
- `cart_items`, which whole-copied ~10 MB on first touch before, now federates on first touch with **0 bytes** copied locally; `reviews` (3 M rows) federates in ~0.5 s instead of dragging ~270 MB over the link.
- Clone time grew only a few seconds (the counts push down and are fast).

## Documentation

- [x] Code comments added for complex logic (each non-obvious step in `calibrate()` and `register_clone()` explains the failure it prevents)
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact

- Clones of a database reached over a slow link no longer download whole tables when a single federated query would do. The router now measures the link and the table sizes honestly, so `count(*)` and aggregates on big tables return in ~1 s instead of hanging and failing with SSL errors.
- No behavior change for a fast link or for correctly-`ANALYZE`d sources; the weights simply land at their true values.
- Not addressed here (follow-ups): size **drift** as the source grows after clone time, and consistency if the source is **written to** during the clone's life (a clone still assumes a read-only source).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests pass locally (`cargo test`): the `gfs` extension builds only inside its pgrx Docker image; validated via a live clone instead (see Testing)
- [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`): extension crate builds in Docker (pgrx)
- [ ] Format check passes (`cargo fmt --check`): new code matches surrounding style
- [x] This PR can be safely reverted if needed (isolated to two SQL functions)
