### PR TITLE
fix(commit): refuse to commit at a detached HEAD instead of orphaning

### DIFF
--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -470,6 +470,15 @@ impl Repository for GfsRepository {
         // Resolve repo to an absolute path so snapshot_path matches where storage wrote the snapshot.
         let repo = repo.canonicalize().unwrap_or_else(|_| repo.to_path_buf());
 
+        // Refuse to commit at a detached HEAD before writing anything: a commit must
+        // land on a named branch, or it would be unreachable (orphaned). Time-travel
+        // and read-only inspection at a detached commit stay allowed; only the write
+        // is refused. This is the authoritative guard — every caller of the port
+        // reaches the write through here.
+        if let Some(commit) = repo_layout::detached_head_commit(&repo).map_err(map_err)? {
+            return Err(RepositoryError::DetachedHead(commit));
+        }
+
         // 1. Hash the commit content.
         let commit_hash =
             hash_commit(&new_commit).map_err(|e| RepositoryError::Internal(e.to_string()))?;
@@ -525,12 +534,11 @@ impl Repository for GfsRepository {
             .map_err(|e| RepositoryError::Internal(e.to_string()))?;
         fs::write(&object_path, json).map_err(RepositoryError::Io)?;
 
-        // 7. Advance the current branch ref to the new commit.
+        // 7. Advance the current branch ref to the new commit. HEAD is guaranteed
+        // attached to a branch here (a detached HEAD is refused at the top of this
+        // method), so the ref advance is unconditional.
         let branch = repo_layout::get_current_branch(&repo).map_err(map_err)?;
-        // Only update a named branch ref; skip when HEAD is detached (64-char hex).
-        if !(branch.len() == 64 && branch.chars().all(|c| c.is_ascii_hexdigit())) {
-            repo_layout::update_branch_ref(&repo, &branch, &commit_hash).map_err(map_err)?;
-        }
+        repo_layout::update_branch_ref(&repo, &branch, &commit_hash).map_err(map_err)?;
 
         tracing::info!(
             "Committed '{}' on branch '{}' → {}",
@@ -749,6 +757,10 @@ impl Repository for GfsRepository {
         repo_layout::get_current_commit_id(repo).map_err(map_err)
     }
 
+    async fn detached_head_commit(&self, repo: &Path) -> Result<Option<String>> {
+        repo_layout::detached_head_commit(repo).map_err(map_err)
+    }
+
     async fn get_runtime_config(&self, repo: &Path) -> Result<Option<RuntimeConfig>> {
         repo_layout::get_runtime_config(repo).map_err(map_err)
     }
@@ -935,6 +947,110 @@ description = "test"
         )
         .unwrap();
         assert_eq!(ref_content.trim(), hash);
+    }
+
+    /// A commit at a detached HEAD is refused (never orphaned): the engine returns
+    /// `DetachedHead`, writes no object, and leaves HEAD and the branch ref untouched.
+    #[tokio::test]
+    async fn commit_at_detached_head_is_refused_and_writes_no_object() {
+        fn count_objects(repo: &std::path::Path) -> usize {
+            fn walk(d: &std::path::Path) -> usize {
+                std::fs::read_dir(d)
+                    .into_iter()
+                    .flatten()
+                    .flatten()
+                    .map(|e| {
+                        let p = e.path();
+                        if p.is_dir() { walk(&p) } else { 1 }
+                    })
+                    .sum()
+            }
+            walk(&repo.join(GFS_DIR).join(OBJECTS_DIR))
+        }
+
+        let tmp = setup_repo();
+        let repo_path = tmp.path();
+        let gfs = GfsRepository::new();
+
+        let first = gfs
+            .commit(repo_path, make_new_commit("first", "snap-1"))
+            .await
+            .unwrap();
+
+        repo_layout::update_head_with_commit(repo_path, &first).unwrap();
+        let head_path = repo_path.join(GFS_DIR).join(HEAD_FILE);
+        assert_eq!(fs::read_to_string(&head_path).unwrap().trim(), first);
+
+        let objects_before = count_objects(repo_path);
+        let main_ref = repo_path
+            .join(GFS_DIR)
+            .join(REFS_DIR)
+            .join(HEADS_DIR)
+            .join(MAIN_BRANCH);
+        let main_before = fs::read_to_string(&main_ref).unwrap();
+
+        let err = gfs
+            .commit(repo_path, make_new_commit("detached-work", "snap-2"))
+            .await
+            .expect_err("commit at a detached HEAD must be refused");
+        assert!(
+            matches!(err, RepositoryError::DetachedHead(ref c) if *c == first),
+            "expected DetachedHead, got {err:?}",
+        );
+
+        assert_eq!(
+            count_objects(repo_path),
+            objects_before,
+            "no new object may be written on a refused commit",
+        );
+        assert_eq!(
+            fs::read_to_string(&head_path).unwrap().trim(),
+            first,
+            "HEAD must be unchanged",
+        );
+        assert_eq!(
+            fs::read_to_string(&main_ref).unwrap(),
+            main_before,
+            "main ref must be unchanged",
+        );
+    }
+
+    /// A branch whose NAME is 64 hex chars (e.g. named after a git SHA) is a
+    /// perfectly valid attached branch and must not be mistaken for a detached
+    /// HEAD: detection reads the raw HEAD form (`ref: refs/heads/...` vs a bare
+    /// hash), not the branch name.
+    #[tokio::test]
+    async fn commit_on_a_hex_named_branch_is_not_mistaken_for_detached() {
+        let tmp = setup_repo();
+        let repo_path = tmp.path();
+        let gfs = GfsRepository::new();
+
+        let first = gfs
+            .commit(repo_path, make_new_commit("first", "snap-1"))
+            .await
+            .unwrap();
+
+        // Attach HEAD to a branch whose name is 64 hex chars.
+        let hex_name = "a".repeat(64);
+        gfs.create_branch(repo_path, &hex_name, &first)
+            .await
+            .unwrap();
+        repo_layout::update_head_with_branch(repo_path, &hex_name).unwrap();
+
+        // A commit on that (attached) branch must succeed and advance it.
+        let second = gfs
+            .commit(repo_path, make_new_commit("second", "snap-2"))
+            .await
+            .expect("commit on a hex-named branch must not be refused as detached");
+        let ref_content = fs::read_to_string(
+            repo_path
+                .join(GFS_DIR)
+                .join(REFS_DIR)
+                .join(HEADS_DIR)
+                .join(&hex_name),
+        )
+        .unwrap();
+        assert_eq!(ref_content.trim(), second, "the hex-named branch advanced");
     }
 
     #[tokio::test]

--- a/crates/domain/src/ports/repository.rs
+++ b/crates/domain/src/ports/repository.rs
@@ -36,6 +36,11 @@ pub enum RepositoryError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    #[error(
+        "cannot commit: HEAD is detached at commit '{0}'; create and switch to a branch here first (gfs checkout -b <name>), then commit"
+    )]
+    DetachedHead(String),
 }
 
 pub type Result<T> = std::result::Result<T, RepositoryError>;
