### PR TITLE
fix(mcp): survive a blank line, answer argument errors one way, and name the actual condition when a directory is not a repository

### DIFF
--- a/crates/applications/mcp/src/blank_line_filter.rs
+++ b/crates/applications/mcp/src/blank_line_filter.rs
@@ -1,0 +1,159 @@
+//! An `AsyncRead` that drops blank lines before the JSON-RPC parser sees them.
+//!
+//! A single empty line on stdin terminated the server with exit code 0. So did
+//! a line of non-JSON. rmcp reports both as `QuitReason::Closed`, the same
+//! value a clean client disconnect produces, so nothing downstream could tell
+//! them apart: a supervisor saw a successful shutdown, and any in-flight
+//! request was lost with no error.
+//!
+//! Only the blank-line case can be fixed without second-guessing the protocol,
+//! and it is the one that happens by accident — a client that flushes a stray
+//! newline, a shell pipeline that appends one, a human testing by hand. A line
+//! with actual content that is not valid JSON is a genuine protocol violation
+//! and is left to rmcp.
+//!
+//! The filter is line-oriented because the transport is: messages are
+//! newline-delimited, so dropping a line that holds nothing but whitespace
+//! cannot split or corrupt a message. It never buffers more than one line.
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf};
+
+/// Wraps a byte stream and forwards every line except the blank ones.
+pub struct SkipBlankLines<R> {
+    inner: BufReader<R>,
+    /// The current line, still to be handed to the caller, and how much of it
+    /// has been handed over already.
+    pending: Vec<u8>,
+    offset: usize,
+    done: bool,
+}
+
+impl<R: AsyncRead + Unpin> SkipBlankLines<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner: BufReader::new(inner),
+            pending: Vec::new(),
+            offset: 0,
+            done: false,
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for SkipBlankLines<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        loop {
+            // Hand over whatever of the current line is left.
+            if this.offset < this.pending.len() {
+                let n = std::cmp::min(buf.remaining(), this.pending.len() - this.offset);
+                buf.put_slice(&this.pending[this.offset..this.offset + n]);
+                this.offset += n;
+                return Poll::Ready(Ok(()));
+            }
+            if this.done {
+                return Poll::Ready(Ok(()));
+            }
+
+            // Pull the next line, skipping any that hold only whitespace.
+            this.pending.clear();
+            this.offset = 0;
+            match Pin::new(&mut this.inner).poll_fill_buf(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(available)) => {
+                    if available.is_empty() {
+                        this.done = true;
+                        return Poll::Ready(Ok(()));
+                    }
+                    let take = match available.iter().position(|b| *b == b'\n') {
+                        Some(at) => at + 1,
+                        // No newline yet: take what there is and come back for
+                        // the rest. A partial line is never judged blank.
+                        None => available.len(),
+                    };
+                    this.pending.extend_from_slice(&available[..take]);
+                    Pin::new(&mut this.inner).consume(take);
+
+                    let complete = this.pending.last() == Some(&b'\n');
+                    if complete && this.pending.iter().all(|b| b.is_ascii_whitespace()) {
+                        // A blank line. Drop it and look at the next one.
+                        this.pending.clear();
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    async fn filtered(input: &str) -> String {
+        let mut out = String::new();
+        SkipBlankLines::new(input.as_bytes())
+            .read_to_string(&mut out)
+            .await
+            .expect("read");
+        out
+    }
+
+    #[tokio::test]
+    async fn blank_lines_are_dropped_and_messages_are_not() {
+        assert_eq!(filtered("{\"a\":1}\n").await, "{\"a\":1}\n");
+        assert_eq!(filtered("\n{\"a\":1}\n").await, "{\"a\":1}\n");
+        assert_eq!(
+            filtered("{\"a\":1}\n\n\n{\"b\":2}\n").await,
+            "{\"a\":1}\n{\"b\":2}\n"
+        );
+        assert_eq!(filtered("\n\n\n").await, "");
+        // Whitespace-only counts as blank; whitespace around content does not.
+        assert_eq!(filtered("   \t \n{\"a\":1}\n").await, "{\"a\":1}\n");
+        assert_eq!(filtered("  {\"a\":1}  \n").await, "  {\"a\":1}  \n");
+    }
+
+    /// A line with content that is not JSON is a protocol violation, not an
+    /// accident, and must still reach rmcp rather than being swallowed here.
+    #[tokio::test]
+    async fn non_json_content_is_passed_through() {
+        assert_eq!(filtered("garbage\n").await, "garbage\n");
+    }
+
+    /// The last line may have no terminator; it must not be judged blank on the
+    /// strength of an incomplete read, and must not be lost.
+    #[tokio::test]
+    async fn a_final_line_without_a_newline_survives() {
+        assert_eq!(filtered("{\"a\":1}").await, "{\"a\":1}");
+        assert_eq!(
+            filtered("{\"a\":1}\n{\"b\":2}").await,
+            "{\"a\":1}\n{\"b\":2}"
+        );
+    }
+
+    /// Reading through a tiny buffer must not change what comes out.
+    #[tokio::test]
+    async fn output_does_not_depend_on_read_size() {
+        let input = "\n{\"a\":1}\n\n{\"b\":2}\n\n";
+        let mut reader = SkipBlankLines::new(input.as_bytes());
+        let mut out = Vec::new();
+        let mut one = [0u8; 1];
+        loop {
+            let n = reader.read(&mut one).await.expect("read");
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&one[..n]);
+        }
+        assert_eq!(String::from_utf8(out).unwrap(), "{\"a\":1}\n{\"b\":2}\n");
+    }
+}

--- a/crates/applications/mcp/src/lib.rs
+++ b/crates/applications/mcp/src/lib.rs
@@ -7,6 +7,7 @@
 //! `#[tool_router]` + tools and `impl ServerHandler` with `get_info()`, then served
 //! over stdio or streamable HTTP (see [docs/http-service.md](docs/http-service.md)).
 
+pub mod blank_line_filter;
 mod tools;
 
 pub use tools::GfsMcpHandler;

--- a/crates/applications/mcp/src/main.rs
+++ b/crates/applications/mcp/src/main.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 
 use axum::Router;
 use gfs_mcp::GfsMcpHandler;
+use gfs_mcp::blank_line_filter::SkipBlankLines;
 use rmcp::ServiceExt;
 use rmcp::transport::{
     StreamableHttpServerConfig, stdio,
@@ -75,7 +76,16 @@ async fn run_stdio(
         "gfs-mcp starting (stdio transport)"
     );
 
-    let service = match GfsMcpHandler::new().serve(stdio()).await {
+    // Stdin goes through a filter that drops blank lines. Without it a single
+    // stray newline terminated the server with exit code 0 — indistinguishable
+    // from a clean client disconnect, so a supervisor saw a successful shutdown
+    // and any in-flight request was lost with no error. See
+    // `blank_line_filter` for why only blank lines are filtered.
+    let (input, output) = stdio();
+    let service = match GfsMcpHandler::new()
+        .serve((SkipBlankLines::new(input), output))
+        .await
+    {
         Ok(s) => s,
         Err(e) => {
             let msg = e.to_string();

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -93,6 +93,20 @@ fn json_ok(value: serde_json::Value) -> Result<CallToolResult, McpError> {
     )]))
 }
 
+/// Report a failure of the tool's WORK as a tool result the model can read.
+///
+/// The distinction from [`to_error_data`] is deliberate and is the one MCP
+/// draws: a JSON-RPC error means the request could not be processed at all —
+/// a missing or malformed argument — while a result carrying `isError` means
+/// the tool ran and the operation failed, which is something a model can read
+/// and act on.
+///
+/// The server used to mix these for one class of failure: a missing `message`
+/// on `commit` came back as a JSON-RPC error (rmcp's own schema validation),
+/// while a missing `revision` on `checkout` came back as an `isError` result.
+/// Same kind of mistake, two shapes, and a client had to handle both. Every
+/// argument check now takes the JSON-RPC path, which is what rmcp already does
+/// for the ones declared in the schema.
 fn json_err(message: &str, code: Option<&str>) -> Result<CallToolResult, McpError> {
     let mut obj = json!({ "message": message });
     if let Some(c) = code {
@@ -695,7 +709,7 @@ async fn do_status(args: &serde_json::Value) -> Result<CallToolResult, McpError>
 
 async fn do_commit(args: &serde_json::Value) -> Result<CallToolResult, McpError> {
     let args = if !args.is_object() {
-        return json_err("missing arguments: message required", Some("MISSING_ARGS"));
+        return Err(to_error_data("missing required argument: message"));
     } else {
         args
     };
@@ -705,7 +719,7 @@ async fn do_commit(args: &serde_json::Value) -> Result<CallToolResult, McpError>
         .unwrap_or("")
         .trim();
     if message.is_empty() {
-        return json_err("commit message must be non-empty", Some("INVALID_INPUT"));
+        return Err(to_error_data("invalid argument: message must be non-empty"));
     }
     let repo_path = repo_path_from_value(args);
     let author = args
@@ -876,10 +890,9 @@ async fn do_checkout(args: &serde_json::Value) -> Result<CallToolResult, McpErro
         (None, Some(b)) => (String::new(), Some(b.clone())),
         (Some(r), Some(b)) => (r.clone(), Some(b.clone())),
         (None, None) => {
-            return json_err(
-                "revision required or use create_branch",
-                Some("MISSING_ARGS"),
-            );
+            return Err(to_error_data(
+                "missing required argument: revision (or create_branch to make one)",
+            ));
         }
     };
 
@@ -1082,13 +1095,10 @@ async fn do_compute(args: &serde_json::Value) -> Result<CallToolResult, McpError
             json!({ "entries": lines })
         }
         _ => {
-            return json_err(
-                &format!(
-                    "unknown action: {} (use status, start, stop, restart, pause, unpause, logs)",
-                    action
-                ),
-                Some("INVALID_INPUT"),
-            );
+            return Err(to_error_data(format!(
+                "invalid argument: unknown action '{action}' \
+                 (use status, start, stop, restart, pause, unpause, logs)"
+            )));
         }
     };
 
@@ -1244,10 +1254,9 @@ async fn do_export(args: &serde_json::Value) -> Result<CallToolResult, McpError>
         .unwrap_or("")
         .trim();
     if format.is_empty() {
-        return json_err(
-            "format is required (e.g. sql, custom)",
-            Some("MISSING_ARGS"),
-        );
+        return Err(to_error_data(
+            "missing required argument: format (e.g. sql, custom)",
+        ));
     }
 
     let output_dir = args

--- a/crates/domain/src/model/config.rs
+++ b/crates/domain/src/model/config.rs
@@ -105,7 +105,20 @@ pub struct GfsConfig {
 impl GfsConfig {
     pub fn load(repo_path: &Path) -> Result<Self, RepoError> {
         let config_path = repo_path.join(GFS_DIR).join(CONFIG_FILE);
-        let content = std::fs::read_to_string(config_path)?;
+        // A missing config is the ordinary "this is not a repository" case and
+        // deserves to say so. Letting `?` convert it made every one of them
+        // read "IO error while searching for repository: No such file or
+        // directory" — which names a file the caller never mentioned, is
+        // identical whether the directory exists or not, and describes a search
+        // this function does not perform. Other IO errors (a permission
+        // problem, a bad symlink) still surface as themselves.
+        let content = match std::fs::read_to_string(&config_path) {
+            Ok(content) => content,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(RepoError::NotARepository(repo_path.to_path_buf()));
+            }
+            Err(e) => return Err(RepoError::from(e)),
+        };
         let config =
             toml::from_str(&content).map_err(|e| RepoError::InvalidConfig(e.to_string()))?;
         Ok(config)

--- a/crates/domain/src/model/errors.rs
+++ b/crates/domain/src/model/errors.rs
@@ -35,6 +35,8 @@ pub enum CommitError {
 pub enum RepoError {
     #[error("No .gfs repository found in {0} or any parent directory")]
     NoRepoFound(PathBuf),
+    #[error("not a GFS repository: '{0}' has no .gfs directory (run `gfs init` there)")]
+    NotARepository(PathBuf),
     #[error("IO error while searching for repository: {0}")]
     IoError(#[from] io::Error),
     #[error("Invalid repository layout: {0}")]


### PR DESCRIPTION
Three findings from a blind audit. None is provider-specific, and all three were reproduced on **unmodified `main`** before anything was changed.

## 1. A blank line on stdin terminates the server with exit code 0

rmcp reports it as `QuitReason::Closed` — the same value a clean client disconnect produces — so nothing downstream can tell the two apart. A supervisor sees a successful shutdown; any in-flight request is lost with no error and no restart.

The distinction does not exist at that layer, so the fix has to sit upstream of it. Stdin now passes through a line-oriented filter that drops lines holding only whitespace. The transport is newline-delimited, so removing such a line cannot split or corrupt a message, and the filter never holds more than one line in memory.

**Only blank lines are filtered.** A line with content that is not JSON is a genuine protocol violation rather than an accident, and remains rmcp's to decide. The blank line is the one that happens by mistake — a client that flushes a stray newline, a shell pipeline that appends one, a human testing by hand.

```console
before:  "\n"        → process exits, code 0
after:   "\n"        → ignored; tools/list still answered
         "garbage\n" → still terminates (unchanged, and correct)
```

## 2. One class of failure had two shapes

| call | before |
|---|---|
| `commit` with no `message` | JSON-RPC error (rmcp schema validation) |
| `checkout` with no `revision` | tool result with `isError` and a `MISSING_ARGS` code |

Same kind of mistake, two shapes, and a client had to handle both — with neither documented.

Every argument check now takes the JSON-RPC path, matching what rmcp already does for arguments declared in the schema. The distinction that remains is the one MCP actually draws, and it is now written down where `json_err` is defined:

- **JSON-RPC error** — the request could not be processed (missing or malformed argument);
- **result with `isError`** — the tool ran and the work failed, which a model can read and act on.

Exactly one call site keeps the second shape: the query failure, which is the one that should.

## 3. "No such file or directory" for a directory that exists

`GfsConfig::load` let `?` convert a missing `.gfs/config.toml` into an IO error, so every "not a repository" case read:

```
error: internal error: IO error while searching for repository: No such file or directory (os error 2)
```

That names a file the caller never mentioned, is **identical whether the directory exists or not**, and describes a search this function does not perform. Both skill files' troubleshooting sections promise a "repository not found" concept the product never emitted.

```
after:  error: not a GFS repository: '<path>' has no .gfs directory (run `gfs init` there)
```

Only `NotFound` is reclassified — a permission problem or a bad symlink still surfaces as itself.

## Verification

Four unit tests for the filter: blank lines, whitespace-only lines, non-JSON passthrough, a final line with no terminator, and reading **one byte at a time** — the last because a filter whose output depends on the read size is worse than no filter.

The transport fix was also driven end to end against the built server: blank and whitespace-only lines are absorbed and `tools/list` still answers afterwards; `garbage\n` still ends the session.

`gfs-domain` 254, `gfs-mcp` 7, `e2e_checkout` 4, `e2e_query` 1. `fmt` and `clippy -D warnings` clean.