### PR TITLE
feat(compute): honor GFS_CONTAINER_UID_GID to override container run-as user

### DIFF
--- a/crates/domain/src/utils/current_user.rs
+++ b/crates/domain/src/utils/current_user.rs
@@ -15,8 +15,20 @@ fn id_value(flag: &str) -> Option<String> {
 
 /// Return current Unix uid and gid as "uid:gid" for `docker run --user`.
 /// Returns `None` if id cannot be determined (e.g. on Windows or when `id` is unavailable).
+///
+/// `GFS_CONTAINER_UID_GID` overrides the detected value: set it to a `uid:gid`
+/// pair to force that user, or to an empty string to run the container as the
+/// image default. This is an escape hatch for runtimes whose bind mounts are not
+/// owned by the host uid — e.g. Colima/Lima `virtiofs` presents them as
+/// root-owned, so pinning the container to the host uid makes `initdb`'s chmod
+/// fail; running as the image default (which chmods as root, then drops
+/// privileges) works there, as it already does on Kubernetes.
 #[cfg(unix)]
 pub fn current_user_uid_gid() -> Option<String> {
+    if let Ok(override_value) = std::env::var("GFS_CONTAINER_UID_GID") {
+        let trimmed = override_value.trim();
+        return (!trimmed.is_empty()).then(|| trimmed.to_string());
+    }
     let uid = id_value("-u")?;
     let gid = id_value("-g")?;
     Some(format!("{uid}:{gid}"))
@@ -35,4 +47,32 @@ pub fn current_user_uid_gid() -> Option<String> {
 #[cfg(not(unix))]
 pub fn current_user_name() -> Option<String> {
     None
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::current_user_uid_gid;
+
+    /// `GFS_CONTAINER_UID_GID` overrides the detected uid:gid — a pair forces that
+    /// user, a blank value runs as the image default, and its absence falls back to
+    /// the host uid:gid. Serialised in one test since the environment is process-wide.
+    #[test]
+    fn container_uid_gid_override_forces_value_blank_or_falls_back() {
+        // SAFETY: single-threaded test; nothing else reads the environment concurrently.
+        unsafe { std::env::set_var("GFS_CONTAINER_UID_GID", "1234:5678") };
+        assert_eq!(current_user_uid_gid().as_deref(), Some("1234:5678"));
+
+        unsafe { std::env::set_var("GFS_CONTAINER_UID_GID", "   ") };
+        assert_eq!(
+            current_user_uid_gid(),
+            None,
+            "a blank override runs the container as the image default"
+        );
+
+        unsafe { std::env::remove_var("GFS_CONTAINER_UID_GID") };
+        assert!(
+            current_user_uid_gid().is_some_and(|v| v.contains(':')),
+            "without the override the detected host uid:gid is used"
+        );
+    }
 }


### PR DESCRIPTION
## What

`current_user_uid_gid` pins the deploy container to the **host uid** (`docker run --user`) so bind-mounted data is host-owned. That is correct on native Docker, but some runtimes present bind mounts as **root-owned inside the container** — notably **Colima/Lima `virtiofs`** — where a host-uid process cannot `chmod` the data dir and `initdb` fails during deploy (`could not change permissions of directory "/var/lib/postgresql/data": Operation not permitted`), so the container exits during startup.

Running the container as the image **default (root)** works there — the entrypoint chmods as root, then drops privileges to `postgres` via `gosu` — which is exactly what the Kubernetes path already does (`run_as_user: Some(0)`).

## Change

`current_user_uid_gid` now honors an optional `GFS_CONTAINER_UID_GID` env var:
- a `uid:gid` pair forces that user,
- an **empty** value runs the container as the image default,
- absence keeps today's behavior (detected host `uid:gid`).

No behavior change unless the env var is set. Unit test covers all three branches.