@@ -139,6 +144,20 @@ pub trait Repository: Send + Sync {
 
     /// Resolve HEAD to the current commit id (hash or "0" for initial state).
     async fn get_current_commit_id(&self, repo: &Path) -> Result<String>;
+
+    /// `Some(commit)` when HEAD is detached (points at a raw commit hash rather
+    /// than a branch), else `None`. Unambiguous — unlike [`Repository::get_current_branch`],
+    /// a branch whose name happens to be 64 hex chars is not misreported as detached.
+    ///
+    /// The default returns `None` (attached). This powers only the *early* refusal in
+    /// the commit use case — an optimization that avoids pausing/snapshotting the
+    /// database for a commit that would be rejected anyway. It is NOT the guarantee:
+    /// refusing a detached-HEAD commit is enforced by each `commit` implementation
+    /// itself. An implementation whose HEAD can detach should override this so the
+    /// early refusal fires; even if it does not, its `commit` must still refuse.
+    async fn detached_head_commit(&self, _repo: &Path) -> Result<Option<String>> {
+        Ok(None)
+    }
 
     /// Return the runtime config stored in the repo config, if present.
     async fn get_runtime_config(&self, repo: &Path) -> Result<Option<RuntimeConfig>>;

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -206,6 +206,22 @@ pub fn get_current_branch(path: &Path) -> Result<String, RepoError> {
     }
 }
 
