### PR TITLE
fix(schema): name a schema object by everything it stores, and stop the sentinel commit id from panicking

### DIFF
--- a/crates/applications/cli/src/commands/cmd_schema.rs
+++ b/crates/applications/cli/src/commands/cmd_schema.rs
@@ -84,7 +84,10 @@ pub async fn run_show(
 
     // Load commit
     let commit_obj = repo_layout::get_commit_from_hash(&repo_path, &commit_hash)
-        .with_context(|| format!("failed to load commit {}", commit_hash))?;
+        // No `.with_context()`: anyhow renders the context string ALONE, so
+        // wrapping replaced "the repository has no commits yet" with "failed to
+        // load commit 0" — the half that says nothing.
+        ?;
 
     // Get schema hash
     let schema_hash = commit_obj.schema_hash.ok_or_else(|| {
@@ -152,10 +155,8 @@ pub async fn run_diff(
         .with_context(|| format!("failed to resolve commit '{}'", commit2))?;
 
     // Load commits
-    let commit1_obj = repo_layout::get_commit_from_hash(&repo_path, &hash1)
-        .with_context(|| format!("failed to load commit {}", hash1))?;
-    let commit2_obj = repo_layout::get_commit_from_hash(&repo_path, &hash2)
-        .with_context(|| format!("failed to load commit {}", hash2))?;
+    let commit1_obj = repo_layout::get_commit_from_hash(&repo_path, &hash1)?;
+    let commit2_obj = repo_layout::get_commit_from_hash(&repo_path, &hash2)?;
 
     // Get schema hashes
     let schema_hash1 = commit1_obj

--- a/crates/domain/src/model/errors.rs
+++ b/crates/domain/src/model/errors.rs
@@ -45,6 +45,8 @@ pub enum RepoError {
     InvalidConfig(String),
     #[error("revision not found: '{0}'")]
     RevisionNotFound(String),
+    #[error("the repository has no commits yet")]
+    NoCommitsYet,
     #[error("short hash '{prefix}' is ambiguous\nPossible matches:\n{}", format_matches(.matches))]
     AmbiguousShortHash {
         prefix: String,

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -522,11 +522,35 @@ pub fn snapshot_diff(
     })
 }
 
+/// Split a 64-hex object hash into its `<2>/<62>` storage path parts.
+///
+/// Guarded, because `str::split_at` panics on a boundary past the end and the
+/// value that reaches here is not always a hash. A repository with no commits
+/// records the sentinel `"0"` as its current commit, so `gfs schema show HEAD`
+/// on a fresh repo — step two of the documented workflow — reached
+/// `"0".split_at(2)` and took the whole process down with
+/// `end byte index 2 is out of bounds for string of length 1`. Over MCP that
+/// was worse than a crash: the panic unwound the request while the server
+/// stayed up, so the call was never answered and the client waited forever.
+///
+/// Returning `RevisionNotFound` instead turns it into the same error every
+/// other bad revision produces.
+pub fn split_object_hash(hash: &str) -> Result<(&str, &str), RepoError> {
+    if hash.len() < 3 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(if hash == "0" {
+            RepoError::NoCommitsYet
+        } else {
+            RepoError::RevisionNotFound(hash.to_string())
+        });
+    }
+    Ok(hash.split_at(2))
+}
+
 pub fn get_commit_from_hash(repo_path: &Path, commit_hash: &str) -> Result<Commit, RepoError> {
     tracing::trace!("Getting commit from hash {}", commit_hash);
 
     let objects_dir = repo_path.join(GFS_DIR).join(OBJECTS_DIR);
-    let (dir_part, file_part) = commit_hash.split_at(2);
+    let (dir_part, file_part) = split_object_hash(commit_hash)?;
     let object_path = objects_dir.join(dir_part).join(file_part);
     let commit_json = fs::read_to_string(object_path).map_err(RepoError::from)?;
 
@@ -659,9 +683,25 @@ pub fn write_schema_object(
     let schema_json = serde_json::to_string_pretty(schema_metadata)
         .map_err(|e| RepoError::InvalidConfig(format!("failed to serialize schema: {}", e)))?;
 
-    // 2. Compute SHA-256 hash of schema.json content
+    // 2. Name the object after EVERYTHING it stores, not just half of it.
+    //
+    //    The hash covered `schema.json` alone while the directory it names also
+    //    holds `schema.sql`. Two commits whose structured metadata matches but
+    //    whose DDL differs — a dropped CHECK constraint, a changed foreign-key
+    //    action, a rewritten trigger body, a different collation — therefore
+    //    landed in the SAME directory, and the second write REPLACED the first
+    //    commit's `schema.sql`. `gfs schema show <old-commit>` then returned
+    //    the newer schema: a stored artefact changing retroactively, with
+    //    nothing to indicate it.
+    //
+    //    Including the DDL makes the name identify the content, which is what a
+    //    content-addressed store is for. A separator keeps the two fields from
+    //    running together, so a byte moved from the end of one to the start of
+    //    the other cannot produce the same digest.
     let mut hasher = Sha256::new();
     hasher.update(schema_json.as_bytes());
+    hasher.update(b"\0schema.sql\0");
+    hasher.update(schema_sql.as_bytes());
     let hash = format!("{:x}", hasher.finalize());
 
     // 3. Create directory: objects/<2>/<62>/
@@ -1104,6 +1144,89 @@ mod tests {
     use std::fs;
     use std::io;
     use tempfile::TempDir;
+
+    /// A schema object must be named by everything it stores.
+    ///
+    /// The hash covered `schema.json` alone while the directory it names also
+    /// holds `schema.sql`, so two commits with identical structured metadata
+    /// and different DDL — a dropped CHECK, a changed FK action, a rewritten
+    /// trigger — collided, and the second write REPLACED the first commit's
+    /// stored DDL. `gfs schema show <old>` then returned the newer schema.
+    #[test]
+    fn two_schemas_differing_only_in_ddl_do_not_collide() {
+        let dir = tempfile::tempdir().unwrap();
+        let metadata = crate::model::datasource::DatasourceMetadata {
+            version: "3".into(),
+            driver: "sqlite".into(),
+            schemas: vec![],
+            tables: vec![],
+            columns: vec![],
+            views: None,
+            functions: None,
+            indexes: None,
+            triggers: None,
+            materialized_views: None,
+            types: None,
+            foreign_tables: None,
+            policies: None,
+            table_privileges: None,
+            column_privileges: None,
+            config: None,
+            publications: None,
+            roles: None,
+            extensions: None,
+        };
+
+        let first =
+            write_schema_object(dir.path(), &metadata, "CREATE TABLE t(a INT CHECK(a > 0));")
+                .expect("first");
+        let second =
+            write_schema_object(dir.path(), &metadata, "CREATE TABLE t(a INT);").expect("second");
+
+        assert_ne!(
+            first, second,
+            "same metadata, different DDL — the objects must not share a name"
+        );
+
+        // And the first commit's DDL is still what it was.
+        let stored = |hash: &str| {
+            let (a, b) = hash.split_at(2);
+            fs::read_to_string(
+                dir.path()
+                    .join(GFS_DIR)
+                    .join(OBJECTS_DIR)
+                    .join(a)
+                    .join(b)
+                    .join("schema.sql"),
+            )
+            .expect("schema.sql")
+        };
+        assert!(stored(&first).contains("CHECK"), "the older DDL survived");
+        assert!(!stored(&second).contains("CHECK"));
+    }
+
+    /// A repository with no commits must not take the process down.
+    ///
+    /// `get_current_commit_id` returns the sentinel `"0"` before the first
+    /// commit, and `"0".split_at(2)` panics. `gfs schema show HEAD` on a fresh
+    /// repository is step two of the documented workflow, so this was reachable
+    /// immediately — and over MCP the panic unwound the request while the
+    /// server stayed up, leaving the client waiting forever.
+    #[test]
+    fn a_hash_that_is_not_a_hash_is_an_error_not_a_panic() {
+        assert!(matches!(
+            split_object_hash("0"),
+            Err(RepoError::NoCommitsYet)
+        ));
+        for bad in ["", "a", "ab", "zz1234", "not-hex-at-all"] {
+            assert!(
+                split_object_hash(bad).is_err(),
+                "{bad:?} is not an object hash"
+            );
+        }
+        let hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert_eq!(split_object_hash(hash).unwrap(), ("01", &hash[2..]));
+    }
 
     #[test]
     fn short_commit_id_for_workspace_keeps_short_and_truncates_long() {


### PR DESCRIPTION
Two defects in the shared schema path, found by an independent audit. Both reproduced on **unmodified `main`** before anything was changed, and neither is provider-specific.

## 1. A schema object is named by half its content

`write_schema_object` writes **`schema.json` and `schema.sql`** into a directory named by a SHA-256 of **the JSON alone**.

Two commits whose structured metadata matches but whose DDL differs land in the same directory, and the second write **replaces the first commit's `schema.sql`**. Cases that collide include a dropped `CHECK` constraint, a changed foreign-key action, a rewritten trigger body, and a changed collation — the audit measured **10 of 18 schema-change classes**.

The consequence is not a duplicate object. It is that **a stored artefact changes retroactively**: `gfs schema show <old-commit>` returns the *newer* schema, for a commit made before that schema existed, with nothing to indicate it.

```rust
// before
hasher.update(schema_json.as_bytes());
// after
hasher.update(schema_json.as_bytes());
hasher.update(b"\0schema.sql\0");
hasher.update(schema_sql.as_bytes());
```

The separator means a byte moved from the end of one field to the start of the other cannot produce the same digest. A content-addressed store whose name does not cover its content is not one.

## 2. The sentinel commit id panics

`get_current_commit_id` returns `"0"` for a repository with no commits, and `str::split_at` panics on a boundary past the end.

```console
$ gfs init r && gfs schema show HEAD --path r
thread 'main' panicked at .../str/mod.rs:845:21:
end byte index 2 is out of bounds for string of length 1
```

That is **step two of the documented workflow** on a fresh repository. There are ~21 unguarded `split_at(2)` sites; this fixes the one reachable from a user-supplied revision, at the point a value first becomes a path.

**Over MCP it is worse than a crash.** The panic unwinds the request while the server stays alive, so the call is *never answered* — the client waits forever with no error and no disconnect.

```console
before:  panicked, exit 0, MCP client hangs
after:   error: the repository has no commits yet
         MCP: answered
```

`split_object_hash` guards it and `get_commit_from_hash` routes through it, so a value that is not an object hash becomes an error where it is first used as one. `RepoError::NoCommitsYet` says the actual thing rather than reporting a missing revision named `"0"`.

Three `.with_context(|| "failed to load commit {hash}")` wrappers in `cmd_schema.rs` come out: anyhow renders the context string **alone**, so wrapping replaced *"the repository has no commits yet"* with *"failed to load commit 0"* — the half that says nothing.

## Verification

Both tests were checked to be **live**, not merely passing:

- reverting the hash to JSON-only makes the collision test fail with the two digests equal;
- the guard test covers the sentinel, plus short, empty and non-hex inputs, and asserts a real hash still splits correctly.

`gfs-domain` 256 green. `fmt` and `clippy -D warnings` clean. `e2e_commit` and `e2e_schema_diff` each fail identically on a clean checkout of the base — every failure is a `postgres_*` test needing a container runtime this machine does not have.