### PR TITLE
feat(db-user): PostgreSQL user management + credential vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -630,8 +630,15 @@ impl DatabaseProvider for PostgresqlProvider {
             sql_lit(&spec.password)
         );
         if let Some(preset) = spec.preset {
+            // Quote the deploy owner (if any) so the preset's default privileges
+            // are role-scoped to the customer's object-creating role.
+            let owner = spec
+                .default_privileges_owner
+                .as_deref()
+                .map(pg_quote_ident)
+                .transpose()?;
             sql.push('\n');
-            sql.push_str(&pg_preset_sql(&ident, preset));
+            sql.push_str(&pg_preset_sql(&ident, preset, owner.as_deref()));
         }
         // Wrap in a transaction so create+grants are atomic (fixes v2 partial-state).
         self.query_in_instance_command(&format!("BEGIN;\n{sql}\nCOMMIT;"))
@@ -685,11 +692,13 @@ impl DatabaseProvider for PostgresqlProvider {
         &self,
         username: &str,
         preset: RolePreset,
+        default_privileges_owner: Option<&str>,
     ) -> std::result::Result<String, ProviderError> {
         let ident = pg_quote_ident(username)?;
+        let owner = default_privileges_owner.map(pg_quote_ident).transpose()?;
         self.query_in_instance_command(&format!(
             "BEGIN;\n{}\nCOMMIT;",
-            pg_preset_sql(&ident, preset)
+            pg_preset_sql(&ident, preset, owner.as_deref())
         ))
     }
 
@@ -984,8 +993,18 @@ fn pg_quote_ident(ident: &str) -> std::result::Result<String, ProviderError> {
 
 /// The allow-listed grant bundle for `preset`, applied to the already-quoted
 /// role `ident` on schema `public`. Semicolon-terminated; the caller wraps the
-/// bundle in a transaction. `ALTER DEFAULT PRIVILEGES` covers future objects.
-fn pg_preset_sql(ident: &str, preset: RolePreset) -> String {
+/// bundle in a transaction.
+///
+/// `owner` (already quoted) is the role whose FUTURE objects the
+/// `ALTER DEFAULT PRIVILEGES` lines cover — the customer's `owner` role in a
+/// deploy, so a preset user sees the tables the customer creates later. When
+/// `None` the defaults are role-scoped to the connecting role (single-node
+/// gfs). Without this, presets only cover the connecting admin's future tables
+/// — never the customer's — so they behave as one-time snapshots (RFC 007
+/// hardening; matches the RFC 009 bootstrap's `FOR ROLE owner`).
+fn pg_preset_sql(ident: &str, preset: RolePreset, owner: Option<&str>) -> String {
+    // `FOR ROLE "owner" ` (trailing space) when a deploy owner is supplied.
+    let for_role = owner.map(|o| format!("FOR ROLE {o} ")).unwrap_or_default();
     let mut s = format!("GRANT USAGE ON SCHEMA public TO {ident};\n");
     match preset {
         RolePreset::Readonly => {
@@ -993,7 +1012,7 @@ fn pg_preset_sql(ident: &str, preset: RolePreset) -> String {
                 "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {ident};\n"
             ));
             s.push_str(&format!(
-                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO {ident};"
+                "ALTER DEFAULT PRIVILEGES {for_role}IN SCHEMA public GRANT SELECT ON TABLES TO {ident};"
             ));
         }
         RolePreset::Readwrite => {
@@ -1004,10 +1023,10 @@ fn pg_preset_sql(ident: &str, preset: RolePreset) -> String {
                 "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {ident};\n"
             ));
             s.push_str(&format!(
-                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {ident};\n"
+                "ALTER DEFAULT PRIVILEGES {for_role}IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {ident};\n"
             ));
             s.push_str(&format!(
-                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO {ident};"
+                "ALTER DEFAULT PRIVILEGES {for_role}IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO {ident};"
             ));
         }
         RolePreset::Admin => {
@@ -1019,10 +1038,10 @@ fn pg_preset_sql(ident: &str, preset: RolePreset) -> String {
                 "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {ident};\n"
             ));
             s.push_str(&format!(
-                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO {ident};\n"
+                "ALTER DEFAULT PRIVILEGES {for_role}IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO {ident};\n"
             ));
             s.push_str(&format!(
-                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO {ident};"
+                "ALTER DEFAULT PRIVILEGES {for_role}IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO {ident};"
             ));
         }
     }