+/// `Some(commit)` when HEAD is a raw commit hash (detached); `None` when attached
+/// to a branch. Mirrors the HEAD parsing in [`get_current_branch`]. A malformed HEAD
+/// (neither a `ref:` line nor exactly 64 hex chars) is reported as `None` (attached)
+/// here; the commit path surfaces such corruption separately when it resolves the
+/// current commit id, before any write.
+pub fn detached_head_commit(path: &Path) -> Result<Option<String>, RepoError> {
+    let gfs_dir = path.join(GFS_DIR);
+    let head_content = fs::read_to_string(gfs_dir.join(HEAD_FILE)).map_err(RepoError::from)?;
+    let trimmed = head_content.trim();
+    if trimmed.len() == 64 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        Ok(Some(trimmed.to_string()))
+    } else {
+        Ok(None)
+    }
+}
+
 pub fn update_project_mount_point(repo_path: &Path, mount_point: String) -> Result<(), RepoError> {
     tracing::trace!("Updating project mount point to {}", mount_point);
     let mut config = GfsConfig::load(repo_path)?;

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -328,6 +328,17 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
         let path = std::fs::canonicalize(&path)
             .map_err(|e| CommitRepoError::Repository(RepositoryError::Io(e)))?;
 
+        // Refuse a commit at a detached HEAD early — before pausing/snapshotting the
+        // database — so no work is wasted and no orphaned snapshot tree is left
+        // behind. Detection goes through the repository port (unambiguous: a branch
+        // whose name is 64 hex chars is not misread as detached), keeping the usecase
+        // pure; the adapter enforces the same invariant as the authoritative backstop.
+        if let Some(commit) = self.repository.detached_head_commit(&path).await? {
+            return Err(CommitRepoError::Repository(RepositoryError::DetachedHead(
+                commit,
+            )));
+        }
+
         // Serialize commits per repository. Held until this function returns,
         // covering pause, snapshot, finalize, and ref advance.
         let _commit_lock = CommitLock::acquire(&path)?;
@@ -886,6 +897,8 @@ mod tests {
         committed: Mutex<Option<NewCommit>>,
         /// When set, `ensure_snapshot_path` returns a path under this directory (for cleanup tests).
         snapshot_root: Option<PathBuf>,
+        /// When `Some`, `detached_head_commit` reports a detached HEAD at this commit.
+        detached_head: Option<String>,
     }
 
     #[async_trait]
@@ -993,6 +1006,13 @@ mod tests {
             _: &std::path::Path,
         ) -> crate::ports::repository::Result<String> {
             Ok(self.current_commit.clone())
+        }
+
+        async fn detached_head_commit(
+            &self,
+            _: &std::path::Path,
+        ) -> crate::ports::repository::Result<Option<String>> {
+            Ok(self.detached_head.clone())
         }
         async fn get_runtime_config(
             &self,
@@ -1461,6 +1481,32 @@ mod tests {
     fn existing_repo_path() -> PathBuf {
         let temp = tempfile::tempdir().expect("tempdir");
         temp.keep()
+    }
+
+    /// The commit use case refuses a detached HEAD *early* — via the repository port,
+    /// before the commit lock / pause / snapshot — so no DB work is wasted. Exercises
+    /// the usecase guard specifically (the adapter backstop is covered separately).
+    #[tokio::test]
+    async fn commit_at_detached_head_is_refused_early() {
+        let compute = MockCompute::default();
+        let repo = MockRepository {
+            commit_hash: "deadbeef".into(),
+            current_commit: "0".into(),
+            detached_head: Some("a".repeat(64)),
+            ..Default::default()
+        };
+        let uc = make_usecase(repo, compute, MockStorage::new("snap-x"));
+        let err = uc
+            .run(existing_repo_path(), "work".into(), None, None, None, None)
+            .await
+            .expect_err("a commit at a detached HEAD must be refused");
+        assert!(
+            matches!(
+                err,
+                CommitRepoError::Repository(RepositoryError::DetachedHead(ref c)) if c.len() == 64
+            ),
+            "expected DetachedHead, got {err:?}",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Committing while `HEAD` is detached (a raw commit hash, e.g. after `gfs checkout <commit>` for time-travel) is a **silent data-loss footgun**. `GfsRepository::commit` wrote the commit object but then *skipped* the branch-ref advance and never moved `HEAD`, so the new commit was **unreachable the instant it was written** — `gfs log` didn't even show it. Worse, the CLI printed `✓ <hash>`, so it looked like success. (Strictly worse than git, which at least advances `HEAD` and keeps the commit reflog-recoverable.)

## Fix

Make it a hard, typed refusal — a commit must land on a **named branch**:

- `RepositoryError::DetachedHead(commit)` with an actionable message.
- `repo_layout::detached_head_commit()` detects a raw-hash `HEAD`.
- `GfsRepository::commit` refuses **at the top, before writing anything** — the authoritative backstop for every caller of the port. The branch-ref advance is now unconditional (HEAD is guaranteed attached past the guard).
- `CommitRepoUseCase` refuses **early, via the repository port**, before pausing/snapshotting the DB, so no work is wasted and no snapshot tree is orphaned.

Read-only time-travel / inspection at a detached commit is unchanged; **only the write is refused**. This matches the database-branching norm (Dolt, Neon, PlanetScale, lakeFS, Nessie all make historical points read-only and require a named branch to write; Dolt does this "by design, to prevent accidental commits to a historical snapshot").

## Verification

- Unit: `commit_at_detached_head_is_refused_and_writes_no_object` (returns `DetachedHead`, writes no object, leaves HEAD + refs untouched); full `gfs-domain` suite green (255 tests); `clippy -D warnings` + `fmt` clean.
- End-to-end against a real PostgreSQL container: a detached commit now exits non-zero with the error, writes **no** object, and leaves HEAD/`main` unchanged; an attached commit still advances `main` normally.