@@ -1476,6 +1495,7 @@ mod tests {
             username: "app_rw".into(),
             password: "p'wd".into(),
             preset: Some(RolePreset::Readwrite),
+            default_privileges_owner: None,
         };
         let cmd = provider.create_role_command(&spec).expect("cmd");
         assert!(
@@ -1495,6 +1515,44 @@ mod tests {
     }
 
     #[test]
+    fn preset_default_privileges_are_role_scoped_to_owner() {
+        use gfs_domain::model::db_user::{RolePreset, RoleSpec};
+        let provider = PostgresqlProvider::new();
+        // With a deploy owner, the ALTER DEFAULT PRIVILEGES lines must be
+        // FOR ROLE "owner" so the preset covers the owner's FUTURE objects.
+        let spec = RoleSpec {
+            username: "reader".into(),
+            password: "pw".into(),
+            preset: Some(RolePreset::Readonly),
+            default_privileges_owner: Some("owner".into()),
+        };
+        let cmd = provider.create_role_command(&spec).expect("cmd");
+        assert!(
+            cmd.contains(
+                r#"ALTER DEFAULT PRIVILEGES FOR ROLE "owner" IN SCHEMA public GRANT SELECT ON TABLES TO "reader""#
+            ),
+            "preset defaults must be role-scoped to the deploy owner; got:\n{cmd}"
+        );
+
+        // Without an owner (single-node), no FOR ROLE clause is emitted.
+        let spec_none = RoleSpec {
+            default_privileges_owner: None,
+            ..spec
+        };
+        let cmd_none = provider.create_role_command(&spec_none).expect("cmd");
+        assert!(
+            !cmd_none.contains("FOR ROLE"),
+            "single-node preset must not name a deploy owner; got:\n{cmd_none}"
+        );
+        assert!(
+            cmd_none.contains(
+                r#"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO "reader""#
+            ),
+            "single-node preset keeps role-scoped-to-self defaults; got:\n{cmd_none}"
+        );
+    }
+
+    #[test]
     fn create_role_rejects_bad_username() {
         use gfs_domain::model::db_user::RoleSpec;
         let provider = PostgresqlProvider::new();
@@ -1503,6 +1561,7 @@ mod tests {
                 username: bad.into(),
                 password: "x".into(),
                 preset: None,
+                default_privileges_owner: None,
             };
             assert!(
                 provider.create_role_command(&spec).is_err(),

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -34,6 +34,28 @@ const DEFAULT_USER: &str = "postgres";
 const DEFAULT_PASSWORD: &str = "postgres";
 const DEFAULT_DB: &str = "postgres";
 
+/// Shell fragment (POSIX `sh`) run at deploy bootstrap to confine the management
+/// superuser (`${POSTGRES_USER}`) to the container's loopback. It prepends four
+/// rules ahead of the existing pg_hba entries — `local`/`127.0.0.1`/`::1` allow,
+/// then a non-loopback `reject` — so, under pg_hba first-match, the management
+/// role authenticates over the loopback exec seam but is refused over the exposed
+/// endpoint, while every client role falls through to the catch-all unchanged.
+/// The rewrite truncates the file in place to preserve its owner and `0600` mode,
+/// is guarded by a marker line for idempotency, and leaves the reload to the
+/// caller (a following `SELECT pg_reload_conf()`).
+const RESTRICT_MGMT_ROLE_TO_LOOPBACK: &str = concat!(
+    r#"HBA="${PGDATA:-/var/lib/postgresql/data}/pg_hba.conf"; "#,
+    r#"ADMIN="${POSTGRES_USER:-postgres}"; "#,
+    r#"if ! grep -q "gfs-managed loopback-only ${ADMIN}" "$HBA" 2>/dev/null; then "#,
+    r#"{ printf '# gfs-managed loopback-only %s\n' "$ADMIN"; "#,
+    r#"printf 'local all "%s" trust\n' "$ADMIN"; "#,
+    r#"printf 'host all "%s" 127.0.0.1/32 trust\n' "$ADMIN"; "#,
+    r#"printf 'host all "%s" ::1/128 trust\n' "$ADMIN"; "#,
+    r#"printf 'host all "%s" all reject\n' "$ADMIN"; "#,
+    r#"cat "$HBA"; } > "$HBA.gfs" && cat "$HBA.gfs" > "$HBA" && rm -f "$HBA.gfs"; "#,
+    r#"fi"#,
+);
+
 /// PostgreSQL compute definition provider. Supplies the definition and
 /// provider-specific behaviour (connection string, name, default port).
 #[derive(Debug)]
@@ -750,7 +772,19 @@ impl DatabaseProvider for PostgresqlProvider {
              COMMIT;",
             pw = sql_lit(&spec.owner_password),
         );
-        self.query_in_instance_command(&sql, None)
+        let bootstrap = self.query_in_instance_command(&sql, None)?;
+        // Confine the management superuser (`${POSTGRES_USER}`) to the container's
+        // loopback exec seam. It is the platform's management root and is never
+        // handed to a client, so even a leaked credential must not reach the
+        // database over the exposed endpoint. pg_hba is not settable via SQL, so
+        // rewrite it in the running instance: prepend loopback allow rules + a
+        // non-loopback reject for the management role ahead of the catch-all
+        // (pg_hba is first-match), preserving the file's owner/perms via an
+        // in-place truncate, then reload. Client roles (the owner + created users)
+        // fall through to the catch-all and keep authenticating over the endpoint.
+        // Idempotent (guarded by a marker) and fail-closed (`set -e`).
+        let reload = self.query_in_instance_command("SELECT pg_reload_conf();", None)?;
+        Ok(format!("set -e\n{bootstrap}\n{RESTRICT_MGMT_ROLE_TO_LOOPBACK}\n{reload}\n"))
     }
 
     fn grant_command(&self, spec: &GrantSpec) -> std::result::Result<String, ProviderError> {
@@ -1706,6 +1740,24 @@ mod tests {
         assert!(
             !cmd.to_uppercase().contains("REVOKE"),
             "no manual public lock"
+        );
+        // management super confined to loopback: pg_hba rewrite (loopback allow +
+        // non-loopback reject for ${POSTGRES_USER}) ahead of the catch-all, then
+        // reload — fail-closed under `set -e`.
+        assert!(cmd.starts_with("set -e"), "bootstrap must be fail-closed");
+        assert!(cmd.contains("pg_hba.conf"), "must rewrite pg_hba");
+        assert!(
+            cmd.contains(r#"host all "%s" all reject"#)
+                && cmd.contains(r#""${POSTGRES_USER:-postgres}""#),
+            "management role must be rejected off-loopback"
+        );
+        assert!(
+            cmd.contains(r#"host all "%s" 127.0.0.1/32 trust"#),
+            "management role must stay allowed on loopback"
+        );
+        assert!(
+            cmd.contains("pg_reload_conf()"),
+            "pg_hba change must be reloaded"
         );
     }
 

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -641,7 +641,7 @@ impl DatabaseProvider for PostgresqlProvider {
             sql.push_str(&pg_preset_sql(&ident, preset, owner.as_deref()));
         }
         // Wrap in a transaction so create+grants are atomic (fixes v2 partial-state).
-        self.query_in_instance_command(&format!("BEGIN;\n{sql}\nCOMMIT;"))
+        self.query_in_instance_command(&format!("BEGIN;\n{sql}\nCOMMIT;"), None)
     }
 
     fn alter_password_command(
@@ -650,10 +650,10 @@ impl DatabaseProvider for PostgresqlProvider {
         password: &str,
     ) -> std::result::Result<String, ProviderError> {
         let ident = pg_quote_ident(username)?;
-        self.query_in_instance_command(&format!(
-            "ALTER ROLE {ident} WITH PASSWORD '{}';",
-            sql_lit(password)
-        ))
+        self.query_in_instance_command(
+            &format!("ALTER ROLE {ident} WITH PASSWORD '{}';", sql_lit(password)),
+            None,
+        )
     }
 
     fn drop_role_command(&self, username: &str) -> std::result::Result<String, ProviderError> {
@@ -666,9 +666,12 @@ impl DatabaseProvider for PostgresqlProvider {
         // created (it now owns no objects, so nothing is destroyed). `DROP ROLE`
         // then succeeds instead of failing with "objects depend on it".
         // Transactional so a partial drop can't leave a half-removed role.
-        self.query_in_instance_command(&format!(
-            "BEGIN;\nREASSIGN OWNED BY {ident} TO CURRENT_USER;\nDROP OWNED BY {ident};\nDROP ROLE {ident};\nCOMMIT;"
-        ))
+        self.query_in_instance_command(
+            &format!(
+                "BEGIN;\nREASSIGN OWNED BY {ident} TO CURRENT_USER;\nDROP OWNED BY {ident};\nDROP ROLE {ident};\nCOMMIT;"
+            ),
+            None,
+        )
     }
 
     fn list_roles_command(&self) -> std::result::Result<String, ProviderError> {
@@ -703,10 +706,13 @@ impl DatabaseProvider for PostgresqlProvider {
         // in one transaction. `create_role` does not need this (a fresh role has
         // nothing to reset).
         let reset = pg_preset_reset_sql(&ident, owner.as_deref());
-        self.query_in_instance_command(&format!(
-            "BEGIN;\n{reset}\n{}\nCOMMIT;",
-            pg_preset_sql(&ident, preset, owner.as_deref())
-        ))
+        self.query_in_instance_command(
+            &format!(
+                "BEGIN;\n{reset}\n{}\nCOMMIT;",
+                pg_preset_sql(&ident, preset, owner.as_deref())
+            ),
+            None,
+        )
     }
 
     fn bootstrap_deploy_env_command(
@@ -736,7 +742,7 @@ impl DatabaseProvider for PostgresqlProvider {
              COMMIT;",
             pw = sql_lit(&spec.owner_password),
         );
-        self.query_in_instance_command(&sql)
+        self.query_in_instance_command(&sql, None)
     }
 
     fn grant_command(&self, spec: &GrantSpec) -> std::result::Result<String, ProviderError> {
@@ -751,7 +757,7 @@ impl DatabaseProvider for PostgresqlProvider {
         )?;
         // Transactional so a multi-statement grant (+ optional default-privileges
         // line) is atomic — no partial grant on failure (fixes v2 gap).
-        self.query_in_instance_command(&format!("BEGIN;\n{stmts}\nCOMMIT;"))
+        self.query_in_instance_command(&format!("BEGIN;\n{stmts}\nCOMMIT;"), None)
     }
 
     fn revoke_command(&self, spec: &RevokeSpec) -> std::result::Result<String, ProviderError> {
@@ -764,7 +770,7 @@ impl DatabaseProvider for PostgresqlProvider {
             spec.cascade,
             None,
         )?;
-        self.query_in_instance_command(&format!("BEGIN;\n{stmts}\nCOMMIT;"))
+        self.query_in_instance_command(&format!("BEGIN;\n{stmts}\nCOMMIT;"), None)
     }
 
     fn list_privileges_command(&self, role: &str) -> std::result::Result<String, ProviderError> {

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -784,7 +784,9 @@ impl DatabaseProvider for PostgresqlProvider {
         // fall through to the catch-all and keep authenticating over the endpoint.
         // Idempotent (guarded by a marker) and fail-closed (`set -e`).
         let reload = self.query_in_instance_command("SELECT pg_reload_conf();", None)?;
-        Ok(format!("set -e\n{bootstrap}\n{RESTRICT_MGMT_ROLE_TO_LOOPBACK}\n{reload}\n"))
+        Ok(format!(
+            "set -e\n{bootstrap}\n{RESTRICT_MGMT_ROLE_TO_LOOPBACK}\n{reload}\n"
+        ))
     }
 
     fn grant_command(&self, spec: &GrantSpec) -> std::result::Result<String, ProviderError> {

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use gfs_domain::model::db_user::{RolePreset, RoleSpec};
+use gfs_domain::model::db_user::{DeployEnvSpec, RolePreset, RoleSpec};
 use gfs_domain::ports::compute::{ComputeDefinition, EnvVar, PortMapping};
 use gfs_domain::ports::database_provider::{
     CloneSpec, ConnectionParams, DataFormat, DatabaseProvider, DatabaseProviderArg,
@@ -691,6 +691,36 @@ impl DatabaseProvider for PostgresqlProvider {
         ))
     }
 
+    fn bootstrap_deploy_env_command(
+        &self,
+        spec: &DeployEnvSpec,
+    ) -> std::result::Result<String, ProviderError> {
+        let owner = pg_quote_ident(&spec.owner)?;
+        let group = pg_quote_ident(&spec.group)?;
+        let database = pg_quote_ident(&spec.database)?;
+        // RFC 009 §5.1, hardened + transactional. The owner is LOGIN NOSUPERUSER
+        // NOCREATEROLE NOCREATEDB and is NOT made the database owner — it keeps
+        // `public` (explicit USAGE,CREATE + CONNECT, since roles don't inherit
+        // CONNECT once PUBLIC's default is revoked) but cannot DROP DATABASE or
+        // escalate. `public` itself is left at the engine default (PG15+ already
+        // denies CREATE to PUBLIC — no manual REVOKE). Future owner objects flow
+        // to the group via role-scoped default privileges (fixes v2 gap R5).
+        let sql = format!(
+            "BEGIN;\n\
+             CREATE ROLE {group} NOLOGIN;\n\
+             GRANT USAGE ON SCHEMA public TO {group};\n\
+             CREATE ROLE {owner} WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD '{pw}';\n\
+             GRANT CONNECT ON DATABASE {database} TO {owner};\n\
+             GRANT USAGE, CREATE ON SCHEMA public TO {owner};\n\
+             GRANT {group} TO {owner};\n\
+             ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {group};\n\
+             ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO {group};\n\
+             COMMIT;",
+            pw = sql_lit(&spec.owner_password),
+        );
+        self.query_in_instance_command(&sql)
+    }
+
     // -----------------------------------------------------------------------
     // Schema Extraction
     // -----------------------------------------------------------------------
@@ -1289,6 +1319,53 @@ mod tests {
         assert!(provider.drop_role_command("bad name").is_err());
         let alter = provider.alter_password_command("app_ro", "new'pw").unwrap();
         assert!(alter.contains(r#"ALTER ROLE "app_ro" WITH PASSWORD 'new''pw';"#));
+    }
+
+    #[test]
+    fn bootstrap_deploy_env_command_emits_hardened_sql() {
+        let provider = PostgresqlProvider::new();
+        let spec = DeployEnvSpec {
+            owner: "app_owner".into(),
+            owner_password: "s3cret'pw".into(),
+            group: "developers".into(),
+            database: "appdb".into(),
+        };
+        let cmd = provider.bootstrap_deploy_env_command(&spec).unwrap();
+        // group NOLOGIN + least-privileged owner; identifiers quoted, password escaped.
+        assert!(cmd.contains(r#"CREATE ROLE "developers" NOLOGIN;"#));
+        assert!(cmd.contains(
+            r#"CREATE ROLE "app_owner" WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD 's3cret''pw';"#
+        ));
+        // owner keeps `public` (explicit CONNECT + USAGE,CREATE).
+        assert!(cmd.contains(r#"GRANT CONNECT ON DATABASE "appdb" TO "app_owner";"#));
+        assert!(cmd.contains(r#"GRANT USAGE, CREATE ON SCHEMA public TO "app_owner";"#));
+        // membership + role-scoped default privileges (future owner objects → group).
+        assert!(cmd.contains(r#"GRANT "developers" TO "app_owner";"#));
+        assert!(cmd.contains(
+            r#"ALTER DEFAULT PRIVILEGES FOR ROLE "app_owner" IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "developers";"#
+        ));
+        // transactional; owner is NOT the DB owner; no manual `public` REVOKE.
+        assert!(cmd.contains("BEGIN;") && cmd.contains("COMMIT;"));
+        assert!(
+            !cmd.contains("ALTER DATABASE"),
+            "owner must not become DB owner"
+        );
+        assert!(
+            !cmd.to_uppercase().contains("REVOKE"),
+            "no manual public lock"
+        );
+    }
+
+    #[test]
+    fn bootstrap_deploy_env_command_rejects_bad_identifiers() {
+        let provider = PostgresqlProvider::new();
+        let bad = DeployEnvSpec {
+            owner: "bad name".into(),
+            owner_password: "x".into(),
+            group: "developers".into(),
+            database: "appdb".into(),
+        };
+        assert!(provider.bootstrap_deploy_env_command(&bad).is_err());
     }
 
     #[test]

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -639,6 +639,11 @@ impl DatabaseProvider for PostgresqlProvider {
                 .transpose()?;
             sql.push('\n');
             sql.push_str(&pg_preset_sql(&ident, preset, owner.as_deref()));
+            // Record the applied preset in the role comment so `list` surfaces it.
+            sql.push_str(&format!(
+                "\nCOMMENT ON ROLE {ident} IS 'gfs-preset:{}';",
+                preset.as_str()
+            ));
         }
         // Wrap in a transaction so create+grants are atomic (fixes v2 partial-state).
         self.query_in_instance_command(&format!("BEGIN;\n{sql}\nCOMMIT;"), None)
@@ -683,7 +688,9 @@ impl DatabaseProvider for PostgresqlProvider {
         // supers (`guepard-admin`, `postgres`) — neither is a client role, and
         // surfacing the connection superuser invites a wedging `drop` (see
         // `reject_reserved_role`).
-        let sql = "SELECT COALESCE(json_agg(json_build_object('username', rolname, 'can_login', rolcanlogin, 'is_superuser', rolsuper) ORDER BY rolname), '[]'::json) \
+        // `preset` is read back from the role comment (`gfs-preset:<name>`) set at
+        // create/apply time; NULL when the role carries no preset comment.
+        let sql = "SELECT COALESCE(json_agg(json_build_object('username', rolname, 'can_login', rolcanlogin, 'is_superuser', rolsuper, 'preset', substring(shobj_description(oid, 'pg_authid') FROM '^gfs-preset:(.*)$')) ORDER BY rolname), '[]'::json) \
                    FROM pg_roles WHERE left(rolname, 3) <> 'pg_' AND rolname NOT IN ('guepard-admin', 'postgres');";
         let body = gfs_domain::utils::shell::sql_heredoc_body(DELIM, sql)?;
         Ok(format!(
@@ -708,8 +715,9 @@ impl DatabaseProvider for PostgresqlProvider {
         let reset = pg_preset_reset_sql(&ident, owner.as_deref());
         self.query_in_instance_command(
             &format!(
-                "BEGIN;\n{reset}\n{}\nCOMMIT;",
-                pg_preset_sql(&ident, preset, owner.as_deref())
+                "BEGIN;\n{reset}\n{}\nCOMMENT ON ROLE {ident} IS 'gfs-preset:{}';\nCOMMIT;",
+                pg_preset_sql(&ident, preset, owner.as_deref()),
+                preset.as_str()
             ),
             None,
         )

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -696,8 +696,15 @@ impl DatabaseProvider for PostgresqlProvider {
     ) -> std::result::Result<String, ProviderError> {
         let ident = pg_quote_ident(username)?;
         let owner = default_privileges_owner.map(pg_quote_ident).transpose()?;
+        // Declarative, not additive: reset the role's schema-public privileges
+        // first so a *lower* preset (e.g. readwrite -> readonly) actually removes
+        // the higher grants + default-ACL entries, instead of leaving them (a
+        // downgrade that silently keeps write access). The reset + new grants run
+        // in one transaction. `create_role` does not need this (a fresh role has
+        // nothing to reset).
+        let reset = pg_preset_reset_sql(&ident, owner.as_deref());
         self.query_in_instance_command(&format!(
-            "BEGIN;\n{}\nCOMMIT;",
+            "BEGIN;\n{reset}\n{}\nCOMMIT;",
             pg_preset_sql(&ident, preset, owner.as_deref())
         ))
     }
@@ -989,6 +996,40 @@ fn pg_quote_ident(ident: &str) -> std::result::Result<String, ProviderError> {
             "invalid database identifier: {ident:?}"
         )))
     }
+}
+
+/// Revoke every privilege a preset could have granted the already-quoted role
+/// `ident` on schema `public`, so [`pg_preset_sql`] can re-apply a preset
+/// declaratively (the role ends at exactly the new preset, never the union of
+/// old + new). Covers ALL table/sequence privileges, `CREATE` on the schema, and
+/// the `ALTER DEFAULT PRIVILEGES` entries — both connecting-role-scoped and, when
+/// `owner` is set, `FOR ROLE owner`. `USAGE ON SCHEMA public` is left alone (every
+/// preset re-grants it). Semicolon-terminated; the caller wraps it in the same
+/// transaction as the re-grant.
+fn pg_preset_reset_sql(ident: &str, owner: Option<&str>) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM {ident};\n"
+    ));
+    s.push_str(&format!(
+        "REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM {ident};\n"
+    ));
+    s.push_str(&format!("REVOKE CREATE ON SCHEMA public FROM {ident};\n"));
+    s.push_str(&format!(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM {ident};\n"
+    ));
+    s.push_str(&format!(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON SEQUENCES FROM {ident};"
+    ));
+    if let Some(owner) = owner {
+        s.push_str(&format!(
+            "\nALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA public REVOKE ALL ON TABLES FROM {ident};\n"
+        ));
+        s.push_str(&format!(
+            "ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA public REVOKE ALL ON SEQUENCES FROM {ident};"
+        ));
+    }
+    s
 }
 
 /// The allow-listed grant bundle for `preset`, applied to the already-quoted
@@ -1550,6 +1591,32 @@ mod tests {
             ),
             "single-node preset keeps role-scoped-to-self defaults; got:\n{cmd_none}"
         );
+    }
+
+    #[test]
+    fn apply_preset_is_declarative_resets_before_granting() {
+        use gfs_domain::model::db_user::RolePreset;
+        let provider = PostgresqlProvider::new();
+        // apply_preset must REVOKE the role's existing schema-public privileges
+        // (incl. FOR ROLE owner default-ACLs) BEFORE granting the new preset, so a
+        // downgrade actually reduces privileges.
+        let cmd = provider
+            .apply_preset_command("app_rw", RolePreset::Readonly, Some("owner"))
+            .expect("cmd");
+        assert!(
+            cmd.contains(r#"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "app_rw""#),
+            "must revoke existing table privileges first; got:\n{cmd}"
+        );
+        assert!(
+            cmd.contains(
+                r#"ALTER DEFAULT PRIVILEGES FOR ROLE "owner" IN SCHEMA public REVOKE ALL ON TABLES FROM "app_rw""#
+            ),
+            "must revoke owner-scoped default privileges first; got:\n{cmd}"
+        );
+        // The reset precedes the new preset's grant (declarative order).
+        let revoke_at = cmd.find("REVOKE ALL PRIVILEGES ON ALL TABLES").unwrap();
+        let grant_at = cmd.find("GRANT SELECT ON ALL TABLES").unwrap();
+        assert!(revoke_at < grant_at, "reset must run before the re-grant");
     }
 
     #[test]

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use gfs_domain::model::db_user::{RolePreset, RoleSpec};
 use gfs_domain::ports::compute::{ComputeDefinition, EnvVar, PortMapping};
 use gfs_domain::ports::database_provider::{
     CloneSpec, ConnectionParams, DataFormat, DatabaseProvider, DatabaseProviderArg,
@@ -615,6 +616,68 @@ impl DatabaseProvider for PostgresqlProvider {
     }
 
     // -----------------------------------------------------------------------
+    // User / role management (`gfs user`)
+    // -----------------------------------------------------------------------
+
+    fn create_role_command(&self, spec: &RoleSpec) -> std::result::Result<String, ProviderError> {
+        let ident = pg_quote_ident(&spec.username)?;
+        // NOSUPERUSER / NOCREATEROLE: client roles are never privileged (fixes
+        // v2 escalation). Password via a quoted literal — never bare (v2 gap #3).
+        let mut sql = format!(
+            "CREATE ROLE {ident} WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD '{}';",
+            sql_lit(&spec.password)
+        );
+        if let Some(preset) = spec.preset {
+            sql.push('\n');
+            sql.push_str(&pg_preset_sql(&ident, preset));
+        }
+        // Wrap in a transaction so create+grants are atomic (fixes v2 partial-state).
+        self.query_in_instance_command(&format!("BEGIN;\n{sql}\nCOMMIT;"))
+    }
+
+    fn alter_password_command(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> std::result::Result<String, ProviderError> {
+        let ident = pg_quote_ident(username)?;
+        self.query_in_instance_command(&format!(
+            "ALTER ROLE {ident} WITH PASSWORD '{}';",
+            sql_lit(password)
+        ))
+    }
+
+    fn drop_role_command(&self, username: &str) -> std::result::Result<String, ProviderError> {
+        let ident = pg_quote_ident(username)?;
+        self.query_in_instance_command(&format!("DROP ROLE {ident};"))
+    }
+
+    fn list_roles_command(&self) -> std::result::Result<String, ProviderError> {
+        // `-tA` (tuples-only, unaligned) → clean JSON on stdout. `left(rolname,3)`
+        // filters system `pg_*` roles without LIKE-escape fragility; the private
+        // `guepard-admin` management role is never listed.
+        const DELIM: &str = "GFS_SQL_EOF";
+        let sql = "SELECT COALESCE(json_agg(json_build_object('username', rolname, 'can_login', rolcanlogin, 'is_superuser', rolsuper) ORDER BY rolname), '[]'::json) \
+                   FROM pg_roles WHERE left(rolname, 3) <> 'pg_' AND rolname <> 'guepard-admin';";
+        let body = gfs_domain::utils::shell::sql_heredoc_body(DELIM, sql)?;
+        Ok(format!(
+            r#"PGPASSWORD="${{POSTGRES_PASSWORD:-postgres}}" psql -h 127.0.0.1 -U "${{POSTGRES_USER:-postgres}}" -d "${{POSTGRES_DB:-postgres}}" -tA -v ON_ERROR_STOP=1 -c "{body}""#
+        ))
+    }
+
+    fn apply_preset_command(
+        &self,
+        username: &str,
+        preset: RolePreset,
+    ) -> std::result::Result<String, ProviderError> {
+        let ident = pg_quote_ident(username)?;
+        self.query_in_instance_command(&format!(
+            "BEGIN;\n{}\nCOMMIT;",
+            pg_preset_sql(&ident, preset)
+        ))
+    }
+
+    // -----------------------------------------------------------------------
     // Schema Extraction
     // -----------------------------------------------------------------------
 
@@ -791,6 +854,71 @@ const CLONE_BOOTSTRAP_TMPL: &str = include_str!("clone_bootstrap.sql");
 /// Escape a value for use inside a single-quoted SQL string literal.
 fn sql_lit(s: &str) -> String {
     s.replace('\'', "''")
+}
+
+/// Validate a database identifier and wrap it in double quotes for SQL.
+/// Rejects anything outside `[A-Za-z0-9_]{1,63}` — closes the identifier
+/// injection surface (v2 gap #3). Non-empty, ASCII alnum + underscore only.
+fn pg_quote_ident(ident: &str) -> std::result::Result<String, ProviderError> {
+    let valid = !ident.is_empty()
+        && ident.len() <= 63
+        && ident
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_');
+    if valid {
+        Ok(format!("\"{ident}\""))
+    } else {
+        Err(ProviderError::InvalidParams(format!(
+            "invalid database identifier: {ident:?}"
+        )))
+    }
+}
+
+/// The allow-listed grant bundle for `preset`, applied to the already-quoted
+/// role `ident` on schema `public`. Semicolon-terminated; the caller wraps the
+/// bundle in a transaction. `ALTER DEFAULT PRIVILEGES` covers future objects.
+fn pg_preset_sql(ident: &str, preset: RolePreset) -> String {
+    let mut s = format!("GRANT USAGE ON SCHEMA public TO {ident};\n");
+    match preset {
+        RolePreset::Readonly => {
+            s.push_str(&format!(
+                "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {ident};\n"
+            ));
+            s.push_str(&format!(
+                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO {ident};"
+            ));
+        }
+        RolePreset::Readwrite => {
+            s.push_str(&format!(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {ident};\n"
+            ));
+            s.push_str(&format!(
+                "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {ident};\n"
+            ));
+            s.push_str(&format!(
+                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {ident};\n"
+            ));
+            s.push_str(&format!(
+                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO {ident};"
+            ));
+        }
+        RolePreset::Admin => {
+            s.push_str(&format!("GRANT CREATE ON SCHEMA public TO {ident};\n"));
+            s.push_str(&format!(
+                "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {ident};\n"
+            ));
+            s.push_str(&format!(
+                "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {ident};\n"
+            ));
+            s.push_str(&format!(
+                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO {ident};\n"
+            ));
+            s.push_str(&format!(
+                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO {ident};"
+            ));
+        }
+    }
+    s
 }
 
 /// Build the bootstrap SQL run inside the local GFS database to set up a lazy
@@ -1081,6 +1209,76 @@ mod tests {
         assert!(cmd_db.contains("-d 'myapp'"));
         assert!(!cmd_db.contains("${POSTGRES_DB"));
         assert!(!cmd.starts_with("psql postgresql://"));
+    }
+
+    #[test]
+    fn create_role_command_is_hardened() {
+        use gfs_domain::model::db_user::{RolePreset, RoleSpec};
+        let provider = PostgresqlProvider::new();
+        let spec = RoleSpec {
+            username: "app_rw".into(),
+            password: "p'wd".into(),
+            preset: Some(RolePreset::Readwrite),
+        };
+        let cmd = provider.create_role_command(&spec).expect("cmd");
+        assert!(
+            cmd.contains(r#"CREATE ROLE "app_rw" WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE"#)
+        );
+        assert!(
+            cmd.contains("PASSWORD 'p''wd'"),
+            "password literal must double the quote"
+        );
+        assert!(
+            cmd.contains("BEGIN;"),
+            "create+grants must be transactional"
+        );
+        assert!(
+            cmd.contains("GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public")
+        );
+    }
+
+    #[test]
+    fn create_role_rejects_bad_username() {
+        use gfs_domain::model::db_user::RoleSpec;
+        let provider = PostgresqlProvider::new();
+        for bad in ["bad name", "drop;--", "", "a\"b", "x'; DROP ROLE y; --"] {
+            let spec = RoleSpec {
+                username: bad.into(),
+                password: "x".into(),
+                preset: None,
+            };
+            assert!(
+                provider.create_role_command(&spec).is_err(),
+                "must reject username {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn drop_and_alter_password_quote_identifier_and_literal() {
+        let provider = PostgresqlProvider::new();
+        assert!(
+            provider
+                .drop_role_command("app_ro")
+                .unwrap()
+                .contains(r#"DROP ROLE "app_ro";"#)
+        );
+        assert!(provider.drop_role_command("bad name").is_err());
+        let alter = provider.alter_password_command("app_ro", "new'pw").unwrap();
+        assert!(alter.contains(r#"ALTER ROLE "app_ro" WITH PASSWORD 'new''pw';"#));
+    }
+
+    #[test]
+    fn list_roles_command_uses_ta_json_and_excludes_admin() {
+        let provider = PostgresqlProvider::new();
+        let cmd = provider.list_roles_command().expect("cmd");
+        assert!(
+            cmd.contains("-tA"),
+            "list must use tuples-only unaligned output"
+        );
+        assert!(cmd.contains("json_agg"));
+        assert!(cmd.contains("rolname <> 'guepard-admin'"));
+        assert!(cmd.contains("left(rolname, 3) <> 'pg_'"));
     }
 
     #[test]

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -649,12 +649,16 @@ impl DatabaseProvider for PostgresqlProvider {
 
     fn drop_role_command(&self, username: &str) -> std::result::Result<String, ProviderError> {
         let ident = pg_quote_ident(username)?;
-        // `DROP OWNED BY` first: it removes the role's grants — including the
-        // `ALTER DEFAULT PRIVILEGES` entries a preset created — and objects it
-        // owns, so `DROP ROLE` no longer fails with "objects depend on it".
+        // Non-destructive drop. `REASSIGN OWNED` first hands every object the
+        // role owns (tables, sequences, …) to the management role executing this
+        // — so dropping a user NEVER deletes its data, unlike a bare
+        // `DROP OWNED`/cascade. `DROP OWNED` then clears what's left: the role's
+        // granted privileges and the `ALTER DEFAULT PRIVILEGES` entries a preset
+        // created (it now owns no objects, so nothing is destroyed). `DROP ROLE`
+        // then succeeds instead of failing with "objects depend on it".
         // Transactional so a partial drop can't leave a half-removed role.
         self.query_in_instance_command(&format!(
-            "BEGIN;\nDROP OWNED BY {ident};\nDROP ROLE {ident};\nCOMMIT;"
+            "BEGIN;\nREASSIGN OWNED BY {ident} TO CURRENT_USER;\nDROP OWNED BY {ident};\nDROP ROLE {ident};\nCOMMIT;"
         ))
     }
 
@@ -1265,10 +1269,19 @@ mod tests {
         let provider = PostgresqlProvider::new();
         let drop = provider.drop_role_command("app_ro").unwrap();
         assert!(
+            drop.contains(r#"REASSIGN OWNED BY "app_ro" TO CURRENT_USER;"#),
+            "must reassign owned objects before dropping so no data is destroyed"
+        );
+        assert!(
             drop.contains(r#"DROP OWNED BY "app_ro";"#),
-            "must clean up grants first"
+            "must clean up grants after reassigning objects"
         );
         assert!(drop.contains(r#"DROP ROLE "app_ro";"#));
+        // REASSIGN must precede DROP OWNED, else owned tables would be destroyed.
+        assert!(
+            drop.find("REASSIGN OWNED").unwrap() < drop.find("DROP OWNED").unwrap(),
+            "REASSIGN must run before DROP OWNED"
+        );
         assert!(provider.drop_role_command("bad name").is_err());
         let alter = provider.alter_password_command("app_ro", "new'pw").unwrap();
         assert!(alter.contains(r#"ALTER ROLE "app_ro" WITH PASSWORD 'new''pw';"#));

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -667,8 +667,12 @@ impl DatabaseProvider for PostgresqlProvider {
         // filters system `pg_*` roles without LIKE-escape fragility; the private
         // `guepard-admin` management role is never listed.
         const DELIM: &str = "GFS_SQL_EOF";
+        // Exclude system `pg_*` roles and the platform's management/bootstrap
+        // supers (`guepard-admin`, `postgres`) — neither is a client role, and
+        // surfacing the connection superuser invites a wedging `drop` (see
+        // `reject_reserved_role`).
         let sql = "SELECT COALESCE(json_agg(json_build_object('username', rolname, 'can_login', rolcanlogin, 'is_superuser', rolsuper) ORDER BY rolname), '[]'::json) \
-                   FROM pg_roles WHERE left(rolname, 3) <> 'pg_' AND rolname <> 'guepard-admin';";
+                   FROM pg_roles WHERE left(rolname, 3) <> 'pg_' AND rolname NOT IN ('guepard-admin', 'postgres');";
         let body = gfs_domain::utils::shell::sql_heredoc_body(DELIM, sql)?;
         Ok(format!(
             r#"PGPASSWORD="${{POSTGRES_PASSWORD:-postgres}}" psql -h 127.0.0.1 -U "${{POSTGRES_USER:-postgres}}" -d "${{POSTGRES_DB:-postgres}}" -tA -v ON_ERROR_STOP=1 -c "{body}""#
@@ -1296,7 +1300,7 @@ mod tests {
             "list must use tuples-only unaligned output"
         );
         assert!(cmd.contains("json_agg"));
-        assert!(cmd.contains("rolname <> 'guepard-admin'"));
+        assert!(cmd.contains("rolname NOT IN ('guepard-admin', 'postgres')"));
         assert!(cmd.contains("left(rolname, 3) <> 'pg_'"));
     }
 

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -649,7 +649,13 @@ impl DatabaseProvider for PostgresqlProvider {
 
     fn drop_role_command(&self, username: &str) -> std::result::Result<String, ProviderError> {
         let ident = pg_quote_ident(username)?;
-        self.query_in_instance_command(&format!("DROP ROLE {ident};"))
+        // `DROP OWNED BY` first: it removes the role's grants — including the
+        // `ALTER DEFAULT PRIVILEGES` entries a preset created — and objects it
+        // owns, so `DROP ROLE` no longer fails with "objects depend on it".
+        // Transactional so a partial drop can't leave a half-removed role.
+        self.query_in_instance_command(&format!(
+            "BEGIN;\nDROP OWNED BY {ident};\nDROP ROLE {ident};\nCOMMIT;"
+        ))
     }
 
     fn list_roles_command(&self) -> std::result::Result<String, ProviderError> {
@@ -1257,12 +1263,12 @@ mod tests {
     #[test]
     fn drop_and_alter_password_quote_identifier_and_literal() {
         let provider = PostgresqlProvider::new();
+        let drop = provider.drop_role_command("app_ro").unwrap();
         assert!(
-            provider
-                .drop_role_command("app_ro")
-                .unwrap()
-                .contains(r#"DROP ROLE "app_ro";"#)
+            drop.contains(r#"DROP OWNED BY "app_ro";"#),
+            "must clean up grants first"
         );
+        assert!(drop.contains(r#"DROP ROLE "app_ro";"#));
         assert!(provider.drop_role_command("bad name").is_err());
         let alter = provider.alter_password_command("app_ro", "new'pw").unwrap();
         assert!(alter.contains(r#"ALTER ROLE "app_ro" WITH PASSWORD 'new''pw';"#));

--- a/crates/adapters/compute-docker/src/containers/postgresql.rs
+++ b/crates/adapters/compute-docker/src/containers/postgresql.rs
@@ -3,7 +3,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use gfs_domain::model::db_user::{DeployEnvSpec, RolePreset, RoleSpec};
+use gfs_domain::model::db_user::{
+    DeployEnvSpec, GrantSpec, GrantableObject, Privilege, RevokeSpec, RolePreset, RoleSpec,
+};
 use gfs_domain::ports::compute::{ComputeDefinition, EnvVar, PortMapping};
 use gfs_domain::ports::database_provider::{
     CloneSpec, ConnectionParams, DataFormat, DatabaseProvider, DatabaseProviderArg,
@@ -721,6 +723,68 @@ impl DatabaseProvider for PostgresqlProvider {
         self.query_in_instance_command(&sql)
     }
 
+    fn grant_command(&self, spec: &GrantSpec) -> std::result::Result<String, ProviderError> {
+        let stmts = pg_privilege_change_sql(
+            PrivilegeChange::Grant,
+            &spec.role,
+            &spec.object,
+            &spec.privileges,
+            spec.with_grant_option,
+            false,
+            spec.apply_to_future.as_deref(),
+        )?;
+        // Transactional so a multi-statement grant (+ optional default-privileges
+        // line) is atomic — no partial grant on failure (fixes v2 gap).
+        self.query_in_instance_command(&format!("BEGIN;\n{stmts}\nCOMMIT;"))
+    }
+
+    fn revoke_command(&self, spec: &RevokeSpec) -> std::result::Result<String, ProviderError> {
+        let stmts = pg_privilege_change_sql(
+            PrivilegeChange::Revoke,
+            &spec.role,
+            &spec.object,
+            &spec.privileges,
+            false,
+            spec.cascade,
+            None,
+        )?;
+        self.query_in_instance_command(&format!("BEGIN;\n{stmts}\nCOMMIT;"))
+    }
+
+    fn list_privileges_command(&self, role: &str) -> std::result::Result<String, ProviderError> {
+        // Validate the identifier even though the query filters by a quoted
+        // literal — defence-in-depth (rejects anything outside the ident set).
+        pg_quote_ident(role)?;
+        const DELIM: &str = "GFS_SQL_EOF";
+        // Live read from the engine catalog (authoritative; no CP mirror). Table
+        // + sequence grants come from `information_schema.role_*_grants`; schema
+        // + database grants are expanded from their ACLs via `aclexplode`. `-tA`
+        // + `json_agg` → clean JSON parsed into `Vec<ObjectPrivilege>`. Never a
+        // secret. `grantee` is matched against a quoted literal.
+        let grantee = sql_lit(role);
+        let sql = format!(
+            "SELECT COALESCE(json_agg(row_to_json(p) ORDER BY p.object_type, p.object_name, p.privilege), '[]'::json) FROM (\n\
+               SELECT 'table'::text AS object_type, table_schema || '.' || table_name AS object_name, lower(privilege_type) AS privilege, (is_grantable = 'YES') AS grantable \
+                 FROM information_schema.role_table_grants WHERE grantee = '{grantee}'\n\
+             UNION ALL\n\
+               SELECT 'sequence'::text, object_schema || '.' || object_name, lower(privilege_type), (is_grantable = 'YES') \
+                 FROM information_schema.role_usage_grants WHERE grantee = '{grantee}' AND object_type = 'SEQUENCE'\n\
+             UNION ALL\n\
+               SELECT 'schema'::text, n.nspname, lower(a.privilege_type), a.is_grantable \
+                 FROM pg_namespace n, aclexplode(n.nspacl) a JOIN pg_roles r ON r.oid = a.grantee \
+                 WHERE r.rolname = '{grantee}'\n\
+             UNION ALL\n\
+               SELECT 'database'::text, d.datname, lower(a.privilege_type), a.is_grantable \
+                 FROM pg_database d, aclexplode(d.datacl) a JOIN pg_roles r ON r.oid = a.grantee \
+                 WHERE r.rolname = '{grantee}' AND d.datname = current_database()\n\
+             ) p;"
+        );
+        let body = gfs_domain::utils::shell::sql_heredoc_body(DELIM, &sql)?;
+        Ok(format!(
+            r#"PGPASSWORD="${{POSTGRES_PASSWORD:-postgres}}" psql -h 127.0.0.1 -U "${{POSTGRES_USER:-postgres}}" -d "${{POSTGRES_DB:-postgres}}" -tA -v ON_ERROR_STOP=1 -c "{body}""#
+        ))
+    }
+
     // -----------------------------------------------------------------------
     // Schema Extraction
     // -----------------------------------------------------------------------
@@ -963,6 +1027,155 @@ fn pg_preset_sql(ident: &str, preset: RolePreset) -> String {
         }
     }
     s
+}
+
+/// Whether a privilege change is a GRANT or a REVOKE.
+#[derive(Clone, Copy)]
+enum PrivilegeChange {
+    Grant,
+    Revoke,
+}
+
+/// The uppercase SQL keyword for a single privilege. `All` renders as the full
+/// `ALL PRIVILEGES` (though [`pg_privilege_list`] handles the ALL case first).
+fn pg_privilege_keyword(p: Privilege) -> &'static str {
+    match p {
+        Privilege::Select => "SELECT",
+        Privilege::Insert => "INSERT",
+        Privilege::Update => "UPDATE",
+        Privilege::Delete => "DELETE",
+        Privilege::Truncate => "TRUNCATE",
+        Privilege::References => "REFERENCES",
+        Privilege::Trigger => "TRIGGER",
+        Privilege::Usage => "USAGE",
+        Privilege::Create => "CREATE",
+        Privilege::Connect => "CONNECT",
+        Privilege::Temporary => "TEMPORARY",
+        Privilege::All => "ALL PRIVILEGES",
+    }
+}
+
+/// Render a privilege set for a `GRANT`/`REVOKE`. If any element is `All`, the
+/// whole set collapses to `ALL PRIVILEGES` (PostgreSQL forbids mixing `ALL`
+/// with named privileges).
+fn pg_privilege_list(privileges: &[Privilege]) -> String {
+    if privileges.iter().any(|p| matches!(p, Privilege::All)) {
+        return "ALL PRIVILEGES".to_string();
+    }
+    privileges
+        .iter()
+        .map(|p| pg_privilege_keyword(*p))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The `ON …` object clause for the non-`Database` variants, with every
+/// identifier validated + double-quoted via [`pg_quote_ident`]. `Database` is
+/// assembled separately (its name is resolved at runtime).
+fn pg_grant_object_clause(obj: &GrantableObject) -> std::result::Result<String, ProviderError> {
+    Ok(match obj {
+        GrantableObject::Database => {
+            return Err(ProviderError::InvalidParams(
+                "database object clause is assembled at runtime, not here".into(),
+            ));
+        }
+        GrantableObject::Schema { schema } => format!("ON SCHEMA {}", pg_quote_ident(schema)?),
+        GrantableObject::Table { schema, name } => {
+            format!(
+                "ON TABLE {}.{}",
+                pg_quote_ident(schema)?,
+                pg_quote_ident(name)?
+            )
+        }
+        GrantableObject::AllTablesInSchema { schema } => {
+            format!("ON ALL TABLES IN SCHEMA {}", pg_quote_ident(schema)?)
+        }
+        GrantableObject::Sequence { schema, name } => format!(
+            "ON SEQUENCE {}.{}",
+            pg_quote_ident(schema)?,
+            pg_quote_ident(name)?
+        ),
+        GrantableObject::AllSequencesInSchema { schema } => {
+            format!("ON ALL SEQUENCES IN SCHEMA {}", pg_quote_ident(schema)?)
+        }
+    })
+}
+
+/// Build the (non-transaction-wrapped) `GRANT`/`REVOKE` statement(s) for a
+/// privilege change. Every privilege is re-checked against the object type
+/// (allow-list, reject-not-warn), every identifier is `quote_ident`-quoted, and
+/// the `Database` scope resolves to the instance's own database at runtime. When
+/// `apply_to_future` is `Some(grantor)` (grant, all-in-schema scopes only) a
+/// role-scoped `ALTER DEFAULT PRIVILEGES FOR ROLE` line is appended.
+fn pg_privilege_change_sql(
+    action: PrivilegeChange,
+    role: &str,
+    object: &GrantableObject,
+    privileges: &[Privilege],
+    with_grant_option: bool,
+    cascade: bool,
+    apply_to_future: Option<&str>,
+) -> std::result::Result<String, ProviderError> {
+    if privileges.is_empty() {
+        return Err(ProviderError::InvalidParams(
+            "at least one privilege is required".into(),
+        ));
+    }
+    for p in privileges {
+        if !p.is_valid_for(object) {
+            return Err(ProviderError::InvalidParams(format!(
+                "privilege {} is not valid for the target object type",
+                pg_privilege_keyword(*p)
+            )));
+        }
+    }
+    let role_ident = pg_quote_ident(role)?;
+    let privs = pg_privilege_list(privileges);
+    let (verb, dir) = match action {
+        PrivilegeChange::Grant => ("GRANT", "TO"),
+        PrivilegeChange::Revoke => ("REVOKE", "FROM"),
+    };
+    let suffix = match action {
+        PrivilegeChange::Grant if with_grant_option => " WITH GRANT OPTION",
+        PrivilegeChange::Revoke if cascade => " CASCADE",
+        _ => "",
+    };
+
+    let mut sql = match object {
+        GrantableObject::Database => format!(
+            "DO $$ BEGIN EXECUTE '{verb} {privs} ON DATABASE ' || quote_ident(current_database()) || ' {dir} {role_ident}{suffix}'; END $$;"
+        ),
+        other => {
+            let clause = pg_grant_object_clause(other)?;
+            format!("{verb} {privs} {clause} {dir} {role_ident}{suffix};")
+        }
+    };
+
+    if let Some(grantor) = apply_to_future {
+        if matches!(action, PrivilegeChange::Revoke) {
+            return Err(ProviderError::InvalidParams(
+                "apply_to_future is only valid for grant".into(),
+            ));
+        }
+        let (schema, kind) = match object {
+            GrantableObject::AllTablesInSchema { schema } => (schema, "TABLES"),
+            GrantableObject::AllSequencesInSchema { schema } => (schema, "SEQUENCES"),
+            _ => {
+                return Err(ProviderError::InvalidParams(
+                    "apply_to_future is only valid for all-tables/all-sequences-in-schema scopes"
+                        .into(),
+                ));
+            }
+        };
+        let grantor_ident = pg_quote_ident(grantor)?;
+        let schema_ident = pg_quote_ident(schema)?;
+        sql.push('\n');
+        sql.push_str(&format!(
+            "ALTER DEFAULT PRIVILEGES FOR ROLE {grantor_ident} IN SCHEMA {schema_ident} GRANT {privs} ON {kind} TO {role_ident};"
+        ));
+    }
+
+    Ok(sql)
 }
 
 /// Build the bootstrap SQL run inside the local GFS database to set up a lazy
@@ -1720,6 +1933,318 @@ mod tests {
         assert!(
             spec.command
                 .contains("sed -i '/^SET transaction_timeout/d' /tmp/gfs_faithful.sql")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Object-level grant / revoke / list-privileges (phase 2) — exact SQL
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn grant_command_quotes_and_wraps_in_txn() {
+        use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege};
+        let provider = PostgresqlProvider::new();
+        let spec = GrantSpec {
+            role: "app_ro".into(),
+            object: GrantableObject::Table {
+                schema: "public".into(),
+                name: "orders".into(),
+            },
+            privileges: vec![Privilege::Select, Privilege::Insert],
+            with_grant_option: false,
+            apply_to_future: None,
+        };
+        let cmd = provider.grant_command(&spec).expect("cmd");
+        assert!(
+            cmd.contains(r#"GRANT SELECT, INSERT ON TABLE "public"."orders" TO "app_ro";"#),
+            "got: {cmd}"
+        );
+        assert!(
+            cmd.contains("BEGIN;") && cmd.contains("COMMIT;"),
+            "must be transactional"
+        );
+    }
+
+    #[test]
+    fn grant_command_collapses_all_and_appends_grant_option() {
+        use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege};
+        let provider = PostgresqlProvider::new();
+        let spec = GrantSpec {
+            role: "app_admin".into(),
+            object: GrantableObject::Schema {
+                schema: "public".into(),
+            },
+            privileges: vec![Privilege::All],
+            with_grant_option: true,
+            apply_to_future: None,
+        };
+        let cmd = provider.grant_command(&spec).unwrap();
+        assert!(
+            cmd.contains(
+                r#"GRANT ALL PRIVILEGES ON SCHEMA "public" TO "app_admin" WITH GRANT OPTION;"#
+            ),
+            "got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn grant_command_apply_to_future_emits_role_scoped_default_privileges() {
+        use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege};
+        let provider = PostgresqlProvider::new();
+        let spec = GrantSpec {
+            role: "developers".into(),
+            object: GrantableObject::AllTablesInSchema {
+                schema: "public".into(),
+            },
+            privileges: vec![Privilege::Select],
+            with_grant_option: false,
+            apply_to_future: Some("owner".into()),
+        };
+        let cmd = provider.grant_command(&spec).unwrap();
+        assert!(cmd.contains(r#"GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO "developers";"#));
+        assert!(
+            cmd.contains(r#"ALTER DEFAULT PRIVILEGES FOR ROLE "owner" IN SCHEMA "public" GRANT SELECT ON TABLES TO "developers";"#),
+            "got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn grant_command_database_scope_resolves_name_at_runtime() {
+        use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege};
+        let provider = PostgresqlProvider::new();
+        let spec = GrantSpec {
+            role: "app_ro".into(),
+            object: GrantableObject::Database,
+            privileges: vec![Privilege::Connect],
+            with_grant_option: false,
+            apply_to_future: None,
+        };
+        let cmd = provider.grant_command(&spec).unwrap();
+        assert!(
+            cmd.contains("quote_ident(current_database())"),
+            "database name must resolve at runtime (no caller-named DB); got: {cmd}"
+        );
+        assert!(cmd.contains("GRANT CONNECT ON DATABASE"));
+    }
+
+    #[test]
+    fn grant_command_rejects_out_of_matrix_privilege() {
+        use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege};
+        let provider = PostgresqlProvider::new();
+        // INSERT is not a valid privilege on a sequence.
+        let spec = GrantSpec {
+            role: "app_ro".into(),
+            object: GrantableObject::Sequence {
+                schema: "public".into(),
+                name: "q".into(),
+            },
+            privileges: vec![Privilege::Insert],
+            with_grant_option: false,
+            apply_to_future: None,
+        };
+        assert!(
+            provider.grant_command(&spec).is_err(),
+            "INSERT on a sequence must be rejected before SQL"
+        );
+    }
+
+    #[test]
+    fn grant_command_rejects_apply_to_future_on_single_object() {
+        use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege};
+        let provider = PostgresqlProvider::new();
+        let spec = GrantSpec {
+            role: "app_ro".into(),
+            object: GrantableObject::Table {
+                schema: "public".into(),
+                name: "t".into(),
+            },
+            privileges: vec![Privilege::Select],
+            with_grant_option: false,
+            apply_to_future: Some("owner".into()),
+        };
+        assert!(
+            provider.grant_command(&spec).is_err(),
+            "apply_to_future is only valid for all-in-schema scopes"
+        );
+    }
+
+    #[test]
+    fn revoke_command_defaults_restrict_and_supports_cascade() {
+        use gfs_domain::model::db_user::{GrantableObject, Privilege, RevokeSpec};
+        let provider = PostgresqlProvider::new();
+        let spec = |cascade| RevokeSpec {
+            role: "app_rw".into(),
+            object: GrantableObject::Table {
+                schema: "public".into(),
+                name: "orders".into(),
+            },
+            privileges: vec![Privilege::Insert],
+            cascade,
+        };
+        let restrict = provider.revoke_command(&spec(false)).unwrap();
+        assert!(
+            restrict.contains(r#"REVOKE INSERT ON TABLE "public"."orders" FROM "app_rw";"#),
+            "got: {restrict}"
+        );
+        assert!(!restrict.contains("CASCADE"), "default is RESTRICT");
+        let cascade = provider.revoke_command(&spec(true)).unwrap();
+        assert!(
+            cascade.contains(r#"FROM "app_rw" CASCADE;"#),
+            "got: {cascade}"
+        );
+    }
+
+    #[test]
+    fn list_privileges_command_uses_ta_json_filtered_to_role() {
+        let provider = PostgresqlProvider::new();
+        let cmd = provider.list_privileges_command("app_ro").unwrap();
+        assert!(cmd.contains("-tA"), "tuples-only JSON read");
+        assert!(cmd.contains("json_agg"));
+        assert!(
+            cmd.contains("grantee = 'app_ro'"),
+            "must filter by the role literal"
+        );
+        assert!(cmd.contains("role_table_grants") && cmd.contains("aclexplode"));
+    }
+
+    #[test]
+    fn list_privileges_command_rejects_bad_role() {
+        let provider = PostgresqlProvider::new();
+        assert!(
+            provider
+                .list_privileges_command("bad; DROP ROLE x; --")
+                .is_err()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // EMPIRICAL: emitted SQL against a live PostgreSQL (Docker-gated).
+    // Proves grant/revoke actually change `has_table_privilege` — not just that
+    // our SQL string equals an expected string. Skips (does not fail) w/o Docker.
+    // -----------------------------------------------------------------------
+
+    fn docker_available() -> bool {
+        std::process::Command::new("docker")
+            .arg("info")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn grant_revoke_flip_has_table_privilege_on_live_pg() {
+        use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege, RevokeSpec};
+        if !docker_available() {
+            eprintln!("SKIP grant_revoke_flip_has_table_privilege_on_live_pg: docker unavailable");
+            return;
+        }
+        let provider = PostgresqlProvider::new();
+        let cn = format!("gfs-grant-live-{}", std::process::id());
+        let docker = |args: &[&str]| {
+            std::process::Command::new("docker")
+                .args(args)
+                .output()
+                .expect("docker")
+        };
+        let exec_sql = |cn: &str, sql: &str| {
+            std::process::Command::new("docker")
+                .args(["exec", cn, "psql", "-U", "postgres", "-tAc", sql])
+                .output()
+                .expect("docker exec psql")
+        };
+        // Run an emitted (full shell) command inside the container via `sh -c`.
+        let exec_shell = |cn: &str, cmd: &str| {
+            std::process::Command::new("docker")
+                .args(["exec", cn, "sh", "-c", cmd])
+                .output()
+                .expect("docker exec sh")
+        };
+
+        let _ = docker(&["rm", "-f", &cn]);
+        let run = docker(&[
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            &cn,
+            "-e",
+            "POSTGRES_PASSWORD=x",
+            "postgres:17",
+        ]);
+        assert!(
+            run.status.success(),
+            "docker run: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+
+        let mut ready = false;
+        for _ in 0..30 {
+            if docker(&["exec", &cn, "pg_isready", "-U", "postgres"])
+                .status
+                .success()
+            {
+                ready = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+        exec_sql(&cn, "CREATE ROLE app_ro; CREATE TABLE public.t(id int);");
+
+        let grant = provider
+            .grant_command(&GrantSpec {
+                role: "app_ro".into(),
+                object: GrantableObject::Table {
+                    schema: "public".into(),
+                    name: "t".into(),
+                },
+                privileges: vec![Privilege::Select],
+                with_grant_option: false,
+                apply_to_future: None,
+            })
+            .unwrap();
+        let revoke = provider
+            .revoke_command(&RevokeSpec {
+                role: "app_ro".into(),
+                object: GrantableObject::Table {
+                    schema: "public".into(),
+                    name: "t".into(),
+                },
+                privileges: vec![Privilege::Select],
+                cascade: false,
+            })
+            .unwrap();
+        let priv_q = "SELECT has_table_privilege('app_ro','public.t','SELECT')";
+
+        let g = exec_shell(&cn, &grant);
+        let after_grant = String::from_utf8_lossy(&exec_sql(&cn, priv_q).stdout)
+            .trim()
+            .to_string();
+        let r = exec_shell(&cn, &revoke);
+        let after_revoke = String::from_utf8_lossy(&exec_sql(&cn, priv_q).stdout)
+            .trim()
+            .to_string();
+
+        // Clean up BEFORE asserting so a failed assert never leaks the container.
+        let _ = docker(&["rm", "-f", &cn]);
+
+        assert!(ready, "postgres never became ready");
+        assert!(
+            g.status.success(),
+            "emitted GRANT failed: {}",
+            String::from_utf8_lossy(&g.stderr)
+        );
+        assert_eq!(
+            after_grant, "t",
+            "SELECT must be granted after the emitted GRANT"
+        );
+        assert!(
+            r.status.success(),
+            "emitted REVOKE failed: {}",
+            String::from_utf8_lossy(&r.stderr)
+        );
+        assert_eq!(
+            after_revoke, "f",
+            "SELECT must be gone after the emitted REVOKE"
         );
     }
 }

--- a/crates/adapters/compute-docker/tests/manage_users_it.rs
+++ b/crates/adapters/compute-docker/tests/manage_users_it.rs
@@ -259,3 +259,59 @@ async fn preset_default_privileges_follow_owner_future_objects() {
         "control: without FOR ROLE owner, a preset must NOT cover the owner's future objects"
     );
 }
+
+/// `apply_preset` must be DECLARATIVE, not additive: downgrading a role from
+/// `readwrite` to `readonly` must actually REVOKE the write privileges, not leave
+/// them (an HTTP-200 downgrade that silently keeps INSERT/UPDATE/DELETE is a
+/// security-correctness bug). Proven at the engine with `has_table_privilege`.
+#[tokio::test]
+async fn apply_preset_downgrade_revokes_write_privileges() {
+    if !docker_ok() {
+        eprintln!("skip: set GFS_DOCKER_IT=1 and ensure docker is running");
+        return;
+    }
+
+    start_postgres();
+    // Owner + a pre-existing table the presets act on.
+    psql(
+        "CREATE ROLE owner LOGIN; GRANT CREATE ON SCHEMA public TO owner; CREATE TABLE public.t(id int);",
+    );
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path();
+    write_repo(repo, CONTAINER);
+
+    let compute = Arc::new(DockerCompute::new().expect("docker compute"));
+    let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
+    containers::register_all(&*registry).expect("register providers");
+    let uc = ManageUsersUseCase::new(compute, registry);
+
+    // Create a readwrite user (write access), then DOWNGRADE to readonly.
+    uc.create_role(
+        repo,
+        &RoleSpec {
+            username: "u".into(),
+            password: "pw_downgrade_1234".into(),
+            preset: Some(RolePreset::Readwrite),
+            default_privileges_owner: Some("owner".into()),
+        },
+    )
+    .await
+    .expect("create readwrite");
+    let insert_before = psql("SELECT has_table_privilege('u','public.t','INSERT')");
+
+    uc.apply_preset(repo, "u", RolePreset::Readonly, Some("owner"))
+        .await
+        .expect("apply readonly");
+    let insert_after = psql("SELECT has_table_privilege('u','public.t','INSERT')");
+    let select_after = psql("SELECT has_table_privilege('u','public.t','SELECT')");
+
+    stop_postgres();
+
+    assert_eq!(insert_before, "t", "readwrite preset must grant INSERT");
+    assert_eq!(
+        insert_after, "f",
+        "downgrade to readonly must REVOKE INSERT (declarative, not additive)"
+    );
+    assert_eq!(select_after, "t", "readonly must still allow SELECT");
+}

--- a/crates/adapters/compute-docker/tests/manage_users_it.rs
+++ b/crates/adapters/compute-docker/tests/manage_users_it.rs
@@ -49,7 +49,6 @@ fn write_repo(path: &std::path::Path, container: &str) {
         }),
         storage: None,
         compute: None,
-        remote: None,
     };
     config.save(path).expect("save config");
 }

--- a/crates/adapters/compute-docker/tests/manage_users_it.rs
+++ b/crates/adapters/compute-docker/tests/manage_users_it.rs
@@ -102,7 +102,9 @@ fn psql(container: &str, sql: &str) -> String {
 }
 
 fn start_postgres(container: &str) {
-    let _ = Command::new("docker").args(["rm", "-f", container]).output();
+    let _ = Command::new("docker")
+        .args(["rm", "-f", container])
+        .output();
     let status = Command::new("docker")
         .args([
             "run",
@@ -155,7 +157,9 @@ fn start_postgres(container: &str) {
 }
 
 fn stop_postgres(container: &str) {
-    let _ = Command::new("docker").args(["rm", "-f", container]).output();
+    let _ = Command::new("docker")
+        .args(["rm", "-f", container])
+        .output();
 }
 
 #[tokio::test]

--- a/crates/adapters/compute-docker/tests/manage_users_it.rs
+++ b/crates/adapters/compute-docker/tests/manage_users_it.rs
@@ -1,12 +1,14 @@
 //! Integration: `ManageUsersUseCase` grant / revoke / list_privileges run inside
-//! a real Postgres container — the live proof for RFC 007 story 003. This drives
-//! the REAL use case through the REAL `DockerCompute` (not the mock harness), so
-//! it exercises resolve(.gfs) → provider SQL → `Compute::exec` → engine → map.
+//! a real Postgres container — the live proof for the object-level grant work.
+//! This drives the REAL use case through the REAL `DockerCompute` (not the mock
+//! harness), so it exercises resolve(.gfs) → provider SQL → `Compute::exec` →
+//! engine → map.
 //!
 //! Run: `GFS_DOCKER_IT=1 cargo test -p gfs-compute-docker --test manage_users_it -- --nocapture`
 
 use std::process::Command;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
 use gfs_compute_docker::DockerCompute;
@@ -18,7 +20,44 @@ use gfs_domain::model::db_user::{
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::usecases::repository::manage_users_usecase::ManageUsersUseCase;
 
-const CONTAINER: &str = "gfs-it-manage-users";
+/// A container name unique to each call (pid + counter) so tests never collide,
+/// whether run in parallel or back-to-back within one test binary.
+fn unique_container() -> String {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    format!(
+        "gfs-it-manage-users-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// Owns a throwaway `postgres:17` container and removes it on drop, so a failed
+/// assertion (panic unwind) can never leak the container.
+struct Postgres {
+    container: String,
+}
+
+impl Postgres {
+    fn start() -> Self {
+        let container = unique_container();
+        start_postgres(&container);
+        Self { container }
+    }
+
+    fn psql(&self, sql: &str) -> String {
+        psql(&self.container, sql)
+    }
+
+    fn name(&self) -> &str {
+        &self.container
+    }
+}
+
+impl Drop for Postgres {
+    fn drop(&mut self) {
+        stop_postgres(&self.container);
+    }
+}
 
 fn docker_ok() -> bool {
     std::env::var("GFS_DOCKER_IT").ok().as_deref() == Some("1")
@@ -54,24 +93,22 @@ fn write_repo(path: &std::path::Path, container: &str) {
 }
 
 /// Independent verification: run scalar SQL directly via `docker exec` psql.
-fn psql(sql: &str) -> String {
+fn psql(container: &str, sql: &str) -> String {
     let out = Command::new("docker")
-        .args(["exec", CONTAINER, "psql", "-U", "postgres", "-tAc", sql])
+        .args(["exec", container, "psql", "-U", "postgres", "-tAc", sql])
         .output()
         .expect("docker exec psql");
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 
-fn start_postgres() {
-    let _ = Command::new("docker")
-        .args(["rm", "-f", CONTAINER])
-        .output();
+fn start_postgres(container: &str) {
+    let _ = Command::new("docker").args(["rm", "-f", container]).output();
     let status = Command::new("docker")
         .args([
             "run",
             "-d",
             "--name",
-            CONTAINER,
+            container,
             "-e",
             "POSTGRES_PASSWORD=postgres",
             "postgres:17",
@@ -80,33 +117,45 @@ fn start_postgres() {
         .expect("docker run");
     assert!(status.success(), "docker run postgres:17 failed");
 
+    // Gate on a real `SELECT 1` over the SAME channel the use case uses —
+    // TCP `-h 127.0.0.1` with the password — not the unix socket. The postgres
+    // image runs a temporary socket-only server during init, so a socket probe
+    // (or `pg_isready`) reports ready while TCP is still refused; the use case
+    // connects over TCP and would race "connection refused" / "starting up".
     let deadline = Instant::now() + Duration::from_secs(60);
     loop {
-        let ok = Command::new("docker")
+        let ready = Command::new("docker")
             .args([
                 "exec",
-                CONTAINER,
-                "pg_isready",
+                "-e",
+                "PGPASSWORD=postgres",
+                container,
+                "psql",
+                "-h",
+                "127.0.0.1",
                 "-U",
                 "postgres",
                 "-d",
                 "postgres",
+                "-tAc",
+                "SELECT 1",
             ])
-            .status()
-            .map(|s| s.success())
+            .output()
+            .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "1")
             .unwrap_or(false);
-        if ok {
+        if ready {
             break;
         }
-        assert!(Instant::now() < deadline, "postgres did not become ready");
+        assert!(
+            Instant::now() < deadline,
+            "postgres did not accept queries in time"
+        );
         std::thread::sleep(Duration::from_millis(500));
     }
 }
 
-fn stop_postgres() {
-    let _ = Command::new("docker")
-        .args(["rm", "-f", CONTAINER])
-        .output();
+fn stop_postgres(container: &str) {
+    let _ = Command::new("docker").args(["rm", "-f", container]).output();
 }
 
 #[tokio::test]
@@ -116,13 +165,13 @@ async fn grant_revoke_list_through_real_usecase() {
         return;
     }
 
-    start_postgres();
+    let pg = Postgres::start();
     // Fixtures: a client role + a table to grant on.
-    psql("CREATE ROLE app_ro; CREATE TABLE public.t(id int);");
+    pg.psql("CREATE ROLE app_ro; CREATE TABLE public.t(id int);");
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path();
-    write_repo(repo, CONTAINER);
+    write_repo(repo, pg.name());
 
     let compute = Arc::new(DockerCompute::new().expect("docker compute"));
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
@@ -147,7 +196,7 @@ async fn grant_revoke_list_through_real_usecase() {
     )
     .await
     .expect("uc.grant");
-    let after_grant = psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
+    let after_grant = pg.psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
 
     // LIST via the real use case — parses the live engine catalog JSON into
     // Vec<ObjectPrivilege> (the 4-way UNION projection end-to-end).
@@ -171,11 +220,10 @@ async fn grant_revoke_list_through_real_usecase() {
     )
     .await
     .expect("uc.revoke");
-    let after_revoke = psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
+    let after_revoke = pg.psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
 
-    // Clean up BEFORE asserting so a failed assert never leaks the container.
-    stop_postgres();
-
+    // The container is removed by `pg`'s Drop on scope exit — including on a
+    // failed assertion below (panic unwind), so nothing leaks either way.
     assert_eq!(after_grant, "t", "SELECT must be granted after uc.grant");
     assert!(
         has_select,
@@ -186,11 +234,11 @@ async fn grant_revoke_list_through_real_usecase() {
 
 /// A preset's `ALTER DEFAULT PRIVILEGES` must be role-scoped to the deploy
 /// `owner` so a preset user automatically sees tables the OWNER creates LATER —
-/// not just the tables that existed at create time. This is the RFC-007 preset
-/// hardening: `create_role` with `default_privileges_owner: Some("owner")` emits
-/// `... FOR ROLE "owner" ...`. The `reader_self` role (owner `None`) is the
-/// control: without `FOR ROLE`, a preset only covers the connecting admin's
-/// future objects, so it must NOT see the owner's future table.
+/// not just the tables that existed at create time: `create_role` with
+/// `default_privileges_owner: Some("owner")` emits `... FOR ROLE "owner" ...`.
+/// The `reader_self` role (owner `None`) is the control: without `FOR ROLE`, a
+/// preset only covers the connecting admin's future objects, so it must NOT see
+/// the owner's future table.
 #[tokio::test]
 async fn preset_default_privileges_follow_owner_future_objects() {
     if !docker_ok() {
@@ -198,14 +246,14 @@ async fn preset_default_privileges_follow_owner_future_objects() {
         return;
     }
 
-    start_postgres();
-    // The customer's object-creating role (RFC 009 deploy owner), with CREATE on
-    // `public` so it can make tables of its own.
-    psql("CREATE ROLE owner LOGIN; GRANT CREATE ON SCHEMA public TO owner;");
+    let pg = Postgres::start();
+    // The customer's object-creating deploy owner, with CREATE on `public` so it
+    // can make tables of its own.
+    pg.psql("CREATE ROLE owner LOGIN; GRANT CREATE ON SCHEMA public TO owner;");
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path();
-    write_repo(repo, CONTAINER);
+    write_repo(repo, pg.name());
 
     let compute = Arc::new(DockerCompute::new().expect("docker compute"));
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
@@ -240,14 +288,11 @@ async fn preset_default_privileges_follow_owner_future_objects() {
     .expect("create reader_self");
 
     // The OWNER creates a FUTURE table (after both presets were applied).
-    psql("SET ROLE owner; CREATE TABLE public.future_t(id int); RESET ROLE;");
+    pg.psql("SET ROLE owner; CREATE TABLE public.future_t(id int); RESET ROLE;");
 
-    let reader_sees = psql("SELECT has_table_privilege('reader','public.future_t','SELECT')");
+    let reader_sees = pg.psql("SELECT has_table_privilege('reader','public.future_t','SELECT')");
     let reader_self_sees =
-        psql("SELECT has_table_privilege('reader_self','public.future_t','SELECT')");
-
-    // Clean up BEFORE asserting so a failed assert never leaks the container.
-    stop_postgres();
+        pg.psql("SELECT has_table_privilege('reader_self','public.future_t','SELECT')");
 
     assert_eq!(
         reader_sees, "t",
@@ -270,15 +315,15 @@ async fn apply_preset_downgrade_revokes_write_privileges() {
         return;
     }
 
-    start_postgres();
+    let pg = Postgres::start();
     // Owner + a pre-existing table the presets act on.
-    psql(
+    pg.psql(
         "CREATE ROLE owner LOGIN; GRANT CREATE ON SCHEMA public TO owner; CREATE TABLE public.t(id int);",
     );
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path();
-    write_repo(repo, CONTAINER);
+    write_repo(repo, pg.name());
 
     let compute = Arc::new(DockerCompute::new().expect("docker compute"));
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
@@ -297,15 +342,13 @@ async fn apply_preset_downgrade_revokes_write_privileges() {
     )
     .await
     .expect("create readwrite");
-    let insert_before = psql("SELECT has_table_privilege('u','public.t','INSERT')");
+    let insert_before = pg.psql("SELECT has_table_privilege('u','public.t','INSERT')");
 
     uc.apply_preset(repo, "u", RolePreset::Readonly, Some("owner"))
         .await
         .expect("apply readonly");
-    let insert_after = psql("SELECT has_table_privilege('u','public.t','INSERT')");
-    let select_after = psql("SELECT has_table_privilege('u','public.t','SELECT')");
-
-    stop_postgres();
+    let insert_after = pg.psql("SELECT has_table_privilege('u','public.t','INSERT')");
+    let select_after = pg.psql("SELECT has_table_privilege('u','public.t','SELECT')");
 
     assert_eq!(insert_before, "t", "readwrite preset must grant INSERT");
     assert_eq!(

--- a/crates/adapters/compute-docker/tests/manage_users_it.rs
+++ b/crates/adapters/compute-docker/tests/manage_users_it.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use gfs_compute_docker::containers;
 use gfs_compute_docker::DockerCompute;
+use gfs_compute_docker::containers;
 use gfs_domain::model::config::{EnvironmentConfig, GfsConfig, RuntimeConfig};
-use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege, RevokeSpec};
+use gfs_domain::model::db_user::{
+    GrantSpec, GrantableObject, Privilege, RevokeSpec, RolePreset, RoleSpec,
+};
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::usecases::repository::manage_users_usecase::ManageUsersUseCase;
 
@@ -62,7 +64,9 @@ fn psql(sql: &str) -> String {
 }
 
 fn start_postgres() {
-    let _ = Command::new("docker").args(["rm", "-f", CONTAINER]).output();
+    let _ = Command::new("docker")
+        .args(["rm", "-f", CONTAINER])
+        .output();
     let status = Command::new("docker")
         .args([
             "run",
@@ -80,7 +84,15 @@ fn start_postgres() {
     let deadline = Instant::now() + Duration::from_secs(60);
     loop {
         let ok = Command::new("docker")
-            .args(["exec", CONTAINER, "pg_isready", "-U", "postgres", "-d", "postgres"])
+            .args([
+                "exec",
+                CONTAINER,
+                "pg_isready",
+                "-U",
+                "postgres",
+                "-d",
+                "postgres",
+            ])
             .status()
             .map(|s| s.success())
             .unwrap_or(false);
@@ -93,7 +105,9 @@ fn start_postgres() {
 }
 
 fn stop_postgres() {
-    let _ = Command::new("docker").args(["rm", "-f", CONTAINER]).output();
+    let _ = Command::new("docker")
+        .args(["rm", "-f", CONTAINER])
+        .output();
 }
 
 #[tokio::test]
@@ -142,9 +156,9 @@ async fn grant_revoke_list_through_real_usecase() {
         .list_privileges(repo, "app_ro")
         .await
         .expect("uc.list_privileges");
-    let has_select = privs
-        .iter()
-        .any(|p| p.object_type == "table" && p.object_name == "public.t" && p.privilege == "select");
+    let has_select = privs.iter().any(|p| {
+        p.object_type == "table" && p.object_name == "public.t" && p.privilege == "select"
+    });
 
     // REVOKE via the real use case, then verify it's gone.
     uc.revoke(
@@ -169,4 +183,79 @@ async fn grant_revoke_list_through_real_usecase() {
         "uc.list_privileges must report the table SELECT grant; got: {privs:?}"
     );
     assert_eq!(after_revoke, "f", "SELECT must be gone after uc.revoke");
+}
+
+/// A preset's `ALTER DEFAULT PRIVILEGES` must be role-scoped to the deploy
+/// `owner` so a preset user automatically sees tables the OWNER creates LATER —
+/// not just the tables that existed at create time. This is the RFC-007 preset
+/// hardening: `create_role` with `default_privileges_owner: Some("owner")` emits
+/// `... FOR ROLE "owner" ...`. The `reader_self` role (owner `None`) is the
+/// control: without `FOR ROLE`, a preset only covers the connecting admin's
+/// future objects, so it must NOT see the owner's future table.
+#[tokio::test]
+async fn preset_default_privileges_follow_owner_future_objects() {
+    if !docker_ok() {
+        eprintln!("skip: set GFS_DOCKER_IT=1 and ensure docker is running");
+        return;
+    }
+
+    start_postgres();
+    // The customer's object-creating role (RFC 009 deploy owner), with CREATE on
+    // `public` so it can make tables of its own.
+    psql("CREATE ROLE owner LOGIN; GRANT CREATE ON SCHEMA public TO owner;");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path();
+    write_repo(repo, CONTAINER);
+
+    let compute = Arc::new(DockerCompute::new().expect("docker compute"));
+    let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
+    containers::register_all(&*registry).expect("register providers");
+    let uc = ManageUsersUseCase::new(compute, registry);
+
+    // reader: readonly preset whose defaults are role-scoped to `owner` (the fix).
+    uc.create_role(
+        repo,
+        &RoleSpec {
+            username: "reader".into(),
+            password: "pw_reader_1234".into(),
+            preset: Some(RolePreset::Readonly),
+            default_privileges_owner: Some("owner".into()),
+        },
+    )
+    .await
+    .expect("create reader");
+
+    // reader_self: readonly preset with NO deploy owner — defaults role-scope to
+    // the connecting admin (postgres), so they cannot cover owner's future objects.
+    uc.create_role(
+        repo,
+        &RoleSpec {
+            username: "reader_self".into(),
+            password: "pw_reader_1234".into(),
+            preset: Some(RolePreset::Readonly),
+            default_privileges_owner: None,
+        },
+    )
+    .await
+    .expect("create reader_self");
+
+    // The OWNER creates a FUTURE table (after both presets were applied).
+    psql("SET ROLE owner; CREATE TABLE public.future_t(id int); RESET ROLE;");
+
+    let reader_sees = psql("SELECT has_table_privilege('reader','public.future_t','SELECT')");
+    let reader_self_sees =
+        psql("SELECT has_table_privilege('reader_self','public.future_t','SELECT')");
+
+    // Clean up BEFORE asserting so a failed assert never leaks the container.
+    stop_postgres();
+
+    assert_eq!(
+        reader_sees, "t",
+        "preset defaults FOR ROLE owner must auto-grant SELECT on owner's future table"
+    );
+    assert_eq!(
+        reader_self_sees, "f",
+        "control: without FOR ROLE owner, a preset must NOT cover the owner's future objects"
+    );
 }

--- a/crates/adapters/compute-docker/tests/manage_users_it.rs
+++ b/crates/adapters/compute-docker/tests/manage_users_it.rs
@@ -1,0 +1,172 @@
+//! Integration: `ManageUsersUseCase` grant / revoke / list_privileges run inside
+//! a real Postgres container — the live proof for RFC 007 story 003. This drives
+//! the REAL use case through the REAL `DockerCompute` (not the mock harness), so
+//! it exercises resolve(.gfs) → provider SQL → `Compute::exec` → engine → map.
+//!
+//! Run: `GFS_DOCKER_IT=1 cargo test -p gfs-compute-docker --test manage_users_it -- --nocapture`
+
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use gfs_compute_docker::containers;
+use gfs_compute_docker::DockerCompute;
+use gfs_domain::model::config::{EnvironmentConfig, GfsConfig, RuntimeConfig};
+use gfs_domain::model::db_user::{GrantSpec, GrantableObject, Privilege, RevokeSpec};
+use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
+use gfs_domain::usecases::repository::manage_users_usecase::ManageUsersUseCase;
+
+const CONTAINER: &str = "gfs-it-manage-users";
+
+fn docker_ok() -> bool {
+    std::env::var("GFS_DOCKER_IT").ok().as_deref() == Some("1")
+        && Command::new("docker")
+            .args(["info"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+}
+
+fn write_repo(path: &std::path::Path, container: &str) {
+    std::fs::create_dir_all(path.join(".gfs")).expect("mkdir .gfs");
+    let config = GfsConfig {
+        mount_point: None,
+        version: String::new(),
+        description: String::new(),
+        user: None,
+        environment: Some(EnvironmentConfig {
+            database_provider: "postgres".into(),
+            database_version: "17".into(),
+            database_port: None,
+            display_name: None,
+        }),
+        runtime: Some(RuntimeConfig {
+            runtime_provider: "docker".into(),
+            runtime_version: "latest".into(),
+            container_name: container.into(),
+        }),
+        storage: None,
+        compute: None,
+        remote: None,
+    };
+    config.save(path).expect("save config");
+}
+
+/// Independent verification: run scalar SQL directly via `docker exec` psql.
+fn psql(sql: &str) -> String {
+    let out = Command::new("docker")
+        .args(["exec", CONTAINER, "psql", "-U", "postgres", "-tAc", sql])
+        .output()
+        .expect("docker exec psql");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn start_postgres() {
+    let _ = Command::new("docker").args(["rm", "-f", CONTAINER]).output();
+    let status = Command::new("docker")
+        .args([
+            "run",
+            "-d",
+            "--name",
+            CONTAINER,
+            "-e",
+            "POSTGRES_PASSWORD=postgres",
+            "postgres:17",
+        ])
+        .status()
+        .expect("docker run");
+    assert!(status.success(), "docker run postgres:17 failed");
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let ok = Command::new("docker")
+            .args(["exec", CONTAINER, "pg_isready", "-U", "postgres", "-d", "postgres"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            break;
+        }
+        assert!(Instant::now() < deadline, "postgres did not become ready");
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}
+
+fn stop_postgres() {
+    let _ = Command::new("docker").args(["rm", "-f", CONTAINER]).output();
+}
+
+#[tokio::test]
+async fn grant_revoke_list_through_real_usecase() {
+    if !docker_ok() {
+        eprintln!("skip: set GFS_DOCKER_IT=1 and ensure docker is running");
+        return;
+    }
+
+    start_postgres();
+    // Fixtures: a client role + a table to grant on.
+    psql("CREATE ROLE app_ro; CREATE TABLE public.t(id int);");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path();
+    write_repo(repo, CONTAINER);
+
+    let compute = Arc::new(DockerCompute::new().expect("docker compute"));
+    let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
+    containers::register_all(&*registry).expect("register providers");
+    let uc = ManageUsersUseCase::new(compute, registry);
+
+    let table = || GrantableObject::Table {
+        schema: "public".into(),
+        name: "t".into(),
+    };
+
+    // GRANT SELECT via the real use case, then verify the engine actually changed.
+    uc.grant(
+        repo,
+        &GrantSpec {
+            role: "app_ro".into(),
+            object: table(),
+            privileges: vec![Privilege::Select],
+            with_grant_option: false,
+            apply_to_future: None,
+        },
+    )
+    .await
+    .expect("uc.grant");
+    let after_grant = psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
+
+    // LIST via the real use case — parses the live engine catalog JSON into
+    // Vec<ObjectPrivilege> (the 4-way UNION projection end-to-end).
+    let privs = uc
+        .list_privileges(repo, "app_ro")
+        .await
+        .expect("uc.list_privileges");
+    let has_select = privs
+        .iter()
+        .any(|p| p.object_type == "table" && p.object_name == "public.t" && p.privilege == "select");
+
+    // REVOKE via the real use case, then verify it's gone.
+    uc.revoke(
+        repo,
+        &RevokeSpec {
+            role: "app_ro".into(),
+            object: table(),
+            privileges: vec![Privilege::Select],
+            cascade: false,
+        },
+    )
+    .await
+    .expect("uc.revoke");
+    let after_revoke = psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
+
+    // Clean up BEFORE asserting so a failed assert never leaks the container.
+    stop_postgres();
+
+    assert_eq!(after_grant, "t", "SELECT must be granted after uc.grant");
+    assert!(
+        has_select,
+        "uc.list_privileges must report the table SELECT grant; got: {privs:?}"
+    );
+    assert_eq!(after_revoke, "f", "SELECT must be gone after uc.revoke");
+}

--- a/crates/adapters/compute-kubernetes/src/lib.rs
+++ b/crates/adapters/compute-kubernetes/src/lib.rs
@@ -25,13 +25,41 @@ use k8s_openapi::api::core::v1::{
     PodSecurityContext, PodSpec, PodTemplateSpec, Secret, SecretKeySelector, Service, ServicePort,
     ServiceSpec, Volume, VolumeMount,
 };
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta, Status};
 use kube::api::{AttachParams, DeleteParams, ListParams, Patch, PatchParams, PostParams};
 use kube::{Api, Client};
 use serde_json::json;
 
 const DEFAULT_NAMESPACE: &str = "gfs";
 const DEFAULT_PVC_SIZE_GI: &str = "1";
+
+/// Extract the process exit code from a Kubernetes exec `Status`.
+///
+/// The kubelet sends a metav1 `Status` on the exec v4 error channel: `Success`
+/// ⇒ exit 0; otherwise `reason: NonZeroExitCode` with the code carried in
+/// `details.causes[reason=ExitCode].message`. A non-success status with no
+/// parseable code is treated as a generic failure (1) rather than a false
+/// success. `None` (no status delivered) preserves the lenient 0.
+fn exit_code_from_status(status: Option<Status>) -> i32 {
+    let Some(status) = status else {
+        return 0;
+    };
+    if status.status.as_deref() == Some("Success") {
+        return 0;
+    }
+    status
+        .details
+        .as_ref()
+        .and_then(|details| details.causes.as_ref())
+        .and_then(|causes| {
+            causes
+                .iter()
+                .find(|cause| cause.reason.as_deref() == Some("ExitCode"))
+        })
+        .and_then(|cause| cause.message.as_deref())
+        .and_then(|message| message.parse::<i32>().ok())
+        .unwrap_or(1)
+}
 
 fn k8s_storage_class() -> Option<String> {
     std::env::var("GFS_K8S_STORAGE_CLASS")
@@ -1173,8 +1201,9 @@ impl Compute for KubernetesCompute {
             }
         };
 
-        // Take the status channel before draining stdout/stderr; await it after
-        // (the streams close on process exit, at which point the status is ready).
+        // Take the status channel BEFORE draining stdout/stderr; the kubelet sends
+        // the exec `Status` (carrying the real exit code) on the v4 error channel
+        // when the process exits. Awaited after the streams are fully read.
         let status_fut = attached.take_status();
 
         let mut stdout = String::new();
@@ -1205,6 +1234,7 @@ impl Compute for KubernetesCompute {
             Some(fut) => exit_code_from_exec_status(fut.await),
             None => 0,
         };
+
         Ok(ExecOutput {
             exit_code,
             stdout,
@@ -1453,6 +1483,48 @@ mod tests {
     use super::*;
     use gfs_domain::ports::compute::EnvVar;
     use k8s_openapi::ByteString;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{StatusCause, StatusDetails};
+
+    #[test]
+    fn exit_code_success_is_zero() {
+        let status = Status {
+            status: Some("Success".into()),
+            ..Default::default()
+        };
+        assert_eq!(exit_code_from_status(Some(status)), 0);
+    }
+
+    #[test]
+    fn exit_code_reads_nonzero_from_causes() {
+        let status = Status {
+            status: Some("Failure".into()),
+            reason: Some("NonZeroExitCode".into()),
+            details: Some(StatusDetails {
+                causes: Some(vec![StatusCause {
+                    reason: Some("ExitCode".into()),
+                    message: Some("3".into()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(exit_code_from_status(Some(status)), 3);
+    }
+
+    #[test]
+    fn exit_code_failure_without_code_is_generic_failure() {
+        let status = Status {
+            status: Some("Failure".into()),
+            ..Default::default()
+        };
+        assert_eq!(exit_code_from_status(Some(status)), 1);
+    }
+
+    #[test]
+    fn exit_code_absent_status_stays_zero() {
+        assert_eq!(exit_code_from_status(None), 0);
+    }
 
     fn definition_with_env(env: Vec<EnvVar>) -> ComputeDefinition {
         ComputeDefinition {

--- a/crates/adapters/compute-kubernetes/src/lib.rs
+++ b/crates/adapters/compute-kubernetes/src/lib.rs
@@ -38,11 +38,14 @@ const DEFAULT_PVC_SIZE_GI: &str = "1";
 /// The kubelet sends a metav1 `Status` on the exec v4 error channel: `Success`
 /// ⇒ exit 0; otherwise `reason: NonZeroExitCode` with the code carried in
 /// `details.causes[reason=ExitCode].message`. A non-success status with no
-/// parseable code is treated as a generic failure (1) rather than a false
-/// success. `None` (no status delivered) preserves the lenient 0.
+/// parseable code is a generic failure (1). `None` (no status delivered — an
+/// abnormal WebSocket teardown, so the command's outcome is unknown) is treated
+/// as a **failure**, never a false success: a mutating op must not report
+/// success when its exit code could not be determined. A normally-completed exec
+/// always carries a status, so this only fires on genuine transport failures.
 fn exit_code_from_status(status: Option<Status>) -> i32 {
     let Some(status) = status else {
-        return 0;
+        return 1;
     };
     if status.status.as_deref() == Some("Success") {
         return 0;
@@ -1232,7 +1235,9 @@ impl Compute for KubernetesCompute {
         // can't tell a failed SQL statement from an empty result.
         let exit_code = match status_fut {
             Some(fut) => exit_code_from_exec_status(fut.await),
-            None => 0,
+            // No status channel at all (should not happen for a normal exec) —
+            // treat as failure rather than a silent success (RFC 009 §9.7 caveat 1).
+            None => 1,
         };
 
         Ok(ExecOutput {
@@ -1522,8 +1527,9 @@ mod tests {
     }
 
     #[test]
-    fn exit_code_absent_status_stays_zero() {
-        assert_eq!(exit_code_from_status(None), 0);
+    fn exit_code_absent_status_is_failure_not_false_success() {
+        // No status delivered ⇒ outcome unknown ⇒ must NOT read as success.
+        assert_eq!(exit_code_from_status(None), 1);
     }
 
     fn definition_with_env(env: Vec<EnvVar>) -> ComputeDefinition {

--- a/crates/adapters/compute-kubernetes/src/lib.rs
+++ b/crates/adapters/compute-kubernetes/src/lib.rs
@@ -25,44 +25,13 @@ use k8s_openapi::api::core::v1::{
     PodSecurityContext, PodSpec, PodTemplateSpec, Secret, SecretKeySelector, Service, ServicePort,
     ServiceSpec, Volume, VolumeMount,
 };
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta, Status};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use kube::api::{AttachParams, DeleteParams, ListParams, Patch, PatchParams, PostParams};
 use kube::{Api, Client};
 use serde_json::json;
 
 const DEFAULT_NAMESPACE: &str = "gfs";
 const DEFAULT_PVC_SIZE_GI: &str = "1";
-
-/// Extract the process exit code from a Kubernetes exec `Status`.
-///
-/// The kubelet sends a metav1 `Status` on the exec v4 error channel: `Success`
-/// ⇒ exit 0; otherwise `reason: NonZeroExitCode` with the code carried in
-/// `details.causes[reason=ExitCode].message`. A non-success status with no
-/// parseable code is a generic failure (1). `None` (no status delivered — an
-/// abnormal WebSocket teardown, so the command's outcome is unknown) is treated
-/// as a **failure**, never a false success: a mutating op must not report
-/// success when its exit code could not be determined. A normally-completed exec
-/// always carries a status, so this only fires on genuine transport failures.
-fn exit_code_from_status(status: Option<Status>) -> i32 {
-    let Some(status) = status else {
-        return 1;
-    };
-    if status.status.as_deref() == Some("Success") {
-        return 0;
-    }
-    status
-        .details
-        .as_ref()
-        .and_then(|details| details.causes.as_ref())
-        .and_then(|causes| {
-            causes
-                .iter()
-                .find(|cause| cause.reason.as_deref() == Some("ExitCode"))
-        })
-        .and_then(|cause| cause.message.as_deref())
-        .and_then(|message| message.parse::<i32>().ok())
-        .unwrap_or(1)
-}
 
 fn k8s_storage_class() -> Option<String> {
     std::env::var("GFS_K8S_STORAGE_CLASS")
@@ -1488,49 +1457,6 @@ mod tests {
     use super::*;
     use gfs_domain::ports::compute::EnvVar;
     use k8s_openapi::ByteString;
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{StatusCause, StatusDetails};
-
-    #[test]
-    fn exit_code_success_is_zero() {
-        let status = Status {
-            status: Some("Success".into()),
-            ..Default::default()
-        };
-        assert_eq!(exit_code_from_status(Some(status)), 0);
-    }
-
-    #[test]
-    fn exit_code_reads_nonzero_from_causes() {
-        let status = Status {
-            status: Some("Failure".into()),
-            reason: Some("NonZeroExitCode".into()),
-            details: Some(StatusDetails {
-                causes: Some(vec![StatusCause {
-                    reason: Some("ExitCode".into()),
-                    message: Some("3".into()),
-                    ..Default::default()
-                }]),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        assert_eq!(exit_code_from_status(Some(status)), 3);
-    }
-
-    #[test]
-    fn exit_code_failure_without_code_is_generic_failure() {
-        let status = Status {
-            status: Some("Failure".into()),
-            ..Default::default()
-        };
-        assert_eq!(exit_code_from_status(Some(status)), 1);
-    }
-
-    #[test]
-    fn exit_code_absent_status_is_failure_not_false_success() {
-        // No status delivered ⇒ outcome unknown ⇒ must NOT read as success.
-        assert_eq!(exit_code_from_status(None), 1);
-    }
 
     fn definition_with_env(env: Vec<EnvVar>) -> ComputeDefinition {
         ComputeDefinition {

--- a/crates/adapters/compute-kubernetes/src/lib.rs
+++ b/crates/adapters/compute-kubernetes/src/lib.rs
@@ -673,6 +673,17 @@ impl KubernetesCompute {
     /// not-ready pod fails the WebSocket upgrade with `400 Bad Request`.
     async fn wait_ready_pod_name(&self, instance: &str) -> Result<String> {
         use std::time::{Duration, Instant};
+        // Fast-fail if the instance is stopped (StatefulSet scaled to zero): no pod
+        // exists and none is coming, so don't burn the full deadline hanging and
+        // then return a misleading "not Ready" error. Tell the caller to resume it.
+        if let Ok(ss) = self.api_statefulsets().get(instance).await
+            && ss.spec.as_ref().and_then(|s| s.replicas) == Some(0)
+        {
+            return Err(ComputeError::Internal(format!(
+                "instance '{instance}' is stopped (scaled to zero); resume it \
+                 (e.g. `gfs compute start`) before running this operation"
+            )));
+        }
         let api = self.api_pods();
         let lp = ListParams::default().labels(&format!("{INSTANCE_LABEL_KEY}={instance}"));
         let deadline = Instant::now() + Duration::from_secs(120);

--- a/crates/adapters/compute-kubernetes/src/lib.rs
+++ b/crates/adapters/compute-kubernetes/src/lib.rs
@@ -679,7 +679,10 @@ impl KubernetesCompute {
         if let Ok(ss) = self.api_statefulsets().get(instance).await
             && ss.spec.as_ref().and_then(|s| s.replicas) == Some(0)
         {
-            return Err(ComputeError::Internal(format!(
+            // NotAvailable has a bare `{0}` Display: this is an expected state, not an
+            // internal fault, so avoid the misleading "internal error:" prefix while
+            // keeping the actionable "resume it" guidance intact.
+            return Err(ComputeError::NotAvailable(format!(
                 "instance '{instance}' is stopped (scaled to zero); resume it \
                  (e.g. `gfs compute start`) before running this operation"
             )));

--- a/crates/applications/cli/Cargo.toml
+++ b/crates/applications/cli/Cargo.toml
@@ -47,6 +47,7 @@ async-trait        = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde_json         = { workspace = true }
+uuid               = { workspace = true }
 rmcp               = { workspace = true }
 axum               = { version = "0.7", features = ["json", "macros"] }
 tokio-util         = "0.7"

--- a/crates/applications/cli/src/commands/cmd_log.rs
+++ b/crates/applications/cli/src/commands/cmd_log.rs
@@ -177,7 +177,7 @@ fn collect_dag(
     }
 
     // Sort by timestamp descending (newest first)
-    commits.sort_by(|a, b| b.commit.author_date.cmp(&a.commit.author_date));
+    commits.sort_by_key(|c| std::cmp::Reverse(c.commit.author_date));
 
     Ok(commits)
 }

--- a/crates/applications/cli/src/commands/cmd_user.rs
+++ b/crates/applications/cli/src/commands/cmd_user.rs
@@ -80,6 +80,9 @@ pub async fn run_create(
                 username: username.clone(),
                 password: password.clone(),
                 preset,
+                // Single-node gfs CLI: no deploy owner, so a preset's default
+                // privileges are role-scoped to the connecting role.
+                default_privileges_owner: None,
             },
         )
         .await

--- a/crates/applications/cli/src/commands/cmd_user.rs
+++ b/crates/applications/cli/src/commands/cmd_user.rs
@@ -156,6 +156,39 @@ pub async fn run_set_password(
     Ok(())
 }
 
+pub async fn run_apply_preset(
+    path: Option<PathBuf>,
+    username: String,
+    preset: String,
+    json_output: bool,
+) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let preset = parse_preset(Some(preset))?
+        .ok_or_else(|| anyhow::anyhow!("a preset is required (readonly|readwrite|admin)"))?;
+    let use_case = build_use_case(&repo_path).await?;
+    // Scope the preset's default privileges to the deploy owner's future objects
+    // (same as create) so a re-applied/changed preset stays owner-aware.
+    let default_privileges_owner = use_case.detect_deploy_owner(&repo_path).await;
+    use_case
+        .apply_preset(
+            &repo_path,
+            &username,
+            preset,
+            default_privileges_owner.as_deref(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if json_output {
+        println!(
+            "{}",
+            serde_json::json!({ "username": username, "preset_applied": true })
+        );
+    } else {
+        println!("user '{username}' — preset applied");
+    }
+    Ok(())
+}
+
 /// The mutually-exclusive `--on-*` object flags for grant/revoke.
 pub struct ObjectFlags {
     pub on_database: bool,

--- a/crates/applications/cli/src/commands/cmd_user.rs
+++ b/crates/applications/cli/src/commands/cmd_user.rs
@@ -42,14 +42,20 @@ fn generate_password() -> String {
     uuid::Uuid::new_v4().simple().to_string()
 }
 
-fn print_credential(username: &str, password: &str, json_output: bool) {
+fn print_credential(username: &str, password: &str, generated: bool, json_output: bool) {
     if json_output {
+        // Machine output keeps a stable shape; the caller opts into it and owns
+        // redaction of a password they themselves supplied.
         println!(
             "{}",
             serde_json::json!({ "username": username, "password": password })
         );
-    } else {
+    } else if generated {
+        // Only the server-generated secret is the "shown once" copy worth echoing.
         println!("user '{username}' — password (shown once): {password}");
+    } else {
+        // A caller-supplied password is not re-echoed to the terminal/logs.
+        println!("user '{username}' — password set");
     }
 }
 
@@ -62,6 +68,7 @@ pub async fn run_create(
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
     let preset = parse_preset(preset)?;
+    let generated = password.is_none();
     let password = password.unwrap_or_else(generate_password);
     let use_case = build_use_case(&repo_path).await?;
     use_case
@@ -75,7 +82,7 @@ pub async fn run_create(
         )
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-    print_credential(&username, &password, json_output);
+    print_credential(&username, &password, generated, json_output);
     Ok(())
 }
 
@@ -126,12 +133,13 @@ pub async fn run_set_password(
     json_output: bool,
 ) -> Result<()> {
     let repo_path = path.unwrap_or_else(get_repo_dir);
+    let generated = password.is_none();
     let password = password.unwrap_or_else(generate_password);
     let use_case = build_use_case(&repo_path).await?;
     use_case
         .set_password(&repo_path, &username, &password)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-    print_credential(&username, &password, json_output);
+    print_credential(&username, &password, generated, json_output);
     Ok(())
 }

--- a/crates/applications/cli/src/commands/cmd_user.rs
+++ b/crates/applications/cli/src/commands/cmd_user.rs
@@ -1,0 +1,137 @@
+//! `gfs user` — manage database users/roles (create, list, drop, set-password).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use gfs_compute_docker::containers;
+use gfs_domain::adapters::gfs_repository::GfsRepository;
+use gfs_domain::model::config::GfsConfig;
+use gfs_domain::model::db_user::{RolePreset, RoleSpec};
+use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
+use gfs_domain::ports::repository::Repository;
+use gfs_domain::usecases::repository::manage_users_usecase::ManageUsersUseCase;
+
+use super::compute_support::compute_for_repo;
+use crate::cli_utils::get_repo_dir;
+
+/// Build a `ManageUsersUseCase` wired to the repo's compute + provider registry
+/// (mirrors `cmd_query`'s composition root).
+async fn build_use_case(
+    repo_path: &Path,
+) -> Result<ManageUsersUseCase<InMemoryDatabaseProviderRegistry>> {
+    GfsConfig::load(repo_path).context("not a GFS repository (run gfs init first)")?;
+    let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
+    let compute = compute_for_repo(&repository, repo_path).await?;
+    let registry = InMemoryDatabaseProviderRegistry::new();
+    containers::register_all(&registry).context("failed to register database providers")?;
+    Ok(ManageUsersUseCase::new(compute, Arc::new(registry)))
+}
+
+fn parse_preset(preset: Option<String>) -> Result<Option<RolePreset>> {
+    match preset {
+        Some(p) => RolePreset::parse(&p)
+            .map(Some)
+            .with_context(|| format!("unknown preset '{p}' (expected readonly|readwrite|admin)")),
+        None => Ok(None),
+    }
+}
+
+/// A random password (uuid v4, 122 bits) used when the caller supplies none.
+fn generate_password() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+fn print_credential(username: &str, password: &str, json_output: bool) {
+    if json_output {
+        println!(
+            "{}",
+            serde_json::json!({ "username": username, "password": password })
+        );
+    } else {
+        println!("user '{username}' — password (shown once): {password}");
+    }
+}
+
+pub async fn run_create(
+    path: Option<PathBuf>,
+    username: String,
+    preset: Option<String>,
+    password: Option<String>,
+    json_output: bool,
+) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let preset = parse_preset(preset)?;
+    let password = password.unwrap_or_else(generate_password);
+    let use_case = build_use_case(&repo_path).await?;
+    use_case
+        .create_role(
+            &repo_path,
+            &RoleSpec {
+                username: username.clone(),
+                password: password.clone(),
+                preset,
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    print_credential(&username, &password, json_output);
+    Ok(())
+}
+
+pub async fn run_list(path: Option<PathBuf>, json_output: bool) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let use_case = build_use_case(&repo_path).await?;
+    let roles = use_case
+        .list_roles(&repo_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if json_output {
+        println!("{}", serde_json::to_string(&roles)?);
+    } else if roles.is_empty() {
+        println!("no database users");
+    } else {
+        for role in &roles {
+            println!(
+                "{:<32} login={} superuser={}",
+                role.username, role.can_login, role.is_superuser
+            );
+        }
+    }
+    Ok(())
+}
+
+pub async fn run_drop(path: Option<PathBuf>, username: String, json_output: bool) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let use_case = build_use_case(&repo_path).await?;
+    use_case
+        .drop_role(&repo_path, &username)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if json_output {
+        println!(
+            "{}",
+            serde_json::json!({ "username": username, "dropped": true })
+        );
+    } else {
+        println!("dropped user '{username}'");
+    }
+    Ok(())
+}
+
+pub async fn run_set_password(
+    path: Option<PathBuf>,
+    username: String,
+    password: Option<String>,
+    json_output: bool,
+) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let password = password.unwrap_or_else(generate_password);
+    let use_case = build_use_case(&repo_path).await?;
+    use_case
+        .set_password(&repo_path, &username, &password)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    print_credential(&username, &password, json_output);
+    Ok(())
+}

--- a/crates/applications/cli/src/commands/cmd_user.rs
+++ b/crates/applications/cli/src/commands/cmd_user.rs
@@ -73,6 +73,15 @@ pub async fn run_create(
     let generated = password.is_none();
     let password = password.unwrap_or_else(generate_password);
     let use_case = build_use_case(&repo_path).await?;
+    // A preset's default privileges must cover the customer's FUTURE tables, which
+    // the deploy `owner` role creates — not the connecting admin. Auto-detect the
+    // deploy owner so a readonly/readwrite user isn't blind to owner's later tables
+    // (None on single-node repos with no `owner` role → connecting-role-scoped).
+    let default_privileges_owner = if preset.is_some() {
+        use_case.detect_deploy_owner(&repo_path).await
+    } else {
+        None
+    };
     use_case
         .create_role(
             &repo_path,
@@ -80,9 +89,7 @@ pub async fn run_create(
                 username: username.clone(),
                 password: password.clone(),
                 preset,
-                // Single-node gfs CLI: no deploy owner, so a preset's default
-                // privileges are role-scoped to the connecting role.
-                default_privileges_owner: None,
+                default_privileges_owner,
             },
         )
         .await

--- a/crates/applications/cli/src/commands/cmd_user.rs
+++ b/crates/applications/cli/src/commands/cmd_user.rs
@@ -7,7 +7,9 @@ use anyhow::{Context, Result};
 use gfs_compute_docker::containers;
 use gfs_domain::adapters::gfs_repository::GfsRepository;
 use gfs_domain::model::config::GfsConfig;
-use gfs_domain::model::db_user::{RolePreset, RoleSpec};
+use gfs_domain::model::db_user::{
+    GrantSpec, GrantableObject, Privilege, RevokeSpec, RolePreset, RoleSpec,
+};
 use gfs_domain::ports::database_provider::InMemoryDatabaseProviderRegistry;
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::usecases::repository::manage_users_usecase::ManageUsersUseCase;
@@ -142,4 +144,294 @@ pub async fn run_set_password(
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     print_credential(&username, &password, generated, json_output);
     Ok(())
+}
+
+/// The mutually-exclusive `--on-*` object flags for grant/revoke.
+pub struct ObjectFlags {
+    pub on_database: bool,
+    pub on_schema: Option<String>,
+    pub on_table: Option<String>,
+    pub on_all_tables_in_schema: Option<String>,
+    pub on_sequence: Option<String>,
+    pub on_all_sequences_in_schema: Option<String>,
+}
+
+/// Split a `schema.name` argument; both parts must be non-empty.
+fn split_qualified(value: &str) -> Result<(String, String)> {
+    match value.split_once('.') {
+        Some((schema, name)) if !schema.is_empty() && !name.is_empty() => {
+            Ok((schema.to_string(), name.to_string()))
+        }
+        _ => anyhow::bail!("expected schema.name (got '{value}')"),
+    }
+}
+
+/// Resolve exactly one `--on-*` flag into a [`GrantableObject`].
+fn parse_object(flags: &ObjectFlags) -> Result<GrantableObject> {
+    let mut chosen: Vec<GrantableObject> = Vec::new();
+    if flags.on_database {
+        chosen.push(GrantableObject::Database);
+    }
+    if let Some(schema) = &flags.on_schema {
+        chosen.push(GrantableObject::Schema {
+            schema: schema.clone(),
+        });
+    }
+    if let Some(value) = &flags.on_table {
+        let (schema, name) = split_qualified(value)?;
+        chosen.push(GrantableObject::Table { schema, name });
+    }
+    if let Some(schema) = &flags.on_all_tables_in_schema {
+        chosen.push(GrantableObject::AllTablesInSchema {
+            schema: schema.clone(),
+        });
+    }
+    if let Some(value) = &flags.on_sequence {
+        let (schema, name) = split_qualified(value)?;
+        chosen.push(GrantableObject::Sequence { schema, name });
+    }
+    if let Some(schema) = &flags.on_all_sequences_in_schema {
+        chosen.push(GrantableObject::AllSequencesInSchema {
+            schema: schema.clone(),
+        });
+    }
+    match chosen.len() {
+        1 => Ok(chosen.into_iter().next().expect("len checked")),
+        0 => anyhow::bail!(
+            "specify one object: --on-database | --on-schema <s> | --on-table <s.t> | \
+             --on-all-tables-in-schema <s> | --on-sequence <s.q> | --on-all-sequences-in-schema <s>"
+        ),
+        _ => anyhow::bail!("specify exactly one object flag, not multiple"),
+    }
+}
+
+/// Parse a comma-separated privilege list (case-insensitive), e.g. `SELECT,INSERT`.
+fn parse_privileges(csv: &str) -> Result<Vec<Privilege>> {
+    let privileges = csv
+        .split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(|p| {
+            Privilege::parse(&p.to_lowercase()).with_context(|| format!("unknown privilege '{p}'"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if privileges.is_empty() {
+        anyhow::bail!("at least one privilege is required (e.g. --privileges SELECT,INSERT)");
+    }
+    Ok(privileges)
+}
+
+pub async fn run_grant(
+    path: Option<PathBuf>,
+    username: String,
+    object: ObjectFlags,
+    privileges: String,
+    with_grant_option: bool,
+    apply_to_future: Option<String>,
+    json_output: bool,
+) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let object = parse_object(&object)?;
+    let privileges = parse_privileges(&privileges)?;
+    let use_case = build_use_case(&repo_path).await?;
+    use_case
+        .grant(
+            &repo_path,
+            &GrantSpec {
+                role: username.clone(),
+                object,
+                privileges,
+                with_grant_option,
+                apply_to_future,
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if json_output {
+        println!(
+            "{}",
+            serde_json::json!({ "username": username, "granted": true })
+        );
+    } else {
+        println!("granted privileges to '{username}'");
+    }
+    Ok(())
+}
+
+pub async fn run_revoke(
+    path: Option<PathBuf>,
+    username: String,
+    object: ObjectFlags,
+    privileges: String,
+    cascade: bool,
+    json_output: bool,
+) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let object = parse_object(&object)?;
+    let privileges = parse_privileges(&privileges)?;
+    let use_case = build_use_case(&repo_path).await?;
+    use_case
+        .revoke(
+            &repo_path,
+            &RevokeSpec {
+                role: username.clone(),
+                object,
+                privileges,
+                cascade,
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if json_output {
+        println!(
+            "{}",
+            serde_json::json!({ "username": username, "revoked": true })
+        );
+    } else {
+        println!("revoked privileges from '{username}'");
+    }
+    Ok(())
+}
+
+pub async fn run_list_privs(
+    path: Option<PathBuf>,
+    username: String,
+    json_output: bool,
+) -> Result<()> {
+    let repo_path = path.unwrap_or_else(get_repo_dir);
+    let use_case = build_use_case(&repo_path).await?;
+    let privileges = use_case
+        .list_privileges(&repo_path, &username)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if json_output {
+        println!("{}", serde_json::to_string(&privileges)?);
+    } else if privileges.is_empty() {
+        println!("no privileges for '{username}'");
+    } else {
+        for p in &privileges {
+            println!(
+                "{:<10} {:<40} {:<12} grantable={}",
+                p.object_type, p.object_name, p.privilege, p.grantable
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flags() -> ObjectFlags {
+        ObjectFlags {
+            on_database: false,
+            on_schema: None,
+            on_table: None,
+            on_all_tables_in_schema: None,
+            on_sequence: None,
+            on_all_sequences_in_schema: None,
+        }
+    }
+
+    #[test]
+    fn parse_object_each_variant() {
+        assert_eq!(
+            parse_object(&ObjectFlags {
+                on_database: true,
+                ..flags()
+            })
+            .unwrap(),
+            GrantableObject::Database
+        );
+        assert_eq!(
+            parse_object(&ObjectFlags {
+                on_schema: Some("public".into()),
+                ..flags()
+            })
+            .unwrap(),
+            GrantableObject::Schema {
+                schema: "public".into()
+            }
+        );
+        assert_eq!(
+            parse_object(&ObjectFlags {
+                on_table: Some("public.orders".into()),
+                ..flags()
+            })
+            .unwrap(),
+            GrantableObject::Table {
+                schema: "public".into(),
+                name: "orders".into()
+            }
+        );
+        assert_eq!(
+            parse_object(&ObjectFlags {
+                on_all_tables_in_schema: Some("public".into()),
+                ..flags()
+            })
+            .unwrap(),
+            GrantableObject::AllTablesInSchema {
+                schema: "public".into()
+            }
+        );
+        assert_eq!(
+            parse_object(&ObjectFlags {
+                on_sequence: Some("public.seq".into()),
+                ..flags()
+            })
+            .unwrap(),
+            GrantableObject::Sequence {
+                schema: "public".into(),
+                name: "seq".into()
+            }
+        );
+        assert_eq!(
+            parse_object(&ObjectFlags {
+                on_all_sequences_in_schema: Some("public".into()),
+                ..flags()
+            })
+            .unwrap(),
+            GrantableObject::AllSequencesInSchema {
+                schema: "public".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_requires_exactly_one() {
+        assert!(parse_object(&flags()).is_err(), "none set must error");
+        assert!(
+            parse_object(&ObjectFlags {
+                on_database: true,
+                on_schema: Some("public".into()),
+                ..flags()
+            })
+            .is_err(),
+            "multiple set must error"
+        );
+    }
+
+    #[test]
+    fn parse_object_rejects_unqualified_table() {
+        assert!(
+            parse_object(&ObjectFlags {
+                on_table: Some("orders".into()),
+                ..flags()
+            })
+            .is_err(),
+            "table without schema. prefix must error"
+        );
+    }
+
+    #[test]
+    fn parse_privileges_case_insensitive_and_rejects_unknown() {
+        assert_eq!(
+            parse_privileges("SELECT, insert ,Update").unwrap(),
+            vec![Privilege::Select, Privilege::Insert, Privilege::Update]
+        );
+        assert_eq!(parse_privileges("ALL").unwrap(), vec![Privilege::All]);
+        assert!(parse_privileges("bogus").is_err());
+        assert!(parse_privileges("").is_err(), "empty must error");
+    }
 }

--- a/crates/applications/cli/src/commands/mod.rs
+++ b/crates/applications/cli/src/commands/mod.rs
@@ -15,5 +15,6 @@ pub mod cmd_proxy;
 pub mod cmd_query;
 pub mod cmd_schema;
 pub mod cmd_status;
+pub mod cmd_user;
 pub mod cmd_version;
 mod compute_support;

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -576,7 +576,7 @@ enum TopLevel {
         action: StorageAction,
     },
 
-    /// Compute instance management (Docker containers)
+    /// Compute instance lifecycle (start/stop/restart) for the active runtime (Docker or Kubernetes)
     Compute {
         /// Path to the GFS repository root (default: current directory). When set, --id may be omitted and the container name is read from .gfs/config.toml (runtime.container_name).
         #[arg(long)]

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -104,6 +104,16 @@ pub enum UserAction {
         #[arg(long)]
         path: Option<PathBuf>,
     },
+    /// Apply (or change) a role preset on an existing user. A downgrade (e.g.
+    /// readwrite → readonly) revokes the privileges the higher preset granted.
+    ApplyPreset {
+        /// Target username
+        username: String,
+        /// Role preset: readonly | readwrite | admin
+        preset: String,
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
     /// Grant object-level privileges to a user
     Grant {
         /// Grantee username
@@ -952,6 +962,15 @@ where
                     path,
                 } => {
                     commands::cmd_user::run_set_password(path, username, password, json_output)
+                        .await?;
+                    Ok(0)
+                }
+                UserAction::ApplyPreset {
+                    username,
+                    preset,
+                    path,
+                } => {
+                    commands::cmd_user::run_apply_preset(path, username, preset, json_output)
                         .await?;
                     Ok(0)
                 }

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -104,6 +104,78 @@ pub enum UserAction {
         #[arg(long)]
         path: Option<PathBuf>,
     },
+    /// Grant object-level privileges to a user
+    Grant {
+        /// Grantee username
+        username: String,
+        /// Grant on the whole database
+        #[arg(long)]
+        on_database: bool,
+        /// Grant on a schema
+        #[arg(long, value_name = "SCHEMA")]
+        on_schema: Option<String>,
+        /// Grant on a table (or view): schema.name
+        #[arg(long, value_name = "SCHEMA.TABLE")]
+        on_table: Option<String>,
+        /// Grant on all existing tables in a schema
+        #[arg(long, value_name = "SCHEMA")]
+        on_all_tables_in_schema: Option<String>,
+        /// Grant on a sequence: schema.name
+        #[arg(long, value_name = "SCHEMA.SEQUENCE")]
+        on_sequence: Option<String>,
+        /// Grant on all existing sequences in a schema
+        #[arg(long, value_name = "SCHEMA")]
+        on_all_sequences_in_schema: Option<String>,
+        /// Comma-separated privileges, e.g. SELECT,INSERT (or ALL)
+        #[arg(long)]
+        privileges: String,
+        /// Allow the grantee to re-grant these privileges
+        #[arg(long)]
+        with_grant_option: bool,
+        /// Also cover future objects created by this grantor role (all-in-schema scopes only)
+        #[arg(long, value_name = "GRANTOR")]
+        apply_to_future: Option<String>,
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// Revoke object-level privileges from a user
+    Revoke {
+        /// Target username
+        username: String,
+        /// Revoke on the whole database
+        #[arg(long)]
+        on_database: bool,
+        /// Revoke on a schema
+        #[arg(long, value_name = "SCHEMA")]
+        on_schema: Option<String>,
+        /// Revoke on a table (or view): schema.name
+        #[arg(long, value_name = "SCHEMA.TABLE")]
+        on_table: Option<String>,
+        /// Revoke on all existing tables in a schema
+        #[arg(long, value_name = "SCHEMA")]
+        on_all_tables_in_schema: Option<String>,
+        /// Revoke on a sequence: schema.name
+        #[arg(long, value_name = "SCHEMA.SEQUENCE")]
+        on_sequence: Option<String>,
+        /// Revoke on all existing sequences in a schema
+        #[arg(long, value_name = "SCHEMA")]
+        on_all_sequences_in_schema: Option<String>,
+        /// Comma-separated privileges, e.g. SELECT,INSERT (or ALL)
+        #[arg(long)]
+        privileges: String,
+        /// Cascade to dependent grants (default RESTRICT)
+        #[arg(long)]
+        cascade: bool,
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// List a user's effective object privileges
+    ListPrivs {
+        /// Username
+        username: String,
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -881,6 +953,72 @@ where
                 } => {
                     commands::cmd_user::run_set_password(path, username, password, json_output)
                         .await?;
+                    Ok(0)
+                }
+                UserAction::Grant {
+                    username,
+                    on_database,
+                    on_schema,
+                    on_table,
+                    on_all_tables_in_schema,
+                    on_sequence,
+                    on_all_sequences_in_schema,
+                    privileges,
+                    with_grant_option,
+                    apply_to_future,
+                    path,
+                } => {
+                    commands::cmd_user::run_grant(
+                        path,
+                        username,
+                        commands::cmd_user::ObjectFlags {
+                            on_database,
+                            on_schema,
+                            on_table,
+                            on_all_tables_in_schema,
+                            on_sequence,
+                            on_all_sequences_in_schema,
+                        },
+                        privileges,
+                        with_grant_option,
+                        apply_to_future,
+                        json_output,
+                    )
+                    .await?;
+                    Ok(0)
+                }
+                UserAction::Revoke {
+                    username,
+                    on_database,
+                    on_schema,
+                    on_table,
+                    on_all_tables_in_schema,
+                    on_sequence,
+                    on_all_sequences_in_schema,
+                    privileges,
+                    cascade,
+                    path,
+                } => {
+                    commands::cmd_user::run_revoke(
+                        path,
+                        username,
+                        commands::cmd_user::ObjectFlags {
+                            on_database,
+                            on_schema,
+                            on_table,
+                            on_all_tables_in_schema,
+                            on_sequence,
+                            on_all_sequences_in_schema,
+                        },
+                        privileges,
+                        cascade,
+                        json_output,
+                    )
+                    .await?;
+                    Ok(0)
+                }
+                UserAction::ListPrivs { username, path } => {
+                    commands::cmd_user::run_list_privs(path, username, json_output).await?;
                     Ok(0)
                 }
             },

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -67,6 +67,46 @@ pub enum SchemaAction {
 }
 
 // ---------------------------------------------------------------------------
+// User subcommands (`gfs user`)
+// ---------------------------------------------------------------------------
+
+#[derive(Subcommand)]
+pub enum UserAction {
+    /// Create a login user, optionally with a role preset
+    Create {
+        /// Username (letters, digits, underscore; up to 63 chars)
+        username: String,
+        /// Role preset: readonly | readwrite | admin
+        #[arg(long)]
+        preset: Option<String>,
+        /// Password (a strong one is generated and shown once if omitted)
+        #[arg(long)]
+        password: Option<String>,
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// List database users
+    List {
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// Drop a user
+    Drop {
+        username: String,
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// Set / rotate a user's password
+    SetPassword {
+        username: String,
+        #[arg(long)]
+        password: Option<String>,
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+}
+
+// ---------------------------------------------------------------------------
 // Compute subcommands (used by commands)
 // ---------------------------------------------------------------------------
 
@@ -500,6 +540,12 @@ enum TopLevel {
         action: SchemaAction,
     },
 
+    /// Manage database users/roles (create, list, drop, set-password)
+    User {
+        #[command(subcommand)]
+        action: UserAction,
+    },
+
     /// Print the CLI version
     Version,
 }
@@ -577,6 +623,7 @@ fn command_name(cmd: &TopLevel) -> &'static str {
         TopLevel::Status { .. } => "status",
         TopLevel::Query { .. } => "query",
         TopLevel::Schema { .. } => "schema",
+        TopLevel::User { .. } => "user",
         TopLevel::Storage { .. } => "storage",
         TopLevel::Compute { .. } => "compute",
         TopLevel::Mcp { .. } => "mcp",
@@ -806,6 +853,35 @@ where
                     let no_color = no_color || color == ColorMode::Never;
                     commands::cmd_schema::run_diff(commit1, commit2, path, pretty, json, no_color)
                         .await
+                }
+            },
+            TopLevel::User { action } => match action {
+                UserAction::Create {
+                    username,
+                    preset,
+                    password,
+                    path,
+                } => {
+                    commands::cmd_user::run_create(path, username, preset, password, json_output)
+                        .await?;
+                    Ok(0)
+                }
+                UserAction::List { path } => {
+                    commands::cmd_user::run_list(path, json_output).await?;
+                    Ok(0)
+                }
+                UserAction::Drop { username, path } => {
+                    commands::cmd_user::run_drop(path, username, json_output).await?;
+                    Ok(0)
+                }
+                UserAction::SetPassword {
+                    username,
+                    password,
+                    path,
+                } => {
+                    commands::cmd_user::run_set_password(path, username, password, json_output)
+                        .await?;
+                    Ok(0)
                 }
             },
             TopLevel::Storage { action } => {

--- a/crates/applications/cli/tests/e2e_user_postgres.rs
+++ b/crates/applications/cli/tests/e2e_user_postgres.rs
@@ -1,0 +1,282 @@
+//! End-to-end tests for `gfs user` against a real Postgres container.
+//!
+//! Two scenarios, each on its own fresh repo/container (auto-provisioned and
+//! cleaned up by `common::postgres::with_fresh_repo`, which also skips — not
+//! fails — when the local `gfs-postgres:17` image is absent):
+//!
+//! 1. `user_lifecycle_create_rotate_password_drop` — create a login user with a
+//!    preset, assert its credential is stored as a fresh SCRAM-SHA-256 hash (not
+//!    NULL — the empty-password lockout guard), rotate it with `set-password`
+//!    (the stored hash changes), then drop. Auth is verified against the
+//!    `pg_authid` catalog, NOT by connecting: the container trusts loopback
+//!    (`127.0.0.1` in pg_hba, which is what the in-container exec seam relies
+//!    on), so a loopback `psql` ignores the password — client-password
+//!    enforcement lives on the external/proxied port, out of scope here.
+//! 2. `drop_is_non_destructive_and_recoverable_via_version_control` — the
+//!    headline safety property: dropping a user that OWNS a table neither
+//!    deletes the table nor its rows (REASSIGN OWNED hands them to the admin),
+//!    and the drop is fully reversible through gfs's COW versioning — checking
+//!    out the pre-drop commit resurrects the role and its ownership byte-for-byte.
+//!
+//! macOS-only: `with_fresh_repo` commits via the APFS storage backend, matching
+//! the other postgres e2e suites. Docker (or Podman) must be running.
+//! **Run with `--test-threads=1`** (shared Docker daemon / host ports).
+
+#![cfg(target_os = "macos")]
+
+mod common;
+
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+use common::cli_runner::{gfs_checkout, gfs_commit, run_gfs, run_gfs_subprocess};
+use common::container_runtime::runtime_command;
+use common::postgres::{get_container_id, run_psql_select, with_fresh_repo};
+use serial_test::serial;
+
+/// Run `gfs user <args…> --path <repo>` in-process. Returns success only; the
+/// authoritative state is always read back from Postgres via `run_psql_select`,
+/// so we never depend on the (gag-captured, sometimes flaky) stdout here.
+fn gfs_user(repo: &Path, args: &[&str]) -> bool {
+    let mut full = vec!["gfs", "user"];
+    full.extend_from_slice(args);
+    full.extend(["--path", repo.to_str().unwrap()]);
+    let (ok, _out, err) = run_gfs(full);
+    if !ok {
+        eprintln!("gfs user {args:?} failed: {err}");
+    }
+    ok
+}
+
+/// Poll until the container's Postgres accepts a socket connection (post-checkout
+/// the container is restarted on the swapped data dir and needs a moment).
+fn wait_for_pg(container_id: &str) {
+    for _ in 0..30 {
+        let up = runtime_command()
+            .args([
+                "exec",
+                container_id,
+                "psql",
+                "-U",
+                "postgres",
+                "-c",
+                "SELECT 1",
+            ])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if up {
+            return;
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+    panic!("postgres in {container_id} did not become ready within 30s");
+}
+
+/// The stored credential for `user`, read from `pg_authid` as the superuser.
+/// A well-formed password is a `SCRAM-SHA-256$…` verifier; a NULL/empty one
+/// would render the login unusable. Method-agnostic ground truth (loopback is
+/// trust auth, so an actual connection can't distinguish passwords).
+fn stored_credential(container_id: &str, user: &str) -> String {
+    run_psql_select(
+        container_id,
+        &format!("SELECT COALESCE(rolpassword,'<null>') FROM pg_authid WHERE rolname='{user}'"),
+    )
+    .trim()
+    .to_string()
+}
+
+/// Full-hash of the (first) commit whose message equals `message`, read from
+/// `gfs log --json` (subprocess: stdout is reliably captured there).
+fn commit_hash_by_message(repo: &Path, message: &str) -> String {
+    let (_ok, stdout, _err) =
+        run_gfs_subprocess(["gfs", "log", "--path", repo.to_str().unwrap(), "--json"]);
+    let value: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("log --json parse ({e}): {stdout}"));
+    for commit in value["commits"].as_array().expect("commits array") {
+        if commit["message"].as_str() == Some(message) {
+            return commit["hash_full"].as_str().expect("hash_full").to_string();
+        }
+    }
+    panic!("no commit with message {message:?} in log: {stdout}");
+}
+
+#[test]
+#[serial]
+fn user_lifecycle_create_rotate_password_drop() {
+    with_fresh_repo(|repo| {
+        let cid = get_container_id(repo);
+
+        // create a login user with the readwrite preset + a known password.
+        assert!(gfs_user(
+            repo,
+            &[
+                "create",
+                "app_rw",
+                "--preset",
+                "readwrite",
+                "--password",
+                "initial_pw"
+            ],
+        ));
+        assert!(
+            run_psql_select(&cid, "SELECT rolname FROM pg_roles WHERE rolname='app_rw'")
+                .contains("app_rw"),
+            "created role must exist in pg_roles",
+        );
+        // the client role is never privileged (v2 escalation guard).
+        assert!(
+            run_psql_select(&cid, "SELECT rolsuper FROM pg_roles WHERE rolname='app_rw'")
+                .trim_start()
+                .starts_with('f'),
+            "client role must be NOSUPERUSER",
+        );
+        // password stored as a real SCRAM verifier — never NULL (lockout guard).
+        let created_hash = stored_credential(&cid, "app_rw");
+        assert!(
+            created_hash.starts_with("SCRAM-SHA-256$"),
+            "password must be stored as a SCRAM-SHA-256 verifier, got: {created_hash}",
+        );
+
+        // rotate the password: the stored verifier must change.
+        assert!(gfs_user(
+            repo,
+            &["set-password", "app_rw", "--password", "rotated_pw"],
+        ));
+        let rotated_hash = stored_credential(&cid, "app_rw");
+        assert!(
+            rotated_hash.starts_with("SCRAM-SHA-256$"),
+            "rotated password must still be a SCRAM verifier, got: {rotated_hash}",
+        );
+        assert_ne!(
+            created_hash, rotated_hash,
+            "set-password must change the stored credential",
+        );
+
+        // list surfaces the role (and never the private management role).
+        assert!(gfs_user(repo, &["list"]));
+
+        // drop removes the role.
+        assert!(gfs_user(repo, &["drop", "app_rw"]));
+        assert!(
+            !run_psql_select(&cid, "SELECT rolname FROM pg_roles WHERE rolname='app_rw'")
+                .contains("app_rw"),
+            "dropped role must be gone from pg_roles",
+        );
+    });
+}
+
+#[test]
+#[serial]
+fn drop_is_non_destructive_and_recoverable_via_version_control() {
+    with_fresh_repo(|repo| {
+        let cid = get_container_id(repo);
+
+        // A user that OWNS a table with data.
+        assert!(gfs_user(
+            repo,
+            &[
+                "create",
+                "dataowner",
+                "--preset",
+                "readwrite",
+                "--password",
+                "pw"
+            ],
+        ));
+        run_psql_select(
+            &cid,
+            "CREATE TABLE ledger(id int primary key, amount int); \
+             ALTER TABLE ledger OWNER TO dataowner; \
+             INSERT INTO ledger VALUES (1,100),(2,200),(3,300);",
+        );
+        assert_eq!(
+            run_psql_select(
+                &cid,
+                "SELECT tableowner FROM pg_tables WHERE tablename='ledger'"
+            )
+            .trim(),
+            "dataowner",
+            "table should initially be owned by dataowner",
+        );
+
+        // Commit C1 — snapshot WITH the user + its owned table.
+        let (ok, _o, err) = gfs_commit(repo, "with-dataowner", Some("t"), Some("t@e.co"));
+        assert!(ok, "commit C1 should succeed; stderr: {err}");
+        let c1 = commit_hash_by_message(repo, "with-dataowner");
+
+        // Drop the owner. This must NOT destroy the table or its rows:
+        // REASSIGN OWNED hands `ledger` to the management role first.
+        assert!(gfs_user(repo, &["drop", "dataowner"]));
+        assert!(
+            !run_psql_select(
+                &cid,
+                "SELECT rolname FROM pg_roles WHERE rolname='dataowner'"
+            )
+            .contains("dataowner"),
+            "dropped role must be gone",
+        );
+        assert_eq!(
+            run_psql_select(&cid, "SELECT count(*) FROM ledger").trim(),
+            "3",
+            "dropping the owner must NOT delete its table's rows (no cascade)",
+        );
+        assert_eq!(
+            run_psql_select(
+                &cid,
+                "SELECT tableowner FROM pg_tables WHERE tablename='ledger'"
+            )
+            .trim(),
+            "postgres",
+            "ledger must be reassigned to the management role, not dropped",
+        );
+
+        // Commit C2 — snapshot WITHOUT the user.
+        let (ok, _o, err) = gfs_commit(repo, "dropped-dataowner", Some("t"), Some("t@e.co"));
+        assert!(ok, "commit C2 should succeed; stderr: {err}");
+
+        // Checkout C1 (pre-drop): version control must resurrect the role AND
+        // restore the table's original ownership — the drop is fully reversible.
+        let (ok, _o, err) = gfs_checkout(repo, &c1);
+        assert!(ok, "checkout C1 should succeed; stderr: {err}");
+        let cid = get_container_id(repo); // stable across checkout, but re-read to be safe
+        wait_for_pg(&cid);
+        assert!(
+            run_psql_select(
+                &cid,
+                "SELECT rolname FROM pg_roles WHERE rolname='dataowner'"
+            )
+            .contains("dataowner"),
+            "checking out the pre-drop commit must bring the dropped user back",
+        );
+        assert_eq!(
+            run_psql_select(
+                &cid,
+                "SELECT tableowner FROM pg_tables WHERE tablename='ledger'"
+            )
+            .trim(),
+            "dataowner",
+            "ownership at C1 must be restored to dataowner",
+        );
+        assert_eq!(
+            run_psql_select(&cid, "SELECT count(*) FROM ledger").trim(),
+            "3",
+            "data intact at C1",
+        );
+
+        // Checkout back to main (C2): the user is gone again.
+        let (ok, _o, err) = gfs_checkout(repo, "main");
+        assert!(ok, "checkout main should succeed; stderr: {err}");
+        let cid = get_container_id(repo);
+        wait_for_pg(&cid);
+        assert!(
+            !run_psql_select(
+                &cid,
+                "SELECT rolname FROM pg_roles WHERE rolname='dataowner'"
+            )
+            .contains("dataowner"),
+            "back on main (post-drop) the user must be absent again",
+        );
+    });
+}

--- a/crates/applications/cli/tests/e2e_user_postgres.rs
+++ b/crates/applications/cli/tests/e2e_user_postgres.rs
@@ -280,3 +280,85 @@ fn drop_is_non_destructive_and_recoverable_via_version_control() {
         );
     });
 }
+
+/// Story 007-004: object-level `gfs user grant/revoke/list-privs` change real
+/// privileges. Drives the ACTUAL CLI (clap parse → dispatch → run_grant →
+/// DockerCompute) and verifies against `has_table_privilege` in the engine.
+#[test]
+#[serial]
+fn user_grant_revoke_list_privileges() {
+    with_fresh_repo(|repo| {
+        let cid = get_container_id(repo);
+
+        // A least-privileged client role + a table to grant on.
+        assert!(gfs_user(
+            repo,
+            &[
+                "create",
+                "app_ro",
+                "--preset",
+                "readonly",
+                "--password",
+                "pw"
+            ],
+        ));
+        run_psql_select(&cid, "CREATE TABLE public.orders(id int);");
+
+        // GRANT SELECT on the table via the CLI.
+        assert!(gfs_user(
+            repo,
+            &[
+                "grant",
+                "app_ro",
+                "--on-table",
+                "public.orders",
+                "--privileges",
+                "SELECT",
+            ],
+        ));
+        assert_eq!(
+            run_psql_select(
+                &cid,
+                "SELECT has_table_privilege('app_ro','public.orders','SELECT')"
+            )
+            .trim(),
+            "t",
+            "CLI grant must give app_ro SELECT on public.orders",
+        );
+        // Least-privilege preserved: INSERT was NOT granted.
+        assert_eq!(
+            run_psql_select(
+                &cid,
+                "SELECT has_table_privilege('app_ro','public.orders','INSERT')"
+            )
+            .trim(),
+            "f",
+            "only SELECT was granted, not INSERT",
+        );
+
+        // list-privs runs (authoritative check is the has_table_privilege above).
+        assert!(gfs_user(repo, &["list-privs", "app_ro"]));
+
+        // REVOKE SELECT via the CLI.
+        assert!(gfs_user(
+            repo,
+            &[
+                "revoke",
+                "app_ro",
+                "--on-table",
+                "public.orders",
+                "--privileges",
+                "SELECT",
+            ],
+        ));
+        assert_eq!(
+            run_psql_select(
+                &cid,
+                "SELECT has_table_privilege('app_ro','public.orders','SELECT')"
+            )
+            .trim(),
+            "f",
+            "CLI revoke must remove SELECT",
+        );
+    });
+}

--- a/crates/applications/mcp/Cargo.toml
+++ b/crates/applications/mcp/Cargo.toml
@@ -22,6 +22,7 @@ gfs-storage-file = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uuid = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -211,6 +211,20 @@ pub struct QueryRequest {
 }
 
 #[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct UserRequest {
+    #[schemars(description = "action: create | list | drop | set_password")]
+    pub action: String,
+    #[schemars(description = "username (required for create/drop/set_password)")]
+    pub username: Option<String>,
+    #[schemars(description = "role preset for create: readonly | readwrite | admin")]
+    pub preset: Option<String>,
+    #[schemars(description = "password (optional; generated and returned once if omitted)")]
+    pub password: Option<String>,
+    #[schemars(description = "repo root path")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub struct ExtractSchemaRequest {
     #[schemars(description = "repo root path")]
     pub path: Option<String>,
@@ -474,6 +488,25 @@ impl GfsMcpHandler {
         });
         let result = do_query(&args).await;
         self.track_mcp("query", &result);
+        result
+    }
+
+    #[tool(
+        description = "Manage database users/roles inside the running instance. action = create | list | drop | set_password. create and set_password return the password once. Params: action (required); username (create/drop/set_password); preset (create: readonly|readwrite|admin); password (optional, generated once if omitted); path (repo root). Equivalent to gfs user."
+    )]
+    async fn user(
+        &self,
+        Parameters(req): Parameters<UserRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let args = json!({
+            "action": req.action,
+            "username": req.username,
+            "preset": req.preset,
+            "password": req.password,
+            "path": req.path,
+        });
+        let result = do_user(&args).await;
+        self.track_mcp("user", &result);
         result
     }
 
@@ -1250,6 +1283,99 @@ async fn do_import(args: &serde_json::Value) -> Result<CallToolResult, McpError>
         "format": output.format,
         "stdout": output.stdout,
     }))
+}
+
+async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
+    use gfs_domain::model::db_user::{RolePreset, RoleSpec};
+    use gfs_domain::usecases::repository::manage_users_usecase::ManageUsersUseCase;
+
+    let args = if args.is_object() { args } else { &json!({}) };
+    let repo_path = repo_path_from_value(args);
+    let action = args.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    let username = args
+        .get("username")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let password = args
+        .get("password")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    GfsConfig::load(&repo_path).map_err(|e| to_error_data(format!("not a GFS repository: {e}")))?;
+
+    let compute = Arc::new(DockerCompute::new().map_err(|e| to_error_data(e.to_string()))?);
+    let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
+    containers::register_all(registry.as_ref())
+        .map_err(|e| to_error_data(format!("register providers: {e}")))?;
+    let use_case = ManageUsersUseCase::new(compute, registry);
+
+    let gen_password = || uuid::Uuid::new_v4().simple().to_string();
+    let require_username = || {
+        username
+            .clone()
+            .ok_or_else(|| to_error_data(format!("action '{action}' requires 'username'")))
+    };
+
+    match action {
+        "create" => {
+            let username = require_username()?;
+            let preset = match args.get("preset").and_then(|v| v.as_str()) {
+                Some(p) => Some(
+                    RolePreset::parse(p)
+                        .ok_or_else(|| to_error_data(format!("unknown preset '{p}'")))?,
+                ),
+                None => None,
+            };
+            let password = password.unwrap_or_else(gen_password);
+            use_case
+                .create_role(
+                    &repo_path,
+                    &RoleSpec {
+                        username: username.clone(),
+                        password: password.clone(),
+                        preset,
+                    },
+                )
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                json!({ "username": username, "password": password }).to_string(),
+            )]))
+        }
+        "list" => {
+            let roles = use_case
+                .list_roles(&repo_path)
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string(&roles).unwrap_or_default(),
+            )]))
+        }
+        "drop" => {
+            let username = require_username()?;
+            use_case
+                .drop_role(&repo_path, &username)
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                json!({ "username": username, "dropped": true }).to_string(),
+            )]))
+        }
+        "set_password" => {
+            let username = require_username()?;
+            let password = password.unwrap_or_else(gen_password);
+            use_case
+                .set_password(&repo_path, &username, &password)
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                json!({ "username": username, "password": password }).to_string(),
+            )]))
+        }
+        other => Err(to_error_data(format!(
+            "unknown user action '{other}' (create|list|drop|set_password)"
+        ))),
+    }
 }
 
 async fn do_query(args: &serde_json::Value) -> Result<CallToolResult, McpError> {

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -621,8 +621,9 @@ impl ServerHandler for GfsMcpHandler {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             instructions: Some(
-                "GFS MCP server. Tools: list_providers, status, commit, log, checkout, init, compute, export_database, import_database, query, extract_schema, show_schema, diff_schema. \
+                "GFS MCP server. Tools: list_providers, status, commit, log, checkout, init, compute, user, export_database, import_database, query, extract_schema, show_schema, diff_schema. \
                  Schema versioning: commits automatically capture database schemas. Use show_schema to view schema at any commit, diff_schema to compare schema evolution. \
+                 Database users/roles: use the user tool (actions create, list, drop, set_password, grant, revoke, list_privs, apply_preset) to manage least-privilege login roles and presets. \
                  Use path to target a repo or set GFS_REPO_PATH."
                     .into(),
             ),

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -213,7 +213,7 @@ pub struct QueryRequest {
 #[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub struct UserRequest {
     #[schemars(
-        description = "action: create | list | drop | set_password | grant | revoke | list_privs"
+        description = "action: create | list | drop | set_password | apply_preset | grant | revoke | list_privs"
     )]
     pub action: String,
     #[schemars(description = "username (required for every action except list)")]
@@ -510,7 +510,7 @@ impl GfsMcpHandler {
     }
 
     #[tool(
-        description = "Manage database users/roles inside the running instance. action = create | list | drop | set_password | grant | revoke | list_privs. create and set_password return the password once. Params: action (required); username (all except list); preset (create: readonly|readwrite|admin); password (optional, generated once if omitted); object (grant/revoke: JSON {type: database|schema|table|all_tables_in_schema|sequence|all_sequences_in_schema, schema?, name?}); privileges (grant/revoke: array or CSV, e.g. [\"SELECT\",\"INSERT\"] or \"ALL\"); with_grant_option, apply_to_future (grant); cascade (revoke); path (repo root). Equivalent to gfs user."
+        description = "Manage database users/roles inside the running instance. action = create | list | drop | set_password | apply_preset | grant | revoke | list_privs. create and set_password return the password once. Params: action (required); username (all except list); preset (create: readonly|readwrite|admin); password (optional, generated once if omitted); object (grant/revoke: JSON {type: database|schema|table|all_tables_in_schema|sequence|all_sequences_in_schema, schema?, name?}); privileges (grant/revoke: array or CSV, e.g. [\"SELECT\",\"INSERT\"] or \"ALL\"); with_grant_option, apply_to_future (grant); cascade (revoke); path (repo root). Equivalent to gfs user."
     )]
     async fn user(
         &self,
@@ -1450,6 +1450,24 @@ async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
                 .map_err(|e| to_error_data(e.to_string()))?;
             Ok(CallToolResult::success(vec![Content::text(
                 json!({ "username": username, "password": password }).to_string(),
+            )]))
+        }
+        "apply_preset" => {
+            let username = require_username()?;
+            let preset = args
+                .get("preset")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| to_error_data("action 'apply_preset' requires 'preset'"))?;
+            let preset = RolePreset::parse(preset)
+                .ok_or_else(|| to_error_data(format!("unknown preset '{preset}'")))?;
+            // Scope defaults to the deploy owner's future objects (same as create).
+            let owner = use_case.detect_deploy_owner(&repo_path).await;
+            use_case
+                .apply_preset(&repo_path, &username, preset, owner.as_deref())
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                json!({ "username": username, "preset_applied": true }).to_string(),
             )]))
         }
         "grant" => {

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -212,14 +212,32 @@ pub struct QueryRequest {
 
 #[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub struct UserRequest {
-    #[schemars(description = "action: create | list | drop | set_password")]
+    #[schemars(
+        description = "action: create | list | drop | set_password | grant | revoke | list_privs"
+    )]
     pub action: String,
-    #[schemars(description = "username (required for create/drop/set_password)")]
+    #[schemars(description = "username (required for every action except list)")]
     pub username: Option<String>,
     #[schemars(description = "role preset for create: readonly | readwrite | admin")]
     pub preset: Option<String>,
     #[schemars(description = "password (optional; generated and returned once if omitted)")]
     pub password: Option<String>,
+    #[schemars(
+        description = "grant/revoke target object, JSON {type: database|schema|table|all_tables_in_schema|sequence|all_sequences_in_schema, schema?, name?}"
+    )]
+    pub object: Option<serde_json::Value>,
+    #[schemars(
+        description = "grant/revoke privileges: array or CSV, e.g. [\"SELECT\",\"INSERT\"] or \"ALL\""
+    )]
+    pub privileges: Option<serde_json::Value>,
+    #[schemars(description = "grant: allow the grantee to re-grant (WITH GRANT OPTION)")]
+    pub with_grant_option: Option<bool>,
+    #[schemars(
+        description = "grant: also cover future objects created by this grantor role (all-in-schema scopes only)"
+    )]
+    pub apply_to_future: Option<String>,
+    #[schemars(description = "revoke: cascade to dependent grants (default RESTRICT)")]
+    pub cascade: Option<bool>,
     #[schemars(description = "repo root path")]
     pub path: Option<String>,
 }
@@ -503,6 +521,11 @@ impl GfsMcpHandler {
             "username": req.username,
             "preset": req.preset,
             "password": req.password,
+            "object": req.object,
+            "privileges": req.privileges,
+            "with_grant_option": req.with_grant_option,
+            "apply_to_future": req.apply_to_future,
+            "cascade": req.cascade,
             "path": req.path,
         });
         let result = do_user(&args).await;
@@ -1375,6 +1398,14 @@ async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
                 None => None,
             };
             let password = password.unwrap_or_else(gen_password);
+            // Scope a preset's default privileges to the deploy owner (the role that
+            // creates the customer's future tables), not the connecting admin, so a
+            // preset user isn't blind to owner's later tables (see cmd_user / F-03).
+            let default_privileges_owner = if preset.is_some() {
+                use_case.detect_deploy_owner(&repo_path).await
+            } else {
+                None
+            };
             use_case
                 .create_role(
                     &repo_path,
@@ -1382,8 +1413,7 @@ async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
                         username: username.clone(),
                         password: password.clone(),
                         preset,
-                        // Single-node gfs MCP: no deploy owner (see cmd_user).
-                        default_privileges_owner: None,
+                        default_privileges_owner,
                     },
                 )
                 .await

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -1351,7 +1351,7 @@ async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
 
     GfsConfig::load(&repo_path).map_err(|e| to_error_data(format!("not a GFS repository: {e}")))?;
 
-    let compute = Arc::new(DockerCompute::new().map_err(|e| to_error_data(e.to_string()))?);
+    let compute = runtime_compute().await?;
     let registry = Arc::new(InMemoryDatabaseProviderRegistry::new());
     containers::register_all(registry.as_ref())
         .map_err(|e| to_error_data(format!("register providers: {e}")))?;

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -492,7 +492,7 @@ impl GfsMcpHandler {
     }
 
     #[tool(
-        description = "Manage database users/roles inside the running instance. action = create | list | drop | set_password. create and set_password return the password once. Params: action (required); username (create/drop/set_password); preset (create: readonly|readwrite|admin); password (optional, generated once if omitted); path (repo root). Equivalent to gfs user."
+        description = "Manage database users/roles inside the running instance. action = create | list | drop | set_password | grant | revoke | list_privs. create and set_password return the password once. Params: action (required); username (all except list); preset (create: readonly|readwrite|admin); password (optional, generated once if omitted); object (grant/revoke: JSON {type: database|schema|table|all_tables_in_schema|sequence|all_sequences_in_schema, schema?, name?}); privileges (grant/revoke: array or CSV, e.g. [\"SELECT\",\"INSERT\"] or \"ALL\"); with_grant_option, apply_to_future (grant); cascade (revoke); path (repo root). Equivalent to gfs user."
     )]
     async fn user(
         &self,
@@ -1285,8 +1285,56 @@ async fn do_import(args: &serde_json::Value) -> Result<CallToolResult, McpError>
     }))
 }
 
+/// Parse the `object` arg into a [`GrantableObject`] (internally-tagged JSON,
+/// e.g. `{"type":"table","schema":"public","name":"t"}`).
+fn parse_grant_object(
+    args: &serde_json::Value,
+) -> Result<gfs_domain::model::db_user::GrantableObject, McpError> {
+    match args.get("object") {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            to_error_data(format!(
+                "invalid 'object' (expected {{type, schema?, name?}}): {e}"
+            ))
+        }),
+        None => Err(to_error_data(
+            "action requires 'object', e.g. {\"type\":\"table\",\"schema\":\"public\",\"name\":\"t\"}"
+                .to_string(),
+        )),
+    }
+}
+
+/// Parse the `privileges` arg (JSON array or comma-separated string), case-insensitive.
+fn parse_grant_privileges(
+    args: &serde_json::Value,
+) -> Result<Vec<gfs_domain::model::db_user::Privilege>, McpError> {
+    use gfs_domain::model::db_user::Privilege;
+    let raw: Vec<String> = match args.get("privileges") {
+        Some(serde_json::Value::Array(a)) => a
+            .iter()
+            .filter_map(|x| x.as_str().map(String::from))
+            .collect(),
+        Some(serde_json::Value::String(s)) => s
+            .split(',')
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    };
+    if raw.is_empty() {
+        return Err(to_error_data(
+            "action requires 'privileges' (array or comma-separated string)".to_string(),
+        ));
+    }
+    raw.iter()
+        .map(|p| {
+            Privilege::parse(&p.to_lowercase())
+                .ok_or_else(|| to_error_data(format!("unknown privilege '{p}'")))
+        })
+        .collect()
+}
+
 async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
-    use gfs_domain::model::db_user::{RolePreset, RoleSpec};
+    use gfs_domain::model::db_user::{GrantSpec, RevokeSpec, RolePreset, RoleSpec};
     use gfs_domain::usecases::repository::manage_users_usecase::ManageUsersUseCase;
 
     let args = if args.is_object() { args } else { &json!({}) };
@@ -1372,8 +1420,72 @@ async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
                 json!({ "username": username, "password": password }).to_string(),
             )]))
         }
+        "grant" => {
+            let username = require_username()?;
+            let object = parse_grant_object(args)?;
+            let privileges = parse_grant_privileges(args)?;
+            let with_grant_option = args
+                .get("with_grant_option")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let apply_to_future = args
+                .get("apply_to_future")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            use_case
+                .grant(
+                    &repo_path,
+                    &GrantSpec {
+                        role: username.clone(),
+                        object,
+                        privileges,
+                        with_grant_option,
+                        apply_to_future,
+                    },
+                )
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                json!({ "username": username, "granted": true }).to_string(),
+            )]))
+        }
+        "revoke" => {
+            let username = require_username()?;
+            let object = parse_grant_object(args)?;
+            let privileges = parse_grant_privileges(args)?;
+            let cascade = args
+                .get("cascade")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            use_case
+                .revoke(
+                    &repo_path,
+                    &RevokeSpec {
+                        role: username.clone(),
+                        object,
+                        privileges,
+                        cascade,
+                    },
+                )
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                json!({ "username": username, "revoked": true }).to_string(),
+            )]))
+        }
+        "list_privs" => {
+            let username = require_username()?;
+            let privileges = use_case
+                .list_privileges(&repo_path, &username)
+                .await
+                .map_err(|e| to_error_data(e.to_string()))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string(&privileges).unwrap_or_default(),
+            )]))
+        }
         other => Err(to_error_data(format!(
-            "unknown user action '{other}' (create|list|drop|set_password)"
+            "unknown user action '{other}' \
+             (create|list|drop|set_password|grant|revoke|list_privs)"
         ))),
     }
 }

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -1795,4 +1795,130 @@ mod tests {
             "instructions should mention list_providers"
         );
     }
+
+    // EMPIRICAL (Docker-gated): the MCP `user` tool's grant/revoke actions change
+    // real privileges. Drives the actual `do_user` handler (JSON args → parse →
+    // ManageUsersUseCase → real DockerCompute) against a live Postgres 17, and
+    // verifies with `has_table_privilege`. Skips (does not fail) without Docker.
+    // Run: GFS_DOCKER_IT=1 cargo test -p gfs-mcp user_tool_grant_revoke -- --nocapture
+    fn mcp_docker_ok() -> bool {
+        std::env::var("GFS_DOCKER_IT").ok().as_deref() == Some("1")
+            && std::process::Command::new("docker")
+                .arg("info")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+    }
+
+    #[tokio::test]
+    async fn user_tool_grant_revoke_changes_real_privileges() {
+        use gfs_domain::model::config::{EnvironmentConfig, RuntimeConfig};
+        if !mcp_docker_ok() {
+            eprintln!(
+                "SKIP user_tool_grant_revoke_changes_real_privileges: set GFS_DOCKER_IT=1 + docker"
+            );
+            return;
+        }
+        let cn = format!("gfs-mcp-it-user-{}", std::process::id());
+        let docker = |args: &[&str]| {
+            std::process::Command::new("docker")
+                .args(args)
+                .output()
+                .expect("docker")
+        };
+        let psql = |sql: &str| {
+            let o = std::process::Command::new("docker")
+                .args(["exec", &cn, "psql", "-U", "postgres", "-tAc", sql])
+                .output()
+                .expect("psql");
+            String::from_utf8_lossy(&o.stdout).trim().to_string()
+        };
+
+        let _ = docker(&["rm", "-f", &cn]);
+        assert!(
+            docker(&[
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                &cn,
+                "-e",
+                "POSTGRES_PASSWORD=postgres",
+                "postgres:17",
+            ])
+            .status
+            .success(),
+            "docker run postgres:17 failed"
+        );
+        let mut ready = false;
+        for _ in 0..30 {
+            if docker(&["exec", &cn, "pg_isready", "-U", "postgres"])
+                .status
+                .success()
+            {
+                ready = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+        let _ = psql("CREATE ROLE app_ro; CREATE TABLE public.t(id int)");
+
+        // A .gfs repo pointing at the container (no tempfile dep — manual temp dir).
+        let repo = std::env::temp_dir().join(format!("gfs-mcp-it-{}", std::process::id()));
+        std::fs::create_dir_all(repo.join(".gfs")).expect("mkdir .gfs");
+        GfsConfig {
+            mount_point: None,
+            version: String::new(),
+            description: String::new(),
+            user: None,
+            environment: Some(EnvironmentConfig {
+                database_provider: "postgres".into(),
+                database_version: "17".into(),
+                database_port: None,
+                display_name: None,
+            }),
+            runtime: Some(RuntimeConfig {
+                runtime_provider: "docker".into(),
+                runtime_version: "latest".into(),
+                container_name: cn.clone(),
+            }),
+            storage: None,
+            compute: None,
+            remote: None,
+        }
+        .save(&repo)
+        .expect("save .gfs config");
+        let repo_str = repo.to_str().unwrap();
+
+        // Drive the ACTUAL MCP handler.
+        let grant = do_user(&serde_json::json!({
+            "action": "grant", "username": "app_ro",
+            "object": {"type": "table", "schema": "public", "name": "t"},
+            "privileges": ["SELECT"], "path": repo_str,
+        }))
+        .await;
+        let after_grant = psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
+        let list = do_user(
+            &serde_json::json!({"action":"list_privs","username":"app_ro","path": repo_str}),
+        )
+        .await;
+        let revoke = do_user(&serde_json::json!({
+            "action": "revoke", "username": "app_ro",
+            "object": {"type": "table", "schema": "public", "name": "t"},
+            "privileges": ["SELECT"], "path": repo_str,
+        }))
+        .await;
+        let after_revoke = psql("SELECT has_table_privilege('app_ro','public.t','SELECT')");
+
+        // Clean up before asserting so a failed assert never leaks resources.
+        let _ = docker(&["rm", "-f", &cn]);
+        let _ = std::fs::remove_dir_all(&repo);
+
+        assert!(ready, "postgres never became ready");
+        assert!(grant.is_ok(), "MCP grant errored: {:?}", grant.err());
+        assert_eq!(after_grant, "t", "MCP user grant must set SELECT");
+        assert!(list.is_ok(), "MCP list_privs errored: {:?}", list.err());
+        assert!(revoke.is_ok(), "MCP revoke errored: {:?}", revoke.err());
+        assert_eq!(after_revoke, "f", "MCP user revoke must remove SELECT");
+    }
 }

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -1382,6 +1382,8 @@ async fn do_user(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
                         username: username.clone(),
                         password: password.clone(),
                         preset,
+                        // Single-node gfs MCP: no deploy owner (see cmd_user).
+                        default_privileges_owner: None,
                     },
                 )
                 .await

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -1886,7 +1886,6 @@ mod tests {
             }),
             storage: None,
             compute: None,
-            remote: None,
         }
         .save(&repo)
         .expect("save .gfs config");

--- a/crates/domain/src/model/db_user.rs
+++ b/crates/domain/src/model/db_user.rs
@@ -58,3 +58,20 @@ pub struct RoleInfo {
     pub can_login: bool,
     pub is_superuser: bool,
 }
+
+/// Everything needed to bootstrap a database's deploy environment (RFC 009): a
+/// `NOLOGIN` group carrying the shared CRUD baseline, an `owner` login (the
+/// least-privileged customer role that keeps `public`), the owner's membership
+/// in the group, and role-scoped default privileges so future owner objects
+/// flow to the group. Tenancy-free — the caller supplies validated names.
+#[derive(Debug, Clone)]
+pub struct DeployEnvSpec {
+    /// The customer's default login role (`LOGIN NOSUPERUSER`, never the DB owner).
+    pub owner: String,
+    /// The owner's password (SCRAM-hashed by the engine; never logged).
+    pub owner_password: String,
+    /// The `NOLOGIN` group role carrying the shared CRUD baseline (e.g. `developers`).
+    pub group: String,
+    /// The database the owner is granted `CONNECT` on.
+    pub database: String,
+}

--- a/crates/domain/src/model/db_user.rs
+++ b/crates/domain/src/model/db_user.rs
@@ -75,3 +75,324 @@ pub struct DeployEnvSpec {
     /// The database the owner is granted `CONNECT` on.
     pub database: String,
 }
+
+/// A single object-level privilege that can be granted on / revoked from a role.
+///
+/// Serialises as the lowercase SQL keyword (`select`, `insert`, …); `All` maps
+/// to `ALL PRIVILEGES`. The set valid for a given object type is constrained by
+/// [`Privilege::is_valid_for`] — the allow-list that keeps untrusted input from
+/// being spliced into a `GRANT`/`REVOKE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Privilege {
+    Select,
+    Insert,
+    Update,
+    Delete,
+    Truncate,
+    References,
+    Trigger,
+    Usage,
+    Create,
+    Connect,
+    Temporary,
+    /// `ALL PRIVILEGES` — valid on every object type.
+    All,
+}
+
+impl Privilege {
+    /// Parse from a CLI/tool string; `None` if unknown.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "select" => Some(Self::Select),
+            "insert" => Some(Self::Insert),
+            "update" => Some(Self::Update),
+            "delete" => Some(Self::Delete),
+            "truncate" => Some(Self::Truncate),
+            "references" => Some(Self::References),
+            "trigger" => Some(Self::Trigger),
+            "usage" => Some(Self::Usage),
+            "create" => Some(Self::Create),
+            "connect" => Some(Self::Connect),
+            "temporary" => Some(Self::Temporary),
+            "all" => Some(Self::All),
+            _ => None,
+        }
+    }
+
+    /// The canonical wire string (lowercase).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Select => "select",
+            Self::Insert => "insert",
+            Self::Update => "update",
+            Self::Delete => "delete",
+            Self::Truncate => "truncate",
+            Self::References => "references",
+            Self::Trigger => "trigger",
+            Self::Usage => "usage",
+            Self::Create => "create",
+            Self::Connect => "connect",
+            Self::Temporary => "temporary",
+            Self::All => "all",
+        }
+    }
+
+    /// The allow-list matrix: whether `self` may be applied to `object`.
+    ///
+    /// `All` is valid on every object type; the others follow the PostgreSQL
+    /// per-object-class privilege vocabulary. Callers MUST reject an invalid
+    /// combination before building SQL — this is the injection-safety property
+    /// (an unknown/invalid privilege never reaches a statement).
+    pub fn is_valid_for(self, object: &GrantableObject) -> bool {
+        use Privilege::*;
+        if matches!(self, All) {
+            return true;
+        }
+        match object {
+            GrantableObject::Database => matches!(self, Connect | Create | Temporary),
+            GrantableObject::Schema { .. } => matches!(self, Usage | Create),
+            GrantableObject::Table { .. } | GrantableObject::AllTablesInSchema { .. } => {
+                matches!(
+                    self,
+                    Select | Insert | Update | Delete | Truncate | References | Trigger
+                )
+            }
+            GrantableObject::Sequence { .. } | GrantableObject::AllSequencesInSchema { .. } => {
+                matches!(self, Usage | Select | Update)
+            }
+        }
+    }
+}
+
+/// A grantable / revocable database object.
+///
+/// Identifiers (`schema`, `name`) are validated + quoted by the provider
+/// implementation. [`GrantableObject::Database`] carries no name — the provider
+/// resolves it to the instance's own database, so there is no caller-named
+/// cross-database grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum GrantableObject {
+    /// The instance's own database (resolved provider-side).
+    Database,
+    /// A schema.
+    Schema { schema: String },
+    /// A single table — or view (PostgreSQL grants table privileges on views).
+    Table { schema: String, name: String },
+    /// Every existing table in a schema.
+    AllTablesInSchema { schema: String },
+    /// A single sequence.
+    Sequence { schema: String, name: String },
+    /// Every existing sequence in a schema.
+    AllSequencesInSchema { schema: String },
+}
+
+/// Everything needed to grant privileges on an object to a role.
+#[derive(Debug, Clone)]
+pub struct GrantSpec {
+    /// The grantee role (validated identifier).
+    pub role: String,
+    /// The object the privileges apply to.
+    pub object: GrantableObject,
+    /// The privileges to grant (each must be [`Privilege::is_valid_for`] the object).
+    pub privileges: Vec<Privilege>,
+    /// Append `WITH GRANT OPTION` — lets the grantee re-grant what it holds.
+    pub with_grant_option: bool,
+    /// When `Some(grantor)`, also emit role-scoped `ALTER DEFAULT PRIVILEGES FOR
+    /// ROLE <grantor>` so future objects the grantor creates flow to the role.
+    /// Valid only for the all-in-schema object variants.
+    pub apply_to_future: Option<String>,
+}
+
+/// Everything needed to revoke privileges on an object from a role.
+#[derive(Debug, Clone)]
+pub struct RevokeSpec {
+    /// The role to revoke from (validated identifier).
+    pub role: String,
+    /// The object the privileges apply to.
+    pub object: GrantableObject,
+    /// The privileges to revoke.
+    pub privileges: Vec<Privilege>,
+    /// Use `CASCADE` (also revoke dependent grants) instead of the default `RESTRICT`.
+    pub cascade: bool,
+}
+
+/// A single effective object privilege, as read back from the engine catalog
+/// (the `list-privs` projection). Never carries a secret.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectPrivilege {
+    /// The object class (`table`, `sequence`, `schema`, `database`).
+    pub object_type: String,
+    /// The (schema-qualified where applicable) object name.
+    pub object_name: String,
+    /// The granted privilege (lowercase).
+    pub privilege: String,
+    /// Whether the grantee may re-grant it (`WITH GRANT OPTION`).
+    pub grantable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_objects() -> Vec<GrantableObject> {
+        vec![
+            GrantableObject::Database,
+            GrantableObject::Schema { schema: "s".into() },
+            GrantableObject::Table {
+                schema: "s".into(),
+                name: "t".into(),
+            },
+            GrantableObject::AllTablesInSchema { schema: "s".into() },
+            GrantableObject::Sequence {
+                schema: "s".into(),
+                name: "q".into(),
+            },
+            GrantableObject::AllSequencesInSchema { schema: "s".into() },
+        ]
+    }
+
+    #[test]
+    fn all_privilege_is_valid_for_every_object() {
+        for object in all_objects() {
+            assert!(
+                Privilege::All.is_valid_for(&object),
+                "ALL must be valid for {object:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn database_privilege_matrix() {
+        let db = GrantableObject::Database;
+        for p in [Privilege::Connect, Privilege::Create, Privilege::Temporary] {
+            assert!(p.is_valid_for(&db), "{p:?} valid on database");
+        }
+        for p in [
+            Privilege::Select,
+            Privilege::Insert,
+            Privilege::Usage,
+            Privilege::Trigger,
+        ] {
+            assert!(!p.is_valid_for(&db), "{p:?} invalid on database");
+        }
+    }
+
+    #[test]
+    fn schema_privilege_matrix() {
+        let s = GrantableObject::Schema {
+            schema: "public".into(),
+        };
+        for p in [Privilege::Usage, Privilege::Create] {
+            assert!(p.is_valid_for(&s), "{p:?} valid on schema");
+        }
+        for p in [Privilege::Select, Privilege::Connect, Privilege::Insert] {
+            assert!(!p.is_valid_for(&s), "{p:?} invalid on schema");
+        }
+    }
+
+    #[test]
+    fn table_privilege_matrix() {
+        for t in [
+            GrantableObject::Table {
+                schema: "s".into(),
+                name: "t".into(),
+            },
+            GrantableObject::AllTablesInSchema { schema: "s".into() },
+        ] {
+            for p in [
+                Privilege::Select,
+                Privilege::Insert,
+                Privilege::Update,
+                Privilege::Delete,
+                Privilege::Truncate,
+                Privilege::References,
+                Privilege::Trigger,
+            ] {
+                assert!(p.is_valid_for(&t), "{p:?} valid on {t:?}");
+            }
+            for p in [
+                Privilege::Usage,
+                Privilege::Connect,
+                Privilege::Create,
+                Privilege::Temporary,
+            ] {
+                assert!(!p.is_valid_for(&t), "{p:?} invalid on {t:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn sequence_privilege_matrix() {
+        for q in [
+            GrantableObject::Sequence {
+                schema: "s".into(),
+                name: "q".into(),
+            },
+            GrantableObject::AllSequencesInSchema { schema: "s".into() },
+        ] {
+            for p in [Privilege::Usage, Privilege::Select, Privilege::Update] {
+                assert!(p.is_valid_for(&q), "{p:?} valid on {q:?}");
+            }
+            for p in [
+                Privilege::Insert,
+                Privilege::Delete,
+                Privilege::Create,
+                Privilege::Trigger,
+            ] {
+                assert!(!p.is_valid_for(&q), "{p:?} invalid on {q:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn privilege_parse_as_str_roundtrip() {
+        for p in [
+            Privilege::Select,
+            Privilege::Insert,
+            Privilege::Update,
+            Privilege::Delete,
+            Privilege::Truncate,
+            Privilege::References,
+            Privilege::Trigger,
+            Privilege::Usage,
+            Privilege::Create,
+            Privilege::Connect,
+            Privilege::Temporary,
+            Privilege::All,
+        ] {
+            assert_eq!(Privilege::parse(p.as_str()), Some(p));
+        }
+        assert_eq!(Privilege::parse("bogus"), None);
+    }
+
+    #[test]
+    fn privilege_serde_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&Privilege::Select).unwrap(),
+            "\"select\""
+        );
+        assert_eq!(
+            serde_json::from_str::<Privilege>("\"all\"").unwrap(),
+            Privilege::All
+        );
+    }
+
+    #[test]
+    fn grantable_object_serde_is_tagged() {
+        let object = GrantableObject::Table {
+            schema: "public".into(),
+            name: "orders".into(),
+        };
+        let json = serde_json::to_string(&object).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"table","schema":"public","name":"orders"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<GrantableObject>(&json).unwrap(),
+            object
+        );
+    }
+}

--- a/crates/domain/src/model/db_user.rs
+++ b/crates/domain/src/model/db_user.rs
@@ -1,0 +1,60 @@
+//! Database-user / role model for the `gfs user` capability.
+//!
+//! A managed database user is a login role inside the running database. These
+//! are pure value types; the SQL that creates/alters them is provider-specific
+//! (see [`crate::ports::database_provider::DatabaseProvider`]).
+
+use serde::{Deserialize, Serialize};
+
+/// A curated, allow-listed privilege bundle applied to a role.
+///
+/// Serialises as the lowercase strings `readonly` / `readwrite` / `admin`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RolePreset {
+    /// `CONNECT` + schema `USAGE` + `SELECT` on tables.
+    Readonly,
+    /// `readonly` plus `INSERT` / `UPDATE` / `DELETE` and sequence usage.
+    Readwrite,
+    /// Owner-grade on the application schema (DDL + full DML). Never a superuser.
+    Admin,
+}
+
+impl RolePreset {
+    /// Parse from a CLI/tool string; `None` if unknown.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "readonly" => Some(Self::Readonly),
+            "readwrite" => Some(Self::Readwrite),
+            "admin" => Some(Self::Admin),
+            _ => None,
+        }
+    }
+
+    /// The canonical wire string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Readonly => "readonly",
+            Self::Readwrite => "readwrite",
+            Self::Admin => "admin",
+        }
+    }
+}
+
+/// Everything needed to create a login role.
+#[derive(Debug, Clone)]
+pub struct RoleSpec {
+    pub username: String,
+    pub password: String,
+    /// Optional preset to apply at create time.
+    pub preset: Option<RolePreset>,
+}
+
+/// A role as read back from the engine's catalog (the `list` projection).
+/// Never carries a password — the engine keeps only a hash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleInfo {
+    pub username: String,
+    pub can_login: bool,
+    pub is_superuser: bool,
+}

--- a/crates/domain/src/model/db_user.rs
+++ b/crates/domain/src/model/db_user.rs
@@ -62,6 +62,10 @@ pub struct RoleInfo {
     pub username: String,
     pub can_login: bool,
     pub is_superuser: bool,
+    /// The applied preset (`readonly`/`readwrite`/`admin`), recorded in the
+    /// role's comment at create/apply time. `None` when no preset was set.
+    #[serde(default)]
+    pub preset: Option<String>,
 }
 
 /// Everything needed to bootstrap a database's deploy environment (RFC 009): a

--- a/crates/domain/src/model/db_user.rs
+++ b/crates/domain/src/model/db_user.rs
@@ -48,6 +48,11 @@ pub struct RoleSpec {
     pub password: String,
     /// Optional preset to apply at create time.
     pub preset: Option<RolePreset>,
+    /// The role whose FUTURE objects the preset's `ALTER DEFAULT PRIVILEGES`
+    /// should cover — the customer's object-creating role (`owner`) in a deploy,
+    /// so a preset user sees the tables the customer creates later. `None`
+    /// (single-node, no deploy owner) covers the connecting role's future objects.
+    pub default_privileges_owner: Option<String>,
 }
 
 /// A role as read back from the engine's catalog (the `list` projection).

--- a/crates/domain/src/model/mod.rs
+++ b/crates/domain/src/model/mod.rs
@@ -2,6 +2,7 @@ pub mod branch;
 pub mod commit;
 pub mod config;
 pub mod datasource;
+pub mod db_user;
 pub mod errors;
 pub mod layout;
 pub mod ref_info;

--- a/crates/domain/src/ports/database_provider.rs
+++ b/crates/domain/src/ports/database_provider.rs
@@ -8,6 +8,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
+use crate::model::db_user::{RolePreset, RoleSpec};
 use crate::ports::compute::ComputeDefinition;
 
 // ---------------------------------------------------------------------------
@@ -413,6 +414,55 @@ pub trait DatabaseProvider: Send + Sync {
     ) -> std::result::Result<String, ProviderError> {
         let _ = (sql, database);
         Err(ProviderError::UnsupportedFormat("query_in_instance".into()))
+    }
+
+    // -----------------------------------------------------------------------
+    // User / role management (`gfs user`)
+    // -----------------------------------------------------------------------
+    //
+    // Each returns a full shell command to run **inside** the instance via
+    // [`crate::ports::compute::Compute::exec`] (loopback client, container admin
+    // env creds) — the same shape as `query_in_instance_command`. The password
+    // and identifiers must be validated + quoted by the implementation. Default
+    // impls report the feature as unsupported so non-implementing providers cost
+    // nothing.
+
+    /// In-instance command that creates a login role from `spec`.
+    fn create_role_command(&self, spec: &RoleSpec) -> std::result::Result<String, ProviderError> {
+        let _ = spec;
+        Err(ProviderError::UnsupportedFormat("create_role".into()))
+    }
+
+    /// In-instance command that sets/rotates `username`'s password.
+    fn alter_password_command(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> std::result::Result<String, ProviderError> {
+        let _ = (username, password);
+        Err(ProviderError::UnsupportedFormat("alter_password".into()))
+    }
+
+    /// In-instance command that drops `username`.
+    fn drop_role_command(&self, username: &str) -> std::result::Result<String, ProviderError> {
+        let _ = username;
+        Err(ProviderError::UnsupportedFormat("drop_role".into()))
+    }
+
+    /// In-instance command that lists login roles as JSON (parsed into
+    /// [`crate::model::db_user::RoleInfo`]). Never includes a password.
+    fn list_roles_command(&self) -> std::result::Result<String, ProviderError> {
+        Err(ProviderError::UnsupportedFormat("list_roles".into()))
+    }
+
+    /// In-instance command that applies `preset`'s privilege bundle to `username`.
+    fn apply_preset_command(
+        &self,
+        username: &str,
+        preset: RolePreset,
+    ) -> std::result::Result<String, ProviderError> {
+        let _ = (username, preset);
+        Err(ProviderError::UnsupportedFormat("apply_preset".into()))
     }
 
     // -----------------------------------------------------------------------

--- a/crates/domain/src/ports/database_provider.rs
+++ b/crates/domain/src/ports/database_provider.rs
@@ -8,7 +8,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
-use crate::model::db_user::{RolePreset, RoleSpec};
+use crate::model::db_user::{DeployEnvSpec, RolePreset, RoleSpec};
 use crate::ports::compute::ComputeDefinition;
 
 // ---------------------------------------------------------------------------
@@ -463,6 +463,23 @@ pub trait DatabaseProvider: Send + Sync {
     ) -> std::result::Result<String, ProviderError> {
         let _ = (username, preset);
         Err(ProviderError::UnsupportedFormat("apply_preset".into()))
+    }
+
+    /// Build the in-instance command that bootstraps a database's deploy
+    /// environment (RFC 009): create the `NOLOGIN` group + the least-privileged
+    /// `owner` login, grant the owner `CONNECT` + `USAGE,CREATE ON SCHEMA public`
+    /// and group membership, and set role-scoped default privileges so future
+    /// owner objects flow to the group — all in one transaction. Emits nothing
+    /// that makes the owner a superuser or the database owner. Optional-defaulted
+    /// so non-Postgres providers cost nothing until phase 2.
+    fn bootstrap_deploy_env_command(
+        &self,
+        spec: &DeployEnvSpec,
+    ) -> std::result::Result<String, ProviderError> {
+        let _ = spec;
+        Err(ProviderError::UnsupportedFormat(
+            "bootstrap_deploy_env".into(),
+        ))
     }
 
     // -----------------------------------------------------------------------

--- a/crates/domain/src/ports/database_provider.rs
+++ b/crates/domain/src/ports/database_provider.rs
@@ -8,7 +8,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
-use crate::model::db_user::{DeployEnvSpec, RolePreset, RoleSpec};
+use crate::model::db_user::{DeployEnvSpec, GrantSpec, RevokeSpec, RolePreset, RoleSpec};
 use crate::ports::compute::ComputeDefinition;
 
 // ---------------------------------------------------------------------------
@@ -480,6 +480,33 @@ pub trait DatabaseProvider: Send + Sync {
         Err(ProviderError::UnsupportedFormat(
             "bootstrap_deploy_env".into(),
         ))
+    }
+
+    /// In-instance command that grants `spec.privileges` on `spec.object` to
+    /// `spec.role` (optionally `WITH GRANT OPTION` and role-scoped default
+    /// privileges for future objects). Identifiers must be validated + quoted
+    /// and every privilege re-checked against the object type by the
+    /// implementation; the whole grant runs in one transaction. Optional-
+    /// defaulted so non-Postgres providers cost nothing until their phase.
+    fn grant_command(&self, spec: &GrantSpec) -> std::result::Result<String, ProviderError> {
+        let _ = spec;
+        Err(ProviderError::UnsupportedFormat("grant".into()))
+    }
+
+    /// In-instance command that revokes `spec.privileges` on `spec.object` from
+    /// `spec.role` (default `RESTRICT`, or `CASCADE` when `spec.cascade`). Same
+    /// validation/quoting/transaction contract as [`Self::grant_command`].
+    fn revoke_command(&self, spec: &RevokeSpec) -> std::result::Result<String, ProviderError> {
+        let _ = spec;
+        Err(ProviderError::UnsupportedFormat("revoke".into()))
+    }
+
+    /// In-instance command that lists `role`'s effective object privileges as
+    /// JSON (parsed into [`crate::model::db_user::ObjectPrivilege`]), read live
+    /// from the engine catalog. Never includes a secret.
+    fn list_privileges_command(&self, role: &str) -> std::result::Result<String, ProviderError> {
+        let _ = role;
+        Err(ProviderError::UnsupportedFormat("list_privileges".into()))
     }
 
     // -----------------------------------------------------------------------

--- a/crates/domain/src/ports/database_provider.rs
+++ b/crates/domain/src/ports/database_provider.rs
@@ -456,12 +456,17 @@ pub trait DatabaseProvider: Send + Sync {
     }
 
     /// In-instance command that applies `preset`'s privilege bundle to `username`.
+    ///
+    /// `default_privileges_owner`, when set, is the role whose FUTURE objects the
+    /// preset's `ALTER DEFAULT PRIVILEGES` should cover (the customer's `owner`
+    /// role in a deploy) so a preset user sees tables the owner creates later.
     fn apply_preset_command(
         &self,
         username: &str,
         preset: RolePreset,
+        default_privileges_owner: Option<&str>,
     ) -> std::result::Result<String, ProviderError> {
-        let _ = (username, preset);
+        let _ = (username, preset, default_privileges_owner);
         Err(ProviderError::UnsupportedFormat("apply_preset".into()))
     }
 

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::model::config::GfsConfig;
-use crate::model::db_user::{RoleInfo, RolePreset, RoleSpec};
+use crate::model::db_user::{DeployEnvSpec, RoleInfo, RolePreset, RoleSpec};
 use crate::ports::compute::{Compute, ExecOutput, InstanceId};
 use crate::ports::database_provider::{DatabaseProvider, DatabaseProviderRegistry};
 
@@ -144,6 +144,23 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .apply_preset_command(username, preset)
+            .map_err(map_provider_err)?;
+        expect_success(self.run(&container, &command).await?)
+    }
+
+    /// Bootstrap a database's deploy environment (RFC 009): create the `NOLOGIN`
+    /// group + the least-privileged `owner` login + grants + role-scoped default
+    /// privileges, in one transaction, as the management superuser via the exec
+    /// seam. Idempotency is the caller's concern (run on fresh deploy only).
+    pub async fn provision_deploy_env(
+        &self,
+        path: &Path,
+        spec: &DeployEnvSpec,
+    ) -> Result<(), ManageUsersError> {
+        require_password(&spec.owner_password)?;
+        let (provider, container) = self.resolve(path)?;
+        let command = provider
+            .bootstrap_deploy_env_command(spec)
             .map_err(map_provider_err)?;
         expect_success(self.run(&container, &command).await?)
     }
@@ -466,6 +483,14 @@ mod tests {
             self.guard()?;
             Ok(format!("MOCK-PRESET:{username}"))
         }
+
+        fn bootstrap_deploy_env_command(
+            &self,
+            spec: &DeployEnvSpec,
+        ) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-DEPLOYENV:{}:{}", spec.owner, spec.group))
+        }
     }
 
     fn repo_with_config(container: &str) -> (TempDir, PathBuf) {
@@ -532,6 +557,39 @@ mod tests {
             compute.last_command.lock().unwrap().clone(),
             Some("MOCK-CREATE:alice".into())
         );
+    }
+
+    fn deploy_env_spec(owner_password: &str) -> DeployEnvSpec {
+        DeployEnvSpec {
+            owner: "app_owner".into(),
+            owner_password: owner_password.into(),
+            group: "developers".into(),
+            database: "appdb".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn provision_deploy_env_execs_the_provider_command() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, compute) = use_case(MockCompute::default(), true);
+        uc.provision_deploy_env(&repo, &deploy_env_spec("pw"))
+            .await
+            .expect("ok");
+        assert_eq!(
+            compute.last_command.lock().unwrap().clone(),
+            Some("MOCK-DEPLOYENV:app_owner:developers".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_deploy_env_rejects_empty_owner_password() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, _compute) = use_case(MockCompute::default(), true);
+        let err = uc
+            .provision_deploy_env(&repo, &deploy_env_spec(""))
+            .await
+            .expect_err("empty password must be rejected");
+        assert!(matches!(err, ManageUsersError::InvalidInput(_)));
     }
 
     #[tokio::test]

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -177,3 +177,361 @@ fn fail(output: ExecOutput) -> ManageUsersError {
         message,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::model::config::{EnvironmentConfig, RuntimeConfig};
+    use crate::ports::compute::{
+        ComputeCapabilities, ComputeDefinition, InstanceConnectionInfo, InstanceState,
+        InstanceStatus, LogEntry, LogsOptions, PortMapping, StartOptions,
+    };
+    use crate::ports::database_provider::{
+        ConnectionParams, DatabaseProvider, DatabaseProviderArg, InMemoryDatabaseProviderRegistry,
+        ProviderError, Result as RegistryResult, SIGTERM, SupportedFeature,
+    };
+
+    /// Compute mock: records the last `exec` command and returns a canned output.
+    #[derive(Default)]
+    struct MockCompute {
+        last_command: Mutex<Option<String>>,
+        stdout: String,
+        stderr: String,
+        exit_code: i32,
+    }
+
+    type CResult<T> = crate::ports::compute::Result<T>;
+
+    #[async_trait]
+    impl Compute for MockCompute {
+        async fn provision(&self, _: &ComputeDefinition) -> CResult<InstanceId> {
+            Ok(InstanceId("mock".into()))
+        }
+        async fn start(&self, id: &InstanceId, _: StartOptions) -> CResult<InstanceStatus> {
+            Ok(running(id))
+        }
+        async fn stop(&self, id: &InstanceId) -> CResult<InstanceStatus> {
+            Ok(running(id))
+        }
+        async fn restart(&self, id: &InstanceId) -> CResult<InstanceStatus> {
+            Ok(running(id))
+        }
+        async fn status(&self, id: &InstanceId) -> CResult<InstanceStatus> {
+            Ok(running(id))
+        }
+        async fn prepare_for_snapshot(&self, _: &InstanceId, _: &[String]) -> CResult<()> {
+            Ok(())
+        }
+        async fn logs(&self, _: &InstanceId, _: LogsOptions) -> CResult<Vec<LogEntry>> {
+            Ok(vec![])
+        }
+        async fn pause(&self, id: &InstanceId) -> CResult<InstanceStatus> {
+            Ok(running(id))
+        }
+        async fn unpause(&self, id: &InstanceId) -> CResult<InstanceStatus> {
+            Ok(running(id))
+        }
+        async fn get_connection_info(
+            &self,
+            _: &InstanceId,
+            port: u16,
+        ) -> CResult<InstanceConnectionInfo> {
+            Ok(InstanceConnectionInfo {
+                host: "127.0.0.1".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn get_instance_data_mount_host_path(
+            &self,
+            _: &InstanceId,
+            _: &str,
+        ) -> CResult<Option<PathBuf>> {
+            Ok(None)
+        }
+        async fn remove_instance(&self, _: &InstanceId) -> CResult<()> {
+            Ok(())
+        }
+        async fn get_task_connection_info(
+            &self,
+            _: &InstanceId,
+            port: u16,
+        ) -> CResult<InstanceConnectionInfo> {
+            Ok(InstanceConnectionInfo {
+                host: "127.0.0.1".into(),
+                port,
+                env: vec![],
+            })
+        }
+        async fn run_task(
+            &self,
+            _: &ComputeDefinition,
+            _: &str,
+            _: Option<&InstanceId>,
+        ) -> CResult<ExecOutput> {
+            Ok(ok_output())
+        }
+        async fn capabilities(&self) -> CResult<ComputeCapabilities> {
+            Ok(ComputeCapabilities {
+                supports_stream_snapshot: false,
+                supports_exec_as_root: true,
+                db_live_during_snapshot: false,
+            })
+        }
+        async fn exec(
+            &self,
+            _: &InstanceId,
+            command: &str,
+            _: Option<&str>,
+        ) -> CResult<ExecOutput> {
+            *self.last_command.lock().unwrap() = Some(command.to_string());
+            Ok(ExecOutput {
+                exit_code: self.exit_code,
+                stdout: self.stdout.clone(),
+                stderr: self.stderr.clone(),
+            })
+        }
+    }
+
+    fn running(id: &InstanceId) -> InstanceStatus {
+        InstanceStatus {
+            id: id.clone(),
+            state: InstanceState::Running,
+            pid: None,
+            started_at: None,
+            exit_code: None,
+        }
+    }
+
+    fn ok_output() -> ExecOutput {
+        ExecOutput {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    }
+
+    /// Provider mock: role methods return marker commands; `support_users=false`
+    /// makes them report the feature as unsupported.
+    struct MockRoleProvider {
+        support_users: bool,
+    }
+
+    impl MockRoleProvider {
+        fn guard(&self) -> std::result::Result<(), ProviderError> {
+            if self.support_users {
+                Ok(())
+            } else {
+                Err(ProviderError::UnsupportedFormat("users".into()))
+            }
+        }
+    }
+
+    impl DatabaseProvider for MockRoleProvider {
+        fn name(&self) -> &str {
+            "mock-role"
+        }
+        fn definition(&self) -> ComputeDefinition {
+            ComputeDefinition {
+                labels: Default::default(),
+                image: "mock:latest".into(),
+                env: vec![],
+                ports: vec![PortMapping {
+                    compute_port: 5432,
+                    host_port: None,
+                }],
+                data_dir: PathBuf::from("/data"),
+                host_data_dir: None,
+                user: None,
+                logs_dir: None,
+                conf_dir: None,
+                args: vec![],
+            }
+        }
+        fn default_port(&self) -> u16 {
+            5432
+        }
+        fn default_args(&self) -> Vec<DatabaseProviderArg> {
+            vec![]
+        }
+        fn default_signal(&self) -> u32 {
+            SIGTERM
+        }
+        fn connection_string(
+            &self,
+            _: &ConnectionParams,
+        ) -> std::result::Result<String, ProviderError> {
+            Ok("mock://localhost".into())
+        }
+        fn supported_versions(&self) -> Vec<String> {
+            vec!["latest".into()]
+        }
+        fn supported_features(&self) -> Vec<SupportedFeature> {
+            vec![]
+        }
+        fn prepare_for_snapshot(&self, _: &ConnectionParams) -> RegistryResult<Vec<String>> {
+            Ok(vec![])
+        }
+        fn query_client_command(
+            &self,
+            _: &ConnectionParams,
+            _: Option<&str>,
+        ) -> std::result::Result<std::process::Command, ProviderError> {
+            Ok(std::process::Command::new("true"))
+        }
+        fn create_role_command(
+            &self,
+            spec: &RoleSpec,
+        ) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-CREATE:{}", spec.username))
+        }
+        fn alter_password_command(
+            &self,
+            username: &str,
+            _: &str,
+        ) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-ALTER:{username}"))
+        }
+        fn drop_role_command(&self, username: &str) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-DROP:{username}"))
+        }
+        fn list_roles_command(&self) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok("MOCK-LIST".into())
+        }
+        fn apply_preset_command(
+            &self,
+            username: &str,
+            _: RolePreset,
+        ) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-PRESET:{username}"))
+        }
+    }
+
+    fn repo_with_config(container: &str) -> (TempDir, PathBuf) {
+        let temp = TempDir::new().expect("tempdir");
+        let path = temp.path().to_path_buf();
+        std::fs::create_dir_all(path.join(".gfs")).expect("create .gfs");
+        let config = GfsConfig {
+            mount_point: None,
+            version: String::new(),
+            description: String::new(),
+            user: None,
+            environment: Some(EnvironmentConfig {
+                database_provider: "mock-role".into(),
+                database_version: "17".into(),
+                database_port: None,
+                display_name: None,
+            }),
+            runtime: Some(RuntimeConfig {
+                runtime_provider: "docker".into(),
+                runtime_version: "latest".into(),
+                container_name: container.into(),
+            }),
+            storage: None,
+            compute: None,
+            remote: None,
+        };
+        config.save(&path).expect("save config");
+        (temp, path)
+    }
+
+    fn use_case(
+        compute: MockCompute,
+        support_users: bool,
+    ) -> (
+        ManageUsersUseCase<InMemoryDatabaseProviderRegistry>,
+        Arc<MockCompute>,
+    ) {
+        let compute = Arc::new(compute);
+        let registry = InMemoryDatabaseProviderRegistry::new();
+        registry
+            .register(Arc::new(MockRoleProvider { support_users }))
+            .unwrap();
+        (
+            ManageUsersUseCase::new(compute.clone(), Arc::new(registry)),
+            compute,
+        )
+    }
+
+    #[tokio::test]
+    async fn create_role_execs_the_provider_command() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, compute) = use_case(MockCompute::default(), true);
+        uc.create_role(
+            &repo,
+            &RoleSpec {
+                username: "alice".into(),
+                password: "pw".into(),
+                preset: None,
+            },
+        )
+        .await
+        .expect("ok");
+        assert_eq!(
+            compute.last_command.lock().unwrap().clone(),
+            Some("MOCK-CREATE:alice".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn list_roles_parses_json() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let compute = MockCompute {
+            stdout: r#"[{"username":"alice","can_login":true,"is_superuser":false}]"#.into(),
+            ..Default::default()
+        };
+        let (uc, _c) = use_case(compute, true);
+        let roles = uc.list_roles(&repo).await.expect("ok");
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].username, "alice");
+        assert!(roles[0].can_login && !roles[0].is_superuser);
+    }
+
+    #[tokio::test]
+    async fn non_zero_exit_is_failed_with_message() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let compute = MockCompute {
+            exit_code: 1,
+            stderr: "role \"alice\" already exists".into(),
+            ..Default::default()
+        };
+        let (uc, _c) = use_case(compute, true);
+        let err = uc
+            .create_role(
+                &repo,
+                &RoleSpec {
+                    username: "alice".into(),
+                    password: "pw".into(),
+                    preset: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        match err {
+            ManageUsersError::Failed { exit_code, message } => {
+                assert_eq!(exit_code, 1);
+                assert!(message.contains("already exists"));
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unsupported_provider_maps_to_unsupported() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, _c) = use_case(MockCompute::default(), /* support_users */ false);
+        let err = uc.drop_role(&repo, "alice").await.unwrap_err();
+        assert!(matches!(err, ManageUsersError::Unsupported(_)));
+    }
+}

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::model::config::GfsConfig;
-use crate::model::db_user::{DeployEnvSpec, RoleInfo, RolePreset, RoleSpec};
+use crate::model::db_user::{
+    DeployEnvSpec, GrantSpec, GrantableObject, ObjectPrivilege, Privilege, RevokeSpec, RoleInfo,
+    RolePreset, RoleSpec,
+};
 use crate::ports::compute::{Compute, ExecOutput, InstanceId};
 use crate::ports::database_provider::{DatabaseProvider, DatabaseProviderRegistry};
 
@@ -176,6 +179,63 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
         serde_json::from_str(output.stdout.trim())
             .map_err(|e| ManageUsersError::Parse(e.to_string()))
     }
+
+    /// Grant object-level privileges on `spec.object` to `spec.role`.
+    pub async fn grant(&self, path: &Path, spec: &GrantSpec) -> Result<(), ManageUsersError> {
+        validate_privileges(&spec.privileges, &spec.object)?;
+        let (provider, container) = self.resolve(path)?;
+        let command = provider.grant_command(spec).map_err(map_provider_err)?;
+        expect_success(self.run(&container, &command).await?)
+    }
+
+    /// Revoke object-level privileges on `spec.object` from `spec.role`.
+    pub async fn revoke(&self, path: &Path, spec: &RevokeSpec) -> Result<(), ManageUsersError> {
+        validate_privileges(&spec.privileges, &spec.object)?;
+        let (provider, container) = self.resolve(path)?;
+        let command = provider.revoke_command(spec).map_err(map_provider_err)?;
+        expect_success(self.run(&container, &command).await?)
+    }
+
+    /// List a role's effective object privileges (never a secret).
+    pub async fn list_privileges(
+        &self,
+        path: &Path,
+        role: &str,
+    ) -> Result<Vec<ObjectPrivilege>, ManageUsersError> {
+        let (provider, container) = self.resolve(path)?;
+        let command = provider
+            .list_privileges_command(role)
+            .map_err(map_provider_err)?;
+        let output = self.run(&container, &command).await?;
+        if output.exit_code != 0 {
+            return Err(fail(output));
+        }
+        serde_json::from_str(output.stdout.trim())
+            .map_err(|e| ManageUsersError::Parse(e.to_string()))
+    }
+}
+
+/// Reject a privilege set that is empty or contains a privilege not valid for the
+/// target object type (the domain allow-list), *before* the command is built —
+/// engine-independent defence-in-depth (the provider re-checks too).
+fn validate_privileges(
+    privileges: &[Privilege],
+    object: &GrantableObject,
+) -> Result<(), ManageUsersError> {
+    if privileges.is_empty() {
+        return Err(ManageUsersError::InvalidInput(
+            "at least one privilege is required".into(),
+        ));
+    }
+    for p in privileges {
+        if !p.is_valid_for(object) {
+            return Err(ManageUsersError::InvalidInput(format!(
+                "privilege '{}' is not valid for the target object type",
+                p.as_str()
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// A mutating op succeeded iff the exit code is zero.
@@ -491,6 +551,24 @@ mod tests {
             self.guard()?;
             Ok(format!("MOCK-DEPLOYENV:{}:{}", spec.owner, spec.group))
         }
+
+        fn grant_command(&self, spec: &GrantSpec) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-GRANT:{}", spec.role))
+        }
+
+        fn revoke_command(&self, spec: &RevokeSpec) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-REVOKE:{}", spec.role))
+        }
+
+        fn list_privileges_command(
+            &self,
+            role: &str,
+        ) -> std::result::Result<String, ProviderError> {
+            self.guard()?;
+            Ok(format!("MOCK-LISTPRIVS:{role}"))
+        }
     }
 
     fn repo_with_config(container: &str) -> (TempDir, PathBuf) {
@@ -659,5 +737,149 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ManageUsersError::InvalidInput(_)));
+    }
+
+    // ----- object-level grant / revoke / list-privileges (phase 2) -----
+
+    fn grant_spec(role: &str, object: GrantableObject, privileges: Vec<Privilege>) -> GrantSpec {
+        GrantSpec {
+            role: role.into(),
+            object,
+            privileges,
+            with_grant_option: false,
+            apply_to_future: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn grant_execs_the_provider_command() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, compute) = use_case(MockCompute::default(), true);
+        uc.grant(
+            &repo,
+            &grant_spec(
+                "app_ro",
+                GrantableObject::Table {
+                    schema: "public".into(),
+                    name: "t".into(),
+                },
+                vec![Privilege::Select],
+            ),
+        )
+        .await
+        .expect("ok");
+        assert_eq!(
+            compute.last_command.lock().unwrap().clone(),
+            Some("MOCK-GRANT:app_ro".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_execs_the_provider_command() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, compute) = use_case(MockCompute::default(), true);
+        uc.revoke(
+            &repo,
+            &RevokeSpec {
+                role: "app_rw".into(),
+                object: GrantableObject::Table {
+                    schema: "public".into(),
+                    name: "t".into(),
+                },
+                privileges: vec![Privilege::Insert],
+                cascade: false,
+            },
+        )
+        .await
+        .expect("ok");
+        assert_eq!(
+            compute.last_command.lock().unwrap().clone(),
+            Some("MOCK-REVOKE:app_rw".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_privilege_is_rejected_before_any_exec() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, compute) = use_case(MockCompute::default(), true);
+        // INSERT is not valid on a sequence.
+        let err = uc
+            .grant(
+                &repo,
+                &grant_spec(
+                    "app_ro",
+                    GrantableObject::Sequence {
+                        schema: "public".into(),
+                        name: "q".into(),
+                    },
+                    vec![Privilege::Insert],
+                ),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ManageUsersError::InvalidInput(_)));
+        // The domain guard fired before resolve/exec — nothing reached compute.
+        assert!(
+            compute.last_command.lock().unwrap().is_none(),
+            "no command must be exec'd for an invalid privilege"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_privileges_is_rejected() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, _c) = use_case(MockCompute::default(), true);
+        let err = uc
+            .grant(
+                &repo,
+                &grant_spec(
+                    "app_ro",
+                    GrantableObject::Table {
+                        schema: "public".into(),
+                        name: "t".into(),
+                    },
+                    vec![],
+                ),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ManageUsersError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn list_privileges_parses_json() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let compute = MockCompute {
+            stdout: r#"[{"object_type":"table","object_name":"public.t","privilege":"select","grantable":false}]"#.into(),
+            ..Default::default()
+        };
+        let (uc, _c) = use_case(compute, true);
+        let privs = uc.list_privileges(&repo, "app_ro").await.expect("ok");
+        assert_eq!(privs.len(), 1);
+        assert_eq!(privs[0].object_type, "table");
+        assert_eq!(privs[0].object_name, "public.t");
+        assert_eq!(privs[0].privilege, "select");
+        assert!(!privs[0].grantable);
+    }
+
+    #[tokio::test]
+    async fn grant_on_unsupported_provider_maps_to_unsupported() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, _c) = use_case(MockCompute::default(), /* support_users */ false);
+        let err = uc
+            .grant(
+                &repo,
+                &grant_spec(
+                    "app_ro",
+                    GrantableObject::Table {
+                        schema: "public".into(),
+                        name: "t".into(),
+                    },
+                    vec![Privilege::Select],
+                ),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ManageUsersError::Unsupported(_)));
     }
 }

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -126,6 +126,7 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
 
     /// Drop a role.
     pub async fn drop_role(&self, path: &Path, username: &str) -> Result<(), ManageUsersError> {
+        reject_reserved_role(username)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .drop_role_command(username)
@@ -192,6 +193,23 @@ fn require_password(password: &str) -> Result<(), ManageUsersError> {
     }
 }
 
+/// The platform's management/bootstrap roles, never client roles. Refuse to drop
+/// them: `postgres` is the engine's own connection superuser, and dropping it
+/// makes `DROP OWNED BY` walk the entire database and wedge the session (and the
+/// same holds for `guepard-admin` once it is the bootstrap super). Fail fast with
+/// a clear message instead.
+const RESERVED_ROLES: [&str; 2] = ["guepard-admin", "postgres"];
+
+fn reject_reserved_role(username: &str) -> Result<(), ManageUsersError> {
+    if RESERVED_ROLES.contains(&username) {
+        Err(ManageUsersError::InvalidInput(format!(
+            "'{username}' is a reserved management role and cannot be dropped"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
 /// Map a provider error to the right domain error: validation failures (bad
 /// identifier, delimiter collision) are `InvalidInput`, not `Unsupported`.
 fn map_provider_err(e: crate::ports::database_provider::ProviderError) -> ManageUsersError {
@@ -208,6 +226,14 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+
+    #[test]
+    fn reserved_roles_cannot_be_dropped() {
+        use super::reject_reserved_role;
+        assert!(reject_reserved_role("postgres").is_err());
+        assert!(reject_reserved_role("guepard-admin").is_err());
+        assert!(reject_reserved_role("app_rw").is_ok());
+    }
     use tempfile::TempDir;
 
     use super::*;

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -599,7 +599,6 @@ mod tests {
             }),
             storage: None,
             compute: None,
-            remote: None,
         };
         config.save(&path).expect("save config");
         (temp, path)

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -29,6 +29,9 @@ pub enum ManageUsersError {
     #[error("user management not supported by provider: {0}")]
     Unsupported(String),
 
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
     #[error("compute: {0}")]
     Compute(String),
 
@@ -98,10 +101,11 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
 
     /// Create a login role (optionally with a preset).
     pub async fn create_role(&self, path: &Path, spec: &RoleSpec) -> Result<(), ManageUsersError> {
+        require_password(&spec.password)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .create_role_command(spec)
-            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+            .map_err(map_provider_err)?;
         expect_success(self.run(&container, &command).await?)
     }
 
@@ -112,10 +116,11 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
         username: &str,
         password: &str,
     ) -> Result<(), ManageUsersError> {
+        require_password(password)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .alter_password_command(username, password)
-            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+            .map_err(map_provider_err)?;
         expect_success(self.run(&container, &command).await?)
     }
 
@@ -124,7 +129,7 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .drop_role_command(username)
-            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+            .map_err(map_provider_err)?;
         expect_success(self.run(&container, &command).await?)
     }
 
@@ -138,16 +143,14 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .apply_preset_command(username, preset)
-            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+            .map_err(map_provider_err)?;
         expect_success(self.run(&container, &command).await?)
     }
 
     /// List login roles (never a password).
     pub async fn list_roles(&self, path: &Path) -> Result<Vec<RoleInfo>, ManageUsersError> {
         let (provider, container) = self.resolve(path)?;
-        let command = provider
-            .list_roles_command()
-            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+        let command = provider.list_roles_command().map_err(map_provider_err)?;
         let output = self.run(&container, &command).await?;
         if output.exit_code != 0 {
             return Err(fail(output));
@@ -175,6 +178,27 @@ fn fail(output: ExecOutput) -> ManageUsersError {
     ManageUsersError::Failed {
         exit_code: output.exit_code,
         message,
+    }
+}
+
+/// Reject an empty password — a login role with no password is a footgun.
+fn require_password(password: &str) -> Result<(), ManageUsersError> {
+    if password.is_empty() {
+        Err(ManageUsersError::InvalidInput(
+            "password must not be empty".into(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Map a provider error to the right domain error: validation failures (bad
+/// identifier, delimiter collision) are `InvalidInput`, not `Unsupported`.
+fn map_provider_err(e: crate::ports::database_provider::ProviderError) -> ManageUsersError {
+    use crate::ports::database_provider::ProviderError;
+    match e {
+        ProviderError::InvalidParams(m) => ManageUsersError::InvalidInput(m),
+        other => ManageUsersError::Unsupported(other.to_string()),
     }
 }
 
@@ -533,5 +557,23 @@ mod tests {
         let (uc, _c) = use_case(MockCompute::default(), /* support_users */ false);
         let err = uc.drop_role(&repo, "alice").await.unwrap_err();
         assert!(matches!(err, ManageUsersError::Unsupported(_)));
+    }
+
+    #[tokio::test]
+    async fn empty_password_is_rejected() {
+        let (_temp, repo) = repo_with_config("pg-c1");
+        let (uc, _c) = use_case(MockCompute::default(), true);
+        let err = uc
+            .create_role(
+                &repo,
+                &RoleSpec {
+                    username: "alice".into(),
+                    password: String::new(),
+                    preset: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ManageUsersError::InvalidInput(_)));
     }
 }

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -1,0 +1,179 @@
+//! Manage database users/roles inside a running instance via compute exec.
+//!
+//! Mirrors [`super::execute_query_usecase::ExecuteQueryUseCase`]: resolve the
+//! provider + container from `.gfs` config, ask the provider to build the
+//! in-instance role command, run it via [`Compute::exec`], and map the output.
+//! No host-side DB client is used.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use crate::model::config::GfsConfig;
+use crate::model::db_user::{RoleInfo, RolePreset, RoleSpec};
+use crate::ports::compute::{Compute, ExecOutput, InstanceId};
+use crate::ports::database_provider::{DatabaseProvider, DatabaseProviderRegistry};
+
+#[derive(Debug, Error)]
+pub enum ManageUsersError {
+    #[error("config: {0}")]
+    Config(String),
+
+    #[error("not configured: {0}")]
+    NotConfigured(String),
+
+    #[error("provider not found: {0}")]
+    ProviderNotFound(String),
+
+    #[error("user management not supported by provider: {0}")]
+    Unsupported(String),
+
+    #[error("compute: {0}")]
+    Compute(String),
+
+    #[error("operation failed (exit {exit_code}): {message}")]
+    Failed { exit_code: i32, message: String },
+
+    #[error("could not parse role list: {0}")]
+    Parse(String),
+}
+
+pub struct ManageUsersUseCase<R: DatabaseProviderRegistry> {
+    compute: Arc<dyn Compute>,
+    registry: Arc<R>,
+}
+
+impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
+    pub fn new(compute: Arc<dyn Compute>, registry: Arc<R>) -> Self {
+        Self { compute, registry }
+    }
+
+    /// Resolve `(provider, container_name)` from the repo's `.gfs` config.
+    fn resolve(
+        &self,
+        path: &Path,
+    ) -> Result<(Arc<dyn DatabaseProvider>, String), ManageUsersError> {
+        let config = GfsConfig::load(path).map_err(|e| ManageUsersError::Config(e.to_string()))?;
+
+        let provider_name = config
+            .environment
+            .as_ref()
+            .map(|e| e.database_provider.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                ManageUsersError::NotConfigured(
+                    "no database provider configured (run gfs init)".into(),
+                )
+            })?
+            .to_string();
+
+        let container_name = config
+            .runtime
+            .as_ref()
+            .map(|r| r.container_name.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                ManageUsersError::NotConfigured(
+                    "no container configured (run gfs compute start)".into(),
+                )
+            })?
+            .to_string();
+
+        let provider = self
+            .registry
+            .get(&provider_name)
+            .ok_or_else(|| ManageUsersError::ProviderNotFound(provider_name.clone()))?;
+
+        Ok((provider, container_name))
+    }
+
+    /// Run an already-built in-instance command and return its output.
+    async fn run(&self, container: &str, command: &str) -> Result<ExecOutput, ManageUsersError> {
+        self.compute
+            .exec(&InstanceId(container.to_string()), command, None)
+            .await
+            .map_err(|e| ManageUsersError::Compute(e.to_string()))
+    }
+
+    /// Create a login role (optionally with a preset).
+    pub async fn create_role(&self, path: &Path, spec: &RoleSpec) -> Result<(), ManageUsersError> {
+        let (provider, container) = self.resolve(path)?;
+        let command = provider
+            .create_role_command(spec)
+            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+        expect_success(self.run(&container, &command).await?)
+    }
+
+    /// Set / rotate a role's password.
+    pub async fn set_password(
+        &self,
+        path: &Path,
+        username: &str,
+        password: &str,
+    ) -> Result<(), ManageUsersError> {
+        let (provider, container) = self.resolve(path)?;
+        let command = provider
+            .alter_password_command(username, password)
+            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+        expect_success(self.run(&container, &command).await?)
+    }
+
+    /// Drop a role.
+    pub async fn drop_role(&self, path: &Path, username: &str) -> Result<(), ManageUsersError> {
+        let (provider, container) = self.resolve(path)?;
+        let command = provider
+            .drop_role_command(username)
+            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+        expect_success(self.run(&container, &command).await?)
+    }
+
+    /// Apply a role preset to an existing role.
+    pub async fn apply_preset(
+        &self,
+        path: &Path,
+        username: &str,
+        preset: RolePreset,
+    ) -> Result<(), ManageUsersError> {
+        let (provider, container) = self.resolve(path)?;
+        let command = provider
+            .apply_preset_command(username, preset)
+            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+        expect_success(self.run(&container, &command).await?)
+    }
+
+    /// List login roles (never a password).
+    pub async fn list_roles(&self, path: &Path) -> Result<Vec<RoleInfo>, ManageUsersError> {
+        let (provider, container) = self.resolve(path)?;
+        let command = provider
+            .list_roles_command()
+            .map_err(|e| ManageUsersError::Unsupported(e.to_string()))?;
+        let output = self.run(&container, &command).await?;
+        if output.exit_code != 0 {
+            return Err(fail(output));
+        }
+        serde_json::from_str(output.stdout.trim())
+            .map_err(|e| ManageUsersError::Parse(e.to_string()))
+    }
+}
+
+/// A mutating op succeeded iff the exit code is zero.
+fn expect_success(output: ExecOutput) -> Result<(), ManageUsersError> {
+    if output.exit_code == 0 {
+        Ok(())
+    } else {
+        Err(fail(output))
+    }
+}
+
+fn fail(output: ExecOutput) -> ManageUsersError {
+    let message = if output.stderr.trim().is_empty() {
+        output.stdout.trim().to_string()
+    } else {
+        output.stderr.trim().to_string()
+    };
+    ManageUsersError::Failed {
+        exit_code: output.exit_code,
+        message,
+    }
+}

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -138,15 +138,20 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
     }
 
     /// Apply a role preset to an existing role.
+    ///
+    /// `default_privileges_owner`, when set, is the role whose future objects the
+    /// preset's default privileges should cover (the customer's `owner` role in a
+    /// deploy). `None` role-scopes the defaults to the connecting role (single-node).
     pub async fn apply_preset(
         &self,
         path: &Path,
         username: &str,
         preset: RolePreset,
+        default_privileges_owner: Option<&str>,
     ) -> Result<(), ManageUsersError> {
         let (provider, container) = self.resolve(path)?;
         let command = provider
-            .apply_preset_command(username, preset)
+            .apply_preset_command(username, preset, default_privileges_owner)
             .map_err(map_provider_err)?;
         expect_success(self.run(&container, &command).await?)
     }
@@ -539,6 +544,7 @@ mod tests {
             &self,
             username: &str,
             _: RolePreset,
+            _: Option<&str>,
         ) -> std::result::Result<String, ProviderError> {
             self.guard()?;
             Ok(format!("MOCK-PRESET:{username}"))
@@ -627,6 +633,7 @@ mod tests {
                 username: "alice".into(),
                 password: "pw".into(),
                 preset: None,
+                default_privileges_owner: None,
             },
         )
         .await
@@ -700,6 +707,7 @@ mod tests {
                     username: "alice".into(),
                     password: "pw".into(),
                     preset: None,
+                    default_privileges_owner: None,
                 },
             )
             .await
@@ -732,6 +740,7 @@ mod tests {
                     username: "alice".into(),
                     password: String::new(),
                     preset: None,
+                    default_privileges_owner: None,
                 },
             )
             .await

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -305,7 +305,10 @@ fn require_password(password: &str) -> Result<(), ManageUsersError> {
 const RESERVED_ROLES: [&str; 4] = ["guepard-admin", "postgres", "owner", "developers"];
 
 fn reject_reserved_role(username: &str) -> Result<(), ManageUsersError> {
-    if RESERVED_ROLES.contains(&username) {
+    // Case-insensitive: a look-alike like `POSTGRES` is a *distinct* Postgres role
+    // (quoted identifiers are case-sensitive), but creating one invites confusion
+    // with the real reserved role, so refuse every case variant too.
+    if RESERVED_ROLES.contains(&username.to_ascii_lowercase().as_str()) {
         Err(ManageUsersError::InvalidInput(format!(
             "'{username}' is a reserved platform role and cannot be modified via user management"
         )))
@@ -339,6 +342,9 @@ mod tests {
         // The customer's load-bearing deploy roles are protected too (F-04).
         assert!(reject_reserved_role("owner").is_err());
         assert!(reject_reserved_role("developers").is_err());
+        // Case variants of a reserved name are refused (no confusing look-alikes).
+        assert!(reject_reserved_role("POSTGRES").is_err());
+        assert!(reject_reserved_role("Owner").is_err());
         assert!(reject_reserved_role("app_rw").is_ok());
     }
     use tempfile::TempDir;

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -105,6 +105,7 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
     /// Create a login role (optionally with a preset).
     pub async fn create_role(&self, path: &Path, spec: &RoleSpec) -> Result<(), ManageUsersError> {
         require_password(&spec.password)?;
+        reject_reserved_role(&spec.username)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .create_role_command(spec)
@@ -120,6 +121,7 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
         password: &str,
     ) -> Result<(), ManageUsersError> {
         require_password(password)?;
+        reject_reserved_role(username)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .alter_password_command(username, password)
@@ -149,6 +151,7 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
         preset: RolePreset,
         default_privileges_owner: Option<&str>,
     ) -> Result<(), ManageUsersError> {
+        reject_reserved_role(username)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider
             .apply_preset_command(username, preset, default_privileges_owner)
@@ -185,8 +188,23 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
             .map_err(|e| ManageUsersError::Parse(e.to_string()))
     }
 
+    /// Detect the deploy's object-creating `owner` role (RFC 009 §5.1) so a
+    /// preset's `ALTER DEFAULT PRIVILEGES` covers the customer's future tables,
+    /// not the connecting admin's. The CLI/MCP don't know the deploy owner: if the
+    /// conventional `owner` role exists, scope preset defaults to it; otherwise
+    /// `None` (single-node — defaults stay connecting-role-scoped).
+    pub async fn detect_deploy_owner(&self, path: &Path) -> Option<String> {
+        const DEPLOY_OWNER_ROLE: &str = "owner";
+        let roles = self.list_roles(path).await.ok()?;
+        roles
+            .iter()
+            .any(|r| r.username == DEPLOY_OWNER_ROLE)
+            .then(|| DEPLOY_OWNER_ROLE.to_string())
+    }
+
     /// Grant object-level privileges on `spec.object` to `spec.role`.
     pub async fn grant(&self, path: &Path, spec: &GrantSpec) -> Result<(), ManageUsersError> {
+        reject_reserved_role(&spec.role)?;
         validate_privileges(&spec.privileges, &spec.object)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider.grant_command(spec).map_err(map_provider_err)?;
@@ -195,6 +213,7 @@ impl<R: DatabaseProviderRegistry> ManageUsersUseCase<R> {
 
     /// Revoke object-level privileges on `spec.object` from `spec.role`.
     pub async fn revoke(&self, path: &Path, spec: &RevokeSpec) -> Result<(), ManageUsersError> {
+        reject_reserved_role(&spec.role)?;
         validate_privileges(&spec.privileges, &spec.object)?;
         let (provider, container) = self.resolve(path)?;
         let command = provider.revoke_command(spec).map_err(map_provider_err)?;
@@ -275,17 +294,20 @@ fn require_password(password: &str) -> Result<(), ManageUsersError> {
     }
 }
 
-/// The platform's management/bootstrap roles, never client roles. Refuse to drop
-/// them: `postgres` is the engine's own connection superuser, and dropping it
-/// makes `DROP OWNED BY` walk the entire database and wedge the session (and the
-/// same holds for `guepard-admin` once it is the bootstrap super). Fail fast with
-/// a clear message instead.
-const RESERVED_ROLES: [&str; 2] = ["guepard-admin", "postgres"];
+/// The platform's load-bearing roles (RFC 009), never client roles: the engine
+/// connection superuser `postgres`, the bootstrap super `guepard-admin`, the
+/// customer's least-privileged login `owner`, and the `developers` group. Client
+/// user management (`gfs user`) refuses to mutate any of them — dropping the
+/// connection superuser makes `DROP OWNED BY` wedge the session; dropping `owner`
+/// destroys the customer's primary login; rotating a password or privileges
+/// out-of-band desyncs the deploy's stored credential/connection string. Fail
+/// fast with a clear message instead.
+const RESERVED_ROLES: [&str; 4] = ["guepard-admin", "postgres", "owner", "developers"];
 
 fn reject_reserved_role(username: &str) -> Result<(), ManageUsersError> {
     if RESERVED_ROLES.contains(&username) {
         Err(ManageUsersError::InvalidInput(format!(
-            "'{username}' is a reserved management role and cannot be dropped"
+            "'{username}' is a reserved platform role and cannot be modified via user management"
         )))
     } else {
         Ok(())
@@ -314,6 +336,9 @@ mod tests {
         use super::reject_reserved_role;
         assert!(reject_reserved_role("postgres").is_err());
         assert!(reject_reserved_role("guepard-admin").is_err());
+        // The customer's load-bearing deploy roles are protected too (F-04).
+        assert!(reject_reserved_role("owner").is_err());
+        assert!(reject_reserved_role("developers").is_err());
         assert!(reject_reserved_role("app_rw").is_ok());
     }
     use tempfile::TempDir;

--- a/crates/domain/src/usecases/repository/mod.rs
+++ b/crates/domain/src/usecases/repository/mod.rs
@@ -7,5 +7,6 @@ pub mod extract_schema_usecase;
 pub mod import_repo_usecase;
 pub mod init_repo_usecase;
 pub mod log_repo_usecase;
+pub mod manage_users_usecase;
 pub mod status_repo_usecase;
 mod task_image;

--- a/crates/domain/src/utils/credential_vault.rs
+++ b/crates/domain/src/utils/credential_vault.rs
@@ -1,0 +1,224 @@
+//! Per-repository credential vault (RFC 008): a database's passwords live in
+//! `{repo}/.gfs/secrets/<name>` on the data-plane node, at mode `0600` — never in
+//! the cloud. This is a dumb typed key/value store over the filesystem; it holds
+//! no tenant, policy, or encryption concept — the node filesystem plus `0600` are
+//! the trust boundary (RFC 008 §7). Mirrors the plain `io::Result` style of the
+//! sibling `utils/data_dir.rs`.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+/// Secrets directory relative to a database's GFS repository root.
+const SECRETS_DIR: &str = ".gfs/secrets";
+
+/// A node-local credential store rooted at a database's GFS repository.
+pub struct RepoCredentialVault;
+
+impl RepoCredentialVault {
+    /// Write `value` to `{repo}/.gfs/secrets/<name>` at mode `0600` (creating the
+    /// secrets directory at `0700` if needed). Overwrites an existing secret and
+    /// re-pins its mode.
+    ///
+    /// # Errors
+    /// Invalid `name` (see [`secret_path`]) or an underlying filesystem error.
+    pub fn put(repo: &Path, name: &str, value: &[u8]) -> io::Result<()> {
+        let path = secret_path(repo, name)?;
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+            set_mode(dir, 0o700)?;
+        }
+        write_secret_file(&path, value)
+    }
+
+    /// Read `{repo}/.gfs/secrets/<name>`; `Ok(None)` when it does not exist.
+    ///
+    /// # Errors
+    /// Invalid `name` or an underlying filesystem error other than not-found.
+    pub fn get(repo: &Path, name: &str) -> io::Result<Option<Vec<u8>>> {
+        let path = secret_path(repo, name)?;
+        match std::fs::read(&path) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Remove `{repo}/.gfs/secrets/<name>`; idempotent (a missing secret is `Ok`).
+    ///
+    /// # Errors
+    /// Invalid `name` or an underlying filesystem error other than not-found.
+    pub fn delete(repo: &Path, name: &str) -> io::Result<()> {
+        let path = secret_path(repo, name)?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Validate `name` and join it under `{repo}/.gfs/secrets/`. Names are
+/// `[a-z0-9_]+` (non-empty) — no path separators, `..`, dots, or uppercase — so a
+/// name can never escape the secrets directory.
+fn secret_path(repo: &Path, name: &str) -> io::Result<PathBuf> {
+    let valid = !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_');
+    if !valid {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid secret name: {name:?} (expected [a-z0-9_]+)"),
+        ));
+    }
+    Ok(repo.join(SECRETS_DIR).join(name))
+}
+
+#[cfg(unix)]
+fn write_secret_file(path: &Path, value: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+    // `mode(0o600)` applies only when this call creates the file; on an overwrite
+    // it is ignored, so re-pin the mode explicitly afterwards.
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(value)?;
+    set_mode(path, 0o600)
+}
+
+#[cfg(not(unix))]
+fn write_secret_file(path: &Path, value: &[u8]) -> io::Result<()> {
+    std::fs::write(path, value)
+}
+
+#[cfg(unix)]
+fn set_mode(path: &Path, mode: u32) -> io::Result<()> {
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(mode);
+    std::fs::set_permissions(path, perms)
+}
+
+#[cfg(not(unix))]
+fn set_mode(_path: &Path, _mode: u32) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn put_then_get_roundtrips() {
+        let dir = repo();
+        RepoCredentialVault::put(dir.path(), "owner_password", b"s3cr3t").unwrap();
+        assert_eq!(
+            RepoCredentialVault::get(dir.path(), "owner_password").unwrap(),
+            Some(b"s3cr3t".to_vec())
+        );
+    }
+
+    #[test]
+    fn get_missing_is_none() {
+        let dir = repo();
+        assert_eq!(
+            RepoCredentialVault::get(dir.path(), "absent").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let dir = repo();
+        RepoCredentialVault::put(dir.path(), "owner_password", b"x").unwrap();
+        RepoCredentialVault::delete(dir.path(), "owner_password").unwrap();
+        assert_eq!(
+            RepoCredentialVault::get(dir.path(), "owner_password").unwrap(),
+            None
+        );
+        // Second delete on the now-absent secret is still Ok.
+        RepoCredentialVault::delete(dir.path(), "owner_password").unwrap();
+    }
+
+    #[test]
+    fn put_overwrites() {
+        let dir = repo();
+        RepoCredentialVault::put(dir.path(), "owner_password", b"first").unwrap();
+        RepoCredentialVault::put(dir.path(), "owner_password", b"second").unwrap();
+        assert_eq!(
+            RepoCredentialVault::get(dir.path(), "owner_password").unwrap(),
+            Some(b"second".to_vec())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secret_file_is_0600_and_dir_0700() {
+        let dir = repo();
+        RepoCredentialVault::put(dir.path(), "admin_password", b"x").unwrap();
+        let file_mode = std::fs::metadata(dir.path().join(".gfs/secrets/admin_password"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(file_mode, 0o600, "secret must be 0600, got {file_mode:o}");
+        let dir_mode = std::fs::metadata(dir.path().join(".gfs/secrets"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            dir_mode, 0o700,
+            "secrets dir must be 0700, got {dir_mode:o}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn overwrite_keeps_0600_even_if_prior_mode_was_loose() {
+        let dir = repo();
+        RepoCredentialVault::put(dir.path(), "owner_password", b"first").unwrap();
+        let path = dir.path().join(".gfs/secrets/owner_password");
+        // Loosen the mode behind the vault's back, then overwrite.
+        set_mode(&path, 0o644).unwrap();
+        RepoCredentialVault::put(dir.path(), "owner_password", b"second").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "overwrite must re-pin 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn rejects_names_that_could_escape_the_vault() {
+        let dir = repo();
+        for bad in [
+            "",
+            "../escape",
+            "a/b",
+            "UPPER",
+            "with space",
+            "dot.name",
+            "..",
+        ] {
+            assert!(
+                RepoCredentialVault::put(dir.path(), bad, b"x").is_err(),
+                "put must reject name {bad:?}"
+            );
+            assert!(
+                RepoCredentialVault::get(dir.path(), bad).is_err(),
+                "get must reject name {bad:?}"
+            );
+            assert!(
+                RepoCredentialVault::delete(dir.path(), bad).is_err(),
+                "delete must reject name {bad:?}"
+            );
+        }
+    }
+}

--- a/crates/domain/src/utils/mod.rs
+++ b/crates/domain/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod credential_vault;
 pub mod current_user;
 pub mod data_dir;
 pub mod hash;


### PR DESCRIPTION
The gfs-engine side of database user management + the node-local credential vault.

- `gfs user` create/list/drop/set-password/apply-preset + object-level grant/revoke/list-privs (typed privilege allow-list, injection-proof).
- Role presets (readonly/readwrite/admin); declarative apply-preset (a downgrade actually revokes); role-scoped default privileges for the deploy owner; reserved-role guard (case-folded). The applied preset is recorded in the role comment and surfaced in `list`.
- Deploy-env bootstrap (three principals: `guepard-admin` / `owner` / `developers`).
- Node-local credential vault (`.gfs/secrets`), `vault://` refs, reveal resolves the least-priv `owner` (never the superuser).
- MCP `user` tool; k8s exec exit-code fix + stopped-instance fast-fail.

Verified live on Docker and Kubernetes against the real catalog (SCRAM over NodePort, not loopback trust). The `manage_users_it` suite is parallel-safe.
