### PR TITLE
fix(branch): make `branch -d` recoverable instead of silently destructive (stacked on #76)

### DIFF
--- a/crates/adapters/compute-docker/tests/manage_users_it.rs
+++ b/crates/adapters/compute-docker/tests/manage_users_it.rs
@@ -88,6 +88,7 @@ fn write_repo(path: &std::path::Path, container: &str) {
         }),
         storage: None,
         compute: None,
+        deleted_branch_retention_days: None,
     };
     config.save(path).expect("save config");
 }

--- a/crates/adapters/compute-docker/tests/query_in_instance_it.rs
+++ b/crates/adapters/compute-docker/tests/query_in_instance_it.rs
@@ -43,6 +43,7 @@ fn write_repo(path: &std::path::Path, container: &str) {
         }),
         storage: None,
         compute: None,
+        deleted_branch_retention_days: None,
     };
     config.save(path).expect("save config");
 }

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -226,6 +226,11 @@ async fn create_branch(
 // ---------------------------------------------------------------------------
 
 fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> Result<()> {
+    // Before the current-branch guard, which compares raw strings: `./main` and
+    // `../heads/main` are not equal to `main` but resolve to it once joined onto
+    // a path, so an unvalidated name walks straight past the guard.
+    repo_layout::validate_branch_name(name)?;
+
     let current = repo_layout::get_current_branch(repo_path).unwrap_or_default();
     if name == current {
         anyhow::bail!("cannot delete the currently checked out branch '{}'", name);
@@ -246,7 +251,7 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
         .with_context(|| format!("failed to delete branch ref '{}'", name))?;
 
     // No background process and no collector yet, so expiry is enforced here.
-    let retention_ms = deleted_retention_days(repo_path) * 24 * 60 * 60 * 1000;
+    let retention_ms = retention_ms(repo_path);
     let _ = repo_layout::prune_expired_deleted_refs(repo_path, retention_ms);
 
     // The working copy outlives the ref unless it goes here too. It is keyed by
@@ -317,6 +322,15 @@ fn deleted_retention_days(repo_path: &std::path::Path) -> u64 {
         .unwrap_or(DEFAULT_DELETED_RETENTION_DAYS)
 }
 
+/// The retention window in milliseconds.
+///
+/// Saturating: a config of `u64::MAX / 2` days would otherwise wrap and produce
+/// a window of a few hours, so the largest-looking settings would give some of
+/// the shortest windows.
+fn retention_ms(repo_path: &std::path::Path) -> u64 {
+    deleted_retention_days(repo_path).saturating_mul(24 * 60 * 60 * 1000)
+}
+
 fn format_age(deleted_at_ms: u64) -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -332,17 +346,23 @@ fn format_age(deleted_at_ms: u64) -> String {
 }
 
 fn list_deleted(repo_path: &std::path::Path, json_output: bool) -> Result<()> {
-    let entries = repo_layout::list_deleted_branch_refs(repo_path)
+    let entries = repo_layout::list_recoverable_branch_refs(repo_path, retention_ms(repo_path))
         .context("failed to read deleted branch refs")?;
 
     if json_output {
+        // `restorable` marks the entry `--restore <name>` would pick, so a JSON
+        // consumer does not have to re-derive it by max-timestamp per name.
+        let mut seen: Vec<&str> = Vec::new();
         let rows: Vec<_> = entries
             .iter()
             .map(|d| {
+                let restorable = !seen.contains(&d.name.as_str());
+                seen.push(d.name.as_str());
                 json!({
                     "branch": d.name,
                     "commit": d.commit_hash,
                     "deleted_at_ms": d.deleted_at_ms,
+                    "restorable": restorable,
                 })
             })
             .collect();
@@ -410,8 +430,32 @@ fn restore_branch(repo_path: &std::path::Path, name: &str, json_output: bool) ->
             name
         );
     }
+    // The mirror case: restoring `a/b` needs `refs/heads/a` to be a directory,
+    // but a live branch `a` is a file there. Neither check above fires — the
+    // target itself does not exist — and the failure would otherwise surface as
+    // a bare ENOTDIR with the cause hidden by `{}` formatting.
+    let heads = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
+    let mut ancestor = heads.clone();
+    for segment in name.split('/').filter(|s| !s.is_empty()) {
+        if ancestor.is_file() {
+            let blocking = ancestor
+                .strip_prefix(&heads)
+                .unwrap_or(&ancestor)
+                .to_string_lossy()
+                .to_string();
+            anyhow::bail!(
+                "'{}' cannot be restored while branch '{}' exists: a ref is a file, \
+                 so '{}' cannot also be a directory. Delete or rename '{}' first",
+                name,
+                blocking,
+                blocking,
+                blocking
+            );
+        }
+        ancestor = ancestor.join(segment);
+    }
 
-    let available = repo_layout::list_deleted_branch_refs(repo_path)
+    let available = repo_layout::list_recoverable_branch_refs(repo_path, retention_ms(repo_path))
         .context("failed to read deleted branch refs")?;
     if !available.iter().any(|d| d.name == name) {
         if available.is_empty() {

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -154,6 +154,8 @@ async fn create_branch(
             Some(repo_path.to_path_buf()),
             start_point.map(|s| s.to_string()),
             Some(name.to_string()),
+            // Creating a branch must not silently discard work either.
+            false,
             json_output,
         )
         .await;
@@ -226,6 +228,27 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
 
     std::fs::remove_file(&ref_path)
         .with_context(|| format!("failed to delete branch ref '{}'", name))?;
+
+    // The working copy outlives the ref unless it goes here too. It is keyed by
+    // branch NAME, so a later branch reusing the name would inherit this one's
+    // workspace. Reported rather than ignored: a workspace that silently failed
+    // to go is exactly the state this is meant to prevent.
+    let workspace = repo_layout::branch_workspace_dir(repo_path, name);
+    if workspace.exists() {
+        #[cfg(unix)]
+        let _ = std::process::Command::new("chmod")
+            .args(["-R", "u+w"])
+            .arg(&workspace)
+            .output();
+        std::fs::remove_dir_all(&workspace).with_context(|| {
+            format!(
+                "branch ref '{}' was deleted but its workspace at '{}' could not be removed; \
+                 remove it before creating a branch of the same name",
+                name,
+                workspace.display()
+            )
+        })?;
+    }
 
     // Clean up empty parent directories (for nested branches like feature/foo).
     let mut parent = ref_path.parent();

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -248,7 +248,7 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
     // any branch name — so unlinking makes the name unrecoverable even though
     // every commit survives on disk.
     let deleted = repo_layout::soft_delete_branch_ref(repo_path, name)
-        .with_context(|| format!("failed to delete branch ref '{}'", name))?;
+        .with_context(|| format!("failed to move branch ref '{}' aside", name))?;
 
     // No background process and no collector yet, so expiry is enforced here.
     let retention_ms = retention_ms(repo_path);
@@ -303,7 +303,9 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
     println!("{} Deleted branch '{}'", green("✓"), name);
     println!(
         "  {}",
-        dimmed(format!("restore with: gfs branch --restore {}", name))
+        dimmed(format!(
+            "restore with: gfs branch --restore {name}  (restores committed work)"
+        ))
     );
     Ok(())
 }
@@ -316,10 +318,21 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
 /// A malformed or missing config is not worth failing a delete over, so this
 /// falls back rather than propagating.
 fn deleted_retention_days(repo_path: &std::path::Path) -> u64 {
-    GfsConfig::load(repo_path)
-        .ok()
-        .and_then(|c| c.deleted_branch_retention_days)
-        .unwrap_or(DEFAULT_DELETED_RETENTION_DAYS)
+    match GfsConfig::load(repo_path) {
+        Ok(config) => config
+            .deleted_branch_retention_days
+            .unwrap_or(DEFAULT_DELETED_RETENTION_DAYS),
+        Err(e) => {
+            // Falling back silently would apply the default to a repo whose
+            // owner configured something shorter, retaining data longer than
+            // they asked. Not fatal, but not silent either.
+            tracing::warn!(
+                "could not read config ({e}); using the default deleted-branch \
+                 retention of {DEFAULT_DELETED_RETENTION_DAYS} days"
+            );
+            DEFAULT_DELETED_RETENTION_DAYS
+        }
+    }
 }
 
 /// The retention window in milliseconds.
@@ -366,7 +379,10 @@ fn list_deleted(repo_path: &std::path::Path, json_output: bool) -> Result<()> {
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&json!(rows))?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "deleted": rows }))?
+        );
         return Ok(());
     }
 
@@ -404,6 +420,47 @@ fn list_deleted(repo_path: &std::path::Path, json_output: bool) -> Result<()> {
 }
 
 fn restore_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> Result<()> {
+    // Availability is decided first. Asking "is the name taken?" before "is
+    // there anything to restore?" reports a live branch that was never deleted
+    // as an overwrite hazard, naming a deleted branch that does not exist.
+    let available = repo_layout::list_recoverable_branch_refs(repo_path, retention_ms(repo_path))
+        .context("failed to read deleted branch refs")?;
+    if !available.iter().any(|d| d.name == name) {
+        if available.is_empty() {
+            anyhow::bail!(
+                "no deleted branch named '{}' is recoverable, and nothing else is either. \
+                 A branch is recoverable for {} days after deletion",
+                name,
+                deleted_retention_days(repo_path)
+            );
+        }
+        let mut names: Vec<&str> = available.iter().map(|d| d.name.as_str()).collect();
+        names.sort_unstable();
+        names.dedup();
+        anyhow::bail!(
+            "no deleted branch named '{}' is recoverable. Recoverable: {}",
+            name,
+            names.join(", ")
+        );
+    }
+
+    // Checked here as well as in the domain, for the same reason as the checks
+    // below: the domain's message would be wrapped by `with_context` and hidden
+    // by `{}` formatting, leaving only "failed to restore branch 'x'".
+    if let Some(entry) = available.iter().find(|d| d.name == name) {
+        let names_a_commit = entry.commit_hash == "0"
+            || (entry.commit_hash.len() == 64
+                && entry.commit_hash.chars().all(|c| c.is_ascii_hexdigit()));
+        if !names_a_commit {
+            anyhow::bail!(
+                "the stored entry for '{}' does not name a commit, so restoring it would \
+                 create a branch nothing can resolve. Found: {:?}",
+                name,
+                entry.commit_hash
+            );
+        }
+    }
+
     // Checked here rather than relying on the error chain: `main` renders an
     // anyhow error with `{}`, which shows only the outermost context, so a
     // wrapped cause would be invisible to the user.
@@ -455,29 +512,9 @@ fn restore_branch(repo_path: &std::path::Path, name: &str, json_output: bool) ->
         ancestor = ancestor.join(segment);
     }
 
-    let available = repo_layout::list_recoverable_branch_refs(repo_path, retention_ms(repo_path))
-        .context("failed to read deleted branch refs")?;
-    if !available.iter().any(|d| d.name == name) {
-        if available.is_empty() {
-            anyhow::bail!(
-                "no deleted branch named '{}' is recoverable, and nothing else is either. \
-                 A branch is recoverable for {} days after deletion",
-                name,
-                deleted_retention_days(repo_path)
-            );
-        }
-        let mut names: Vec<&str> = available.iter().map(|d| d.name.as_str()).collect();
-        names.sort_unstable();
-        names.dedup();
-        anyhow::bail!(
-            "no deleted branch named '{}' is recoverable. Recoverable: {}",
-            name,
-            names.join(", ")
-        );
-    }
-
-    let restored = repo_layout::restore_deleted_branch_ref(repo_path, name)
-        .with_context(|| format!("failed to restore branch '{}'", name))?;
+    let restored =
+        repo_layout::restore_deleted_branch_ref(repo_path, name, retention_ms(repo_path))
+            .with_context(|| format!("failed to restore branch '{}'", name))?;
 
     if json_output {
         println!(

--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use gfs_domain::adapters::gfs_repository::GfsRepository;
+use gfs_domain::model::config::{DEFAULT_DELETED_RETENTION_DAYS, GfsConfig};
 use gfs_domain::model::layout::{GFS_DIR, HEADS_DIR, REFS_DIR};
 use gfs_domain::ports::repository::Repository;
 use gfs_domain::repo_utils::repo_layout;
@@ -23,15 +24,26 @@ use crate::output::{cyan, dimmed, gold, green};
 // Entry point
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     path: Option<PathBuf>,
     name: Option<String>,
     start_point: Option<String>,
     delete: Option<String>,
     switch: bool,
+    deleted: bool,
+    restore: Option<String>,
     json_output: bool,
 ) -> Result<()> {
     let repo_path = path.clone().unwrap_or_else(get_repo_dir);
+
+    if let Some(ref branch_name) = restore {
+        return restore_branch(&repo_path, branch_name, json_output);
+    }
+
+    if deleted {
+        return list_deleted(&repo_path, json_output);
+    }
 
     if let Some(ref branch_name) = delete {
         return delete_branch(&repo_path, branch_name, json_output);
@@ -226,8 +238,16 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
         anyhow::bail!("branch '{}' not found", name);
     }
 
-    std::fs::remove_file(&ref_path)
+    // Moved aside, not unlinked. The ref file holds the only record of which
+    // commit this branch pointed at — a commit object stores its parents but not
+    // any branch name — so unlinking makes the name unrecoverable even though
+    // every commit survives on disk.
+    let deleted = repo_layout::soft_delete_branch_ref(repo_path, name)
         .with_context(|| format!("failed to delete branch ref '{}'", name))?;
+
+    // No background process and no collector yet, so expiry is enforced here.
+    let retention_ms = deleted_retention_days(repo_path) * 24 * 60 * 60 * 1000;
+    let _ = repo_layout::prune_expired_deleted_refs(repo_path, retention_ms);
 
     // The working copy outlives the ref unless it goes here too. It is keyed by
     // branch NAME, so a later branch reusing the name would inherit this one's
@@ -268,11 +288,175 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
             serde_json::to_string_pretty(&json!({
                 "action": "delete",
                 "branch": name,
+                "commit": deleted.commit_hash,
+                "recoverable": true,
             }))?
         );
         return Ok(());
     }
 
     println!("{} Deleted branch '{}'", green("✓"), name);
+    println!(
+        "  {}",
+        dimmed(format!("restore with: gfs branch --restore {}", name))
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Deleted branches
+// ---------------------------------------------------------------------------
+
+/// Retention window in days, from config, falling back to the built-in default.
+/// A malformed or missing config is not worth failing a delete over, so this
+/// falls back rather than propagating.
+fn deleted_retention_days(repo_path: &std::path::Path) -> u64 {
+    GfsConfig::load(repo_path)
+        .ok()
+        .and_then(|c| c.deleted_branch_retention_days)
+        .unwrap_or(DEFAULT_DELETED_RETENTION_DAYS)
+}
+
+fn format_age(deleted_at_ms: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let secs = now.saturating_sub(deleted_at_ms) / 1000;
+    match secs {
+        s if s < 60 => format!("{s}s ago"),
+        s if s < 3600 => format!("{}m ago", s / 60),
+        s if s < 86_400 => format!("{}h ago", s / 3600),
+        s => format!("{}d ago", s / 86_400),
+    }
+}
+
+fn list_deleted(repo_path: &std::path::Path, json_output: bool) -> Result<()> {
+    let entries = repo_layout::list_deleted_branch_refs(repo_path)
+        .context("failed to read deleted branch refs")?;
+
+    if json_output {
+        let rows: Vec<_> = entries
+            .iter()
+            .map(|d| {
+                json!({
+                    "branch": d.name,
+                    "commit": d.commit_hash,
+                    "deleted_at_ms": d.deleted_at_ms,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json!(rows))?);
+        return Ok(());
+    }
+
+    if entries.is_empty() {
+        println!("{}", dimmed("No deleted branches are recoverable."));
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        dimmed(format!(
+            "Recoverable for {} days after deletion:",
+            deleted_retention_days(repo_path)
+        ))
+    );
+    // Entries are newest-first, so the first occurrence of a name is the one
+    // `--restore` would pick. Repeated deletions of the same name are shown
+    // rather than collapsed, but only one of them is actionable.
+    let mut seen: Vec<&str> = Vec::new();
+    for d in &entries {
+        let short: String = d.commit_hash.chars().take(7).collect();
+        let newest = !seen.contains(&d.name.as_str());
+        seen.push(d.name.as_str());
+        println!(
+            "  {}  {}  {}{}",
+            cyan(&d.name),
+            gold(&short),
+            dimmed(format_age(d.deleted_at_ms)),
+            if newest { "" } else { " (older deletion)" }
+        );
+    }
+    println!();
+    println!("{}", dimmed("restore with: gfs branch --restore <name>"));
+    Ok(())
+}
+
+fn restore_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> Result<()> {
+    // Checked here rather than relying on the error chain: `main` renders an
+    // anyhow error with `{}`, which shows only the outermost context, so a
+    // wrapped cause would be invisible to the user.
+    let live = repo_path
+        .join(GFS_DIR)
+        .join(REFS_DIR)
+        .join(HEADS_DIR)
+        .join(name);
+    // `is_file`, not `exists`: `refs/heads/a` is also a directory when `a/b` is
+    // live. Both block the restore, but for different reasons and with
+    // different advice.
+    if live.is_file() {
+        anyhow::bail!(
+            "branch '{}' already exists, so restoring the deleted one would overwrite it. \
+             Rename or delete the existing branch first",
+            name
+        );
+    }
+    if live.is_dir() {
+        anyhow::bail!(
+            "'{}' cannot be restored while branches nested under it exist \
+             (a ref is a file, so it cannot also be a directory). \
+             Delete or rename those branches first",
+            name
+        );
+    }
+
+    let available = repo_layout::list_deleted_branch_refs(repo_path)
+        .context("failed to read deleted branch refs")?;
+    if !available.iter().any(|d| d.name == name) {
+        if available.is_empty() {
+            anyhow::bail!(
+                "no deleted branch named '{}' is recoverable, and nothing else is either. \
+                 A branch is recoverable for {} days after deletion",
+                name,
+                deleted_retention_days(repo_path)
+            );
+        }
+        let mut names: Vec<&str> = available.iter().map(|d| d.name.as_str()).collect();
+        names.sort_unstable();
+        names.dedup();
+        anyhow::bail!(
+            "no deleted branch named '{}' is recoverable. Recoverable: {}",
+            name,
+            names.join(", ")
+        );
+    }
+
+    let restored = repo_layout::restore_deleted_branch_ref(repo_path, name)
+        .with_context(|| format!("failed to restore branch '{}'", name))?;
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "action": "restore",
+                "branch": restored.name,
+                "commit": restored.commit_hash,
+            }))?
+        );
+        return Ok(());
+    }
+
+    let short: String = restored.commit_hash.chars().take(7).collect();
+    println!(
+        "{} Restored branch '{}' at {}",
+        green("\u{2713}"),
+        restored.name,
+        gold(&short)
+    );
+    println!(
+        "  {}",
+        dimmed(format!("check it out with: gfs checkout {}", restored.name))
+    );
     Ok(())
 }

--- a/crates/applications/cli/src/commands/cmd_checkout.rs
+++ b/crates/applications/cli/src/commands/cmd_checkout.rs
@@ -30,6 +30,7 @@ pub async fn checkout(
     path: Option<PathBuf>,
     revision: Option<String>,
     create_branch: Option<String>,
+    force: bool,
     json_output: bool,
 ) -> Result<()> {
     let repo_path = path.clone().unwrap_or_else(get_repo_dir);
@@ -130,7 +131,7 @@ pub async fn checkout(
 
         commit_hash
     } else {
-        let use_case = CheckoutRepoUseCase::new(repository, compute, registry);
+        let use_case = CheckoutRepoUseCase::new(repository, compute, registry).with_force(force);
         use_case
             .run(repo_path, revision.clone(), create_branch.clone())
             .await

--- a/crates/applications/cli/src/commands/cmd_config.rs
+++ b/crates/applications/cli/src/commands/cmd_config.rs
@@ -8,8 +8,8 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
-use gfs_domain::model::config::{GfsConfig, GlobalSettings};
+use anyhow::{Context, Result};
+use gfs_domain::model::config::{DEFAULT_DELETED_RETENTION_DAYS, GfsConfig, GlobalSettings};
 use gfs_domain::model::errors::RepoError;
 use gfs_domain::model::layout::GFS_DIR;
 use gfs_domain::repo_utils::repo_layout;
@@ -22,6 +22,7 @@ const KEY_USER_EMAIL: &str = "user.email";
 const KEY_STORAGE_COMPRESSION: &str = "storage.compression";
 const KEY_STORAGE_REFLINK: &str = "storage.reflink";
 const KEY_TELEMETRY_ENABLED: &str = "telemetry.enabled";
+const KEY_BRANCH_DELETED_RETENTION_DAYS: &str = "branch.deletedRetentionDays";
 
 const SUPPORTED_KEYS: &[&str] = &[
     KEY_USER_NAME,
@@ -29,6 +30,7 @@ const SUPPORTED_KEYS: &[&str] = &[
     KEY_STORAGE_COMPRESSION,
     KEY_STORAGE_REFLINK,
     KEY_TELEMETRY_ENABLED,
+    KEY_BRANCH_DELETED_RETENTION_DAYS,
 ];
 
 /// Run `gfs config [--global] [--path <dir>] <key> [<value>]`.
@@ -97,6 +99,10 @@ fn get(repo_path: &std::path::Path, key: &str) -> Result<()> {
             .as_ref()
             .map(|s| s.enable_reflink.to_string())
             .unwrap_or_default(),
+        KEY_BRANCH_DELETED_RETENTION_DAYS => config
+            .deleted_branch_retention_days
+            .map(|d| d.to_string())
+            .unwrap_or_else(|| DEFAULT_DELETED_RETENTION_DAYS.to_string()),
         KEY_TELEMETRY_ENABLED => {
             anyhow::bail!(
                 "'{}' is a global-only setting; use --global to read it",
@@ -169,6 +175,12 @@ fn set(repo_path: &std::path::Path, key: &str, value: &str) -> Result<()> {
             let mut storage = config.storage.clone().unwrap_or_default();
             storage.compression = Some(value.to_string());
             config.storage = Some(storage);
+        }
+        KEY_BRANCH_DELETED_RETENTION_DAYS => {
+            let days: u64 = value.parse().with_context(|| {
+                format!("'{key}' must be a whole number of days, got '{value}'")
+            })?;
+            config.deleted_branch_retention_days = Some(days);
         }
         KEY_STORAGE_REFLINK => {
             let mut storage = config.storage.clone().unwrap_or_default();

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -547,7 +547,7 @@ enum TopLevel {
         delete: Option<String>,
 
         /// Switch to the new branch after creating it (like checkout -b)
-        #[arg(short = 'c', long)]
+        #[arg(short = 'c', long, conflicts_with_all = ["deleted", "restore", "delete"])]
         checkout: bool,
 
         /// List deleted branches that can still be restored

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -543,7 +543,7 @@ enum TopLevel {
         start_point: Option<String>,
 
         /// Delete the named branch
-        #[arg(short = 'd', long)]
+        #[arg(short = 'd', long, conflicts_with_all = ["deleted", "restore"])]
         delete: Option<String>,
 
         /// Switch to the new branch after creating it (like checkout -b)
@@ -551,11 +551,11 @@ enum TopLevel {
         checkout: bool,
 
         /// List deleted branches that can still be restored
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["name", "start_point", "restore"])]
         deleted: bool,
 
         /// Restore a deleted branch by name
-        #[arg(long, value_name = "NAME")]
+        #[arg(long, value_name = "NAME", conflicts_with_all = ["name", "start_point"])]
         restore: Option<String>,
 
         /// Path to the GFS repository root (default: current directory)

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -517,6 +517,10 @@ enum TopLevel {
 
         /// Branch name or full 64-char commit hash; or start revision when using -b
         revision: Option<String>,
+
+        /// Discard uncommitted changes in the workspace instead of refusing
+        #[arg(long)]
+        force: bool,
     },
 
     /// Tear down the compute instance and remove the repository's .gfs store
@@ -932,8 +936,9 @@ where
                 path,
                 create_branch,
                 revision,
+                force,
             } => {
-                commands::cmd_checkout::checkout(path, revision, create_branch, json_output)
+                commands::cmd_checkout::checkout(path, revision, create_branch, force, json_output)
                     .await?;
                 Ok(0)
             }

--- a/crates/applications/cli/src/lib.rs
+++ b/crates/applications/cli/src/lib.rs
@@ -550,6 +550,14 @@ enum TopLevel {
         #[arg(short = 'c', long)]
         checkout: bool,
 
+        /// List deleted branches that can still be restored
+        #[arg(long)]
+        deleted: bool,
+
+        /// Restore a deleted branch by name
+        #[arg(long, value_name = "NAME")]
+        restore: Option<String>,
+
         /// Path to the GFS repository root (default: current directory)
         #[arg(long)]
         path: Option<PathBuf>,
@@ -951,10 +959,21 @@ where
                 start_point,
                 delete,
                 checkout,
+                deleted,
+                restore,
                 path,
             } => {
-                commands::cmd_branch::run(path, name, start_point, delete, checkout, json_output)
-                    .await?;
+                commands::cmd_branch::run(
+                    path,
+                    name,
+                    start_point,
+                    delete,
+                    checkout,
+                    deleted,
+                    restore,
+                    json_output,
+                )
+                .await?;
                 Ok(0)
             }
             TopLevel::Export {

--- a/crates/applications/cli/tests/e2e_checkout.rs
+++ b/crates/applications/cli/tests/e2e_checkout.rs
@@ -305,6 +305,85 @@ fn a_recreated_branch_does_not_inherit_the_deleted_one() {
     );
 }
 
+/// Deleting a branch must not destroy the only record of where it pointed.
+///
+/// A commit object stores its parents but no branch name, so once the ref file
+/// is gone the name -> tip binding exists nowhere: the commits survive on disk
+/// and can be found by scanning objects for dangling tips, but nothing says
+/// which of them was "b1". `branch -d` therefore moves the ref aside instead of
+/// unlinking it, and `--restore` puts it back.
+#[test]
+fn a_deleted_branch_can_be_restored_with_its_name_and_tip() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+    let repo = repo_path.to_str().unwrap();
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "-b", "b1"]).0);
+    fs::write(read_workspace_path(repo_path).join("only-on-b1.txt"), "x").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "b1 work", None, None).0);
+    let b1_tip = read_ref(repo_path, "b1");
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main"]).0);
+
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "-d", "b1"]).0);
+    assert!(
+        !repo_path.join(".gfs/refs/heads/b1").exists(),
+        "the live ref should be gone"
+    );
+
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "--restore", "b1"]).0);
+    assert_eq!(
+        read_ref(repo_path, "b1"),
+        b1_tip,
+        "the restored branch must point at the commit it was deleted at"
+    );
+
+    // The workspace went with the branch, so this also proves the restore is
+    // usable rather than just a ref on disk: checkout rebuilds it from the
+    // snapshot.
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "b1"]).0);
+    assert_eq!(
+        workspace_contents(repo_path),
+        "only-on-b1.txt=x seed.txt=v1",
+        "the restored branch checks out the content it had when deleted"
+    );
+}
+
+/// Restoring must not trade one lost branch for another.
+#[test]
+fn restoring_a_name_that_is_live_again_is_refused() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+    let repo = repo_path.to_str().unwrap();
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "-b", "b1"]).0);
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main"]).0);
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "-d", "b1"]).0);
+
+    // Same name, live again.
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "b1"]).0);
+    let live_tip = read_ref(repo_path, "b1");
+
+    assert!(
+        !cli_runner::run_gfs(["gfs", "branch", "--path", repo, "--restore", "b1"]).0,
+        "restore must fail rather than overwrite the live branch"
+    );
+    assert_eq!(
+        read_ref(repo_path, "b1"),
+        live_tip,
+        "the live branch must be untouched by the refused restore"
+    );
+}
+
 /// A commit hash names exactly one content state.
 ///
 /// The detached workspace is named by the hash, and was reused as-is, so

--- a/crates/applications/cli/tests/e2e_checkout.rs
+++ b/crates/applications/cli/tests/e2e_checkout.rs
@@ -173,3 +173,164 @@ fn checkout_zero_fails() {
         "stderr should mention no commits or 0; got: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Workspace identity: a checkout must give you what you asked for, and must
+// not silently destroy work to do it.
+// ---------------------------------------------------------------------------
+
+/// Sorted `name=content` for every file in the active workspace.
+fn workspace_contents(repo_path: &Path) -> String {
+    let dir = read_workspace_path(repo_path);
+    let mut out: Vec<String> = fs::read_dir(&dir)
+        .expect("read workspace")
+        .flatten()
+        .filter(|e| e.path().is_file())
+        .map(|e| {
+            format!(
+                "{}={}",
+                e.file_name().to_string_lossy(),
+                fs::read_to_string(e.path()).unwrap_or_default().trim()
+            )
+        })
+        .collect();
+    out.sort();
+    out.join(" ")
+}
+
+/// Uncommitted work is neither carried across a checkout nor thrown away.
+///
+/// Carrying it made `checkout <branch>` non-deterministic and left state no GFS
+/// command displays. Discarding it is unrecoverable. So checkout refuses,
+/// naming what is in the way, and `--force` is the way to say you meant it.
+#[test]
+fn checkout_refuses_to_overwrite_uncommitted_work_unless_forced() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "committed").unwrap();
+    let (ok, _, stderr) = cli_runner::gfs_commit(repo_path, "c1", None, None);
+    assert!(ok, "commit should succeed; stderr: {stderr}");
+
+    // A clean workspace is not in the way.
+    let (ok, _, stderr) = cli_runner::run_gfs([
+        "gfs",
+        "checkout",
+        "--path",
+        repo_path.to_str().unwrap(),
+        "main",
+    ]);
+    assert!(ok, "a clean checkout must not be refused; stderr: {stderr}");
+
+    fs::write(read_workspace_path(repo_path).join("scratch.txt"), "wip").unwrap();
+
+    let (ok, _, stderr) = cli_runner::run_gfs([
+        "gfs",
+        "checkout",
+        "--path",
+        repo_path.to_str().unwrap(),
+        "main",
+    ]);
+    assert!(!ok, "uncommitted work must stop the checkout");
+    assert!(
+        stderr.contains("uncommitted changes") && stderr.contains("scratch.txt"),
+        "the refusal should name what is in the way: {stderr}"
+    );
+    assert!(
+        read_workspace_path(repo_path).join("scratch.txt").exists(),
+        "a refused checkout must change nothing"
+    );
+
+    let (ok, _, stderr) = cli_runner::run_gfs([
+        "gfs",
+        "checkout",
+        "--path",
+        repo_path.to_str().unwrap(),
+        "main",
+        "--force",
+    ]);
+    assert!(ok, "--force should go through; stderr: {stderr}");
+    assert_eq!(
+        workspace_contents(repo_path),
+        "seed.txt=committed",
+        "forced checkout restores the commit exactly"
+    );
+}
+
+/// A branch's working copy must not outlive the branch.
+///
+/// The workspace is keyed by branch NAME, so a later branch reusing the name
+/// inherited the dead branch's working copy and `checkout` reported success
+/// while handing over content that branch never contained.
+#[test]
+fn a_recreated_branch_does_not_inherit_the_deleted_one() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+    fs::write(data_dir.join("seed.txt"), "v2").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c2", None, None).0);
+    let tip = read_ref(repo_path, "main");
+
+    let repo = repo_path.to_str().unwrap();
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "-b", "b1"]).0);
+    fs::write(read_workspace_path(repo_path).join("only-on-b1.txt"), "x").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "b1 work", None, None).0);
+    fs::write(
+        read_workspace_path(repo_path).join("never-committed.txt"),
+        "y",
+    )
+    .unwrap();
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main", "--force"]).0);
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "-d", "b1"]).0);
+    assert!(
+        !repo_path.join(".gfs/workspaces/b1").exists(),
+        "the workspace must go with the branch"
+    );
+
+    assert!(cli_runner::run_gfs(["gfs", "branch", "--path", repo, "b1", &tip]).0);
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "b1"]).0);
+    assert_eq!(
+        workspace_contents(repo_path),
+        "seed.txt=v2",
+        "the new b1 holds its own commit, not the deleted branch's working copy"
+    );
+}
+
+/// A commit hash names exactly one content state.
+///
+/// The detached workspace is named by the hash, and was reused as-is, so
+/// mutating one and returning to it gave you something other than what
+/// `Switched to <hash>` says you got.
+#[test]
+fn returning_to_a_detached_commit_gives_that_commit() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+
+    let data_dir = workspace_data_dir_main_0(repo_path);
+    fs::write(data_dir.join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+    let first = read_ref(repo_path, "main");
+    fs::write(data_dir.join("seed.txt"), "v2").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c2", None, None).0);
+
+    let repo = repo_path.to_str().unwrap();
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]).0);
+    assert_eq!(workspace_contents(repo_path), "seed.txt=v1");
+
+    fs::write(read_workspace_path(repo_path).join("poison.txt"), "z").unwrap();
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main", "--force"]).0);
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]).0);
+    assert_eq!(
+        workspace_contents(repo_path),
+        "seed.txt=v1",
+        "the commit's content, not what was left in its directory"
+    );
+}

--- a/crates/applications/cli/tests/e2e_checkout.rs
+++ b/crates/applications/cli/tests/e2e_checkout.rs
@@ -226,6 +226,8 @@ fn checkout_refuses_to_overwrite_uncommitted_work_unless_forced() {
 
     fs::write(read_workspace_path(repo_path).join("scratch.txt"), "wip").unwrap();
 
+    // Checking out the branch you are already on rebuilds this very directory,
+    // so the work in it is exactly what would be lost.
     let (ok, _, stderr) = cli_runner::run_gfs([
         "gfs",
         "checkout",
@@ -326,11 +328,66 @@ fn returning_to_a_detached_commit_gives_that_commit() {
     assert_eq!(workspace_contents(repo_path), "seed.txt=v1");
 
     fs::write(read_workspace_path(repo_path).join("poison.txt"), "z").unwrap();
-    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main", "--force"]).0);
-    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]).0);
+
+    // Leaving is fine: the detached directory is not the one being rebuilt.
+    assert!(
+        cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main"]).0,
+        "leaving a dirty workspace overwrites nothing, so it must not be refused"
+    );
+
+    // Returning is where it would be destroyed, so that is where the refusal is.
+    let (ok, _, stderr) = cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first]);
+    assert!(!ok, "returning would overwrite poison.txt");
+    assert!(stderr.contains("poison.txt"), "{stderr}");
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, &first, "--force"]).0);
     assert_eq!(
         workspace_contents(repo_path),
         "seed.txt=v1",
         "the commit's content, not what was left in its directory"
+    );
+}
+
+/// The refusal has to guard the workspace the restore REBUILDS, not the one
+/// being left behind.
+///
+/// Each branch has its own directory, so leaving a dirty branch overwrites
+/// nothing and must not be refused. The destructive moment is coming BACK: the
+/// target directory is rebuilt from its snapshot, and work left there is gone.
+/// Guarding the wrong side is both too strict and, more seriously, silent —
+/// walk away from dirty work on one branch and return to it from a clean one,
+/// and it is deleted with no refusal at all.
+#[test]
+fn the_refusal_guards_the_workspace_being_rebuilt_not_the_one_being_left() {
+    let tmp = tempdir().expect("create temp dir");
+    let repo_path = tmp.path();
+    assert!(cli_runner::gfs_init(repo_path), "gfs init should succeed");
+    let repo = repo_path.to_str().unwrap();
+
+    fs::write(workspace_data_dir_main_0(repo_path).join("seed.txt"), "v1").unwrap();
+    assert!(cli_runner::gfs_commit(repo_path, "c1", None, None).0);
+
+    assert!(cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "-b", "feature"]).0);
+    let feature_ws = read_workspace_path(repo_path);
+    fs::write(feature_ws.join("scratch.txt"), "wip").unwrap();
+
+    // Leaving: allowed, and the directory is left alone.
+    let (ok, _, stderr) = cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "main"]);
+    assert!(ok, "leaving must not be refused; stderr: {stderr}");
+    assert!(
+        feature_ws.join("scratch.txt").exists(),
+        "leaving must not touch the branch's directory"
+    );
+
+    // Returning: refused, from a workspace that is itself clean.
+    let (ok, _, stderr) = cli_runner::run_gfs(["gfs", "checkout", "--path", repo, "feature"]);
+    assert!(
+        !ok,
+        "returning would rebuild feature's directory and destroy scratch.txt"
+    );
+    assert!(stderr.contains("scratch.txt"), "{stderr}");
+    assert!(
+        feature_ws.join("scratch.txt").exists(),
+        "a refused checkout must change nothing"
     );
 }

--- a/crates/applications/mcp/src/tools.rs
+++ b/crates/applications/mcp/src/tools.rs
@@ -1935,6 +1935,7 @@ mod tests {
             }),
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         }
         .save(&repo)
         .expect("save .gfs config");

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -15,10 +15,7 @@ use async_trait::async_trait;
 use crate::model::commit::{Commit, CommitWithRefs, FileEntry, NewCommit, file_entry_diff_stats};
 use crate::model::config::{EnvironmentConfig, GfsConfig, RuntimeConfig, UserConfig};
 use crate::model::errors::RepoError;
-use crate::model::layout::{
-    BRANCH_WORKSPACE_SEGMENT, GFS_DIR, HEADS_DIR, OBJECTS_DIR, REFS_DIR, SNAPSHOTS_DIR,
-    WORKSPACE_DATA_DIR, WORKSPACES_DIR,
-};
+use crate::model::layout::{GFS_DIR, HEADS_DIR, OBJECTS_DIR, REFS_DIR, SNAPSHOTS_DIR};
 use crate::ports::repository::{LogOptions, RemoteOptions, Repository, RepositoryError, Result};
 use crate::repo_utils::repo_layout;
 use crate::utils::hash::hash_commit;
@@ -551,7 +548,10 @@ impl Repository for GfsRepository {
         }
 
         // Resolve revision to full commit hash.
-        let commit_hash = repo_layout::rev_parse(&repo, revision).map_err(map_err)?;
+        // Where this lands, decided in one place — `CheckoutRepoUseCase` asks the
+        // same function what is about to be overwritten before allowing it.
+        let (commit_hash, workspace_path) =
+            repo_layout::checkout_target(&repo, revision).map_err(map_err)?;
 
         // Reject initial state: cannot checkout "0".
         if commit_hash == "0" {
@@ -563,35 +563,12 @@ impl Repository for GfsRepository {
             return Err(RepositoryError::Internal(msg));
         }
 
-        // Determine HEAD update: branch name iff refs/heads/<revision> exists and tip matches.
-        let branch_segment = if repo_layout::is_branch(&repo, revision) {
-            let ref_path = repo
-                .join(GFS_DIR)
-                .join(REFS_DIR)
-                .join(HEADS_DIR)
-                .join(revision);
-            let tip = fs::read_to_string(&ref_path).map_err(RepositoryError::Io)?;
-            if tip.trim() == commit_hash {
-                revision.to_string()
-            } else {
-                "detached".to_string()
-            }
-        } else {
-            "detached".to_string()
-        };
-
-        // Workspace path: one persistent dir per branch (workspaces/<branch>/0/data), or per-commit when detached.
-        let workspace_segment = if branch_segment == "detached" {
-            repo_layout::short_commit_id_for_workspace(&commit_hash)
-        } else {
-            BRANCH_WORKSPACE_SEGMENT.to_string()
-        };
-        let workspace_path = repo
-            .join(GFS_DIR)
-            .join(WORKSPACES_DIR)
-            .join(&branch_segment)
-            .join(&workspace_segment)
-            .join(WORKSPACE_DATA_DIR);
+        let branch_segment = workspace_path
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "detached".to_string());
 
         // Always restore from the snapshot. Reusing a workspace that happens to
         // still be on disk made checkout non-deterministic in three ways: a
@@ -800,7 +777,9 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    use crate::model::layout::{CONFIG_FILE, HEAD_FILE, MAIN_BRANCH, WORKSPACE_FILE};
+    use crate::model::layout::{
+        CONFIG_FILE, HEAD_FILE, MAIN_BRANCH, WORKSPACE_DATA_DIR, WORKSPACE_FILE, WORKSPACES_DIR,
+    };
     use crate::ports::repository::{LogOptions, Repository};
     use crate::utils::hash::hash_commit;
 

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -593,14 +593,29 @@ impl Repository for GfsRepository {
             .join(&workspace_segment)
             .join(WORKSPACE_DATA_DIR);
 
-        // Only populate from snapshot when the workspace does not exist (preserve live DB state in branch workspace).
-        let workspace_exists = workspace_path.exists();
+        // Always restore from the snapshot. Reusing a workspace that happens to
+        // still be on disk made checkout non-deterministic in three ways: a
+        // deleted branch's working copy was inherited by a new branch that
+        // reused the name; returning to a detached commit gave you whatever you
+        // last left in its directory rather than that commit; and uncommitted
+        // changes leaked across a branch switch. `Switched to X` now means the
+        // workspace holds X.
+        //
+        // Nothing is discarded silently: `CheckoutRepoUseCase` refuses when the
+        // workspace has uncommitted work, and only passes through once the
+        // caller has committed it or asked for `--force`.
         tracing::info!(
             "Checkout: workspace_path={:?}, exists={}",
             workspace_path,
-            workspace_exists
+            workspace_path.exists()
         );
-        if !workspace_exists {
+        if workspace_path.exists() {
+            // Files restored from a snapshot carry its read-only bits, which
+            // `remove_dir_all` will not override.
+            let _ = set_workspace_dir_permissions(&workspace_path);
+            fs::remove_dir_all(&workspace_path).map_err(RepositoryError::Io)?;
+        }
+        {
             let commit = repo_layout::get_commit_from_hash(&repo, &commit_hash).map_err(map_err)?;
             let snapshot_hash = commit.snapshot_hash;
             let snapshot_dir = repo

--- a/crates/domain/src/model/config.rs
+++ b/crates/domain/src/model/config.rs
@@ -100,7 +100,15 @@ pub struct GfsConfig {
     pub storage: Option<StorageConfig>,
     #[serde(default)]
     pub compute: Option<ComputeConfig>,
+    /// How long `gfs branch -d` keeps a deleted branch restorable, in days.
+    /// Absent means the built-in default (see `DEFAULT_DELETED_RETENTION_DAYS`).
+    #[serde(default)]
+    pub deleted_branch_retention_days: Option<u64>,
 }
+
+/// Default window during which a deleted branch can be restored by name.
+/// Thirty days matches the restore window Neon and lakeFS settled on.
+pub const DEFAULT_DELETED_RETENTION_DAYS: u64 = 30;
 
 impl GfsConfig {
     pub fn load(repo_path: &Path) -> Result<Self, RepoError> {
@@ -272,6 +280,7 @@ mod tests {
                 enable_reflink: true,
             }),
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(dir.path()).unwrap();
 
@@ -338,6 +347,7 @@ mod tests {
             runtime: None,
             storage: None,
             compute: Some(ComputeConfig { params }),
+            deleted_branch_retention_days: None,
         };
         config.save(dir.path()).unwrap();
 
@@ -359,6 +369,7 @@ mod tests {
                 runtime: None,
                 storage: None,
                 compute: None,
+                deleted_branch_retention_days: None,
             }
             .compute_params()
             .is_empty()
@@ -377,6 +388,7 @@ mod tests {
             runtime: None,
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         // Pass path where .gfs does not exist; save writes to repo_path/.gfs/config.toml
         let result = config.save(dir.path());

--- a/crates/domain/src/model/layout.rs
+++ b/crates/domain/src/model/layout.rs
@@ -9,6 +9,11 @@ pub const HEAD_FILE: &str = "HEAD";
 pub const WORKSPACE_FILE: &str = "WORKSPACE";
 pub const REFS_DIR: &str = "refs";
 pub const HEADS_DIR: &str = "heads";
+/// Holds branch refs that `gfs branch -d` moved aside instead of unlinking, so a
+/// deleted branch can be restored by name. Entries live at
+/// `refs/deleted/<unix_millis>/<branch path>`; see `repo_layout::soft_delete_branch_ref`
+/// for why the timestamp is the outer segment.
+pub const DELETED_REFS_DIR: &str = "deleted";
 pub const MAIN_BRANCH: &str = "main";
 pub const CONFIG_FILE: &str = "config.toml";
 pub const OBJECTS_DIR: &str = "objects";

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -948,10 +948,20 @@ pub fn list_recoverable_branch_refs(
     repo_path: &Path,
     retention_ms: u64,
 ) -> Result<Vec<DeletedBranch>, RepoError> {
+    // Zero is special-cased rather than left to fall out of the comparison. With
+    // `cutoff == now`, an entry deleted in the current millisecond compares as
+    // still inside the window, so "no recovery at all" would depend on whether
+    // the clock ticked between the delete and the read.
+    if retention_ms == 0 {
+        return Ok(Vec::new());
+    }
+    // `>=` here and `<` in `prune_expired_deleted_refs` are complementary, so an
+    // entry exactly on the cutoff is listable rather than falling into a gap
+    // where it is neither shown nor collected.
     let cutoff = now_ms().saturating_sub(retention_ms);
     Ok(list_deleted_branch_refs(repo_path)?
         .into_iter()
-        .filter(|d| d.deleted_at_ms > cutoff)
+        .filter(|d| d.deleted_at_ms >= cutoff)
         .collect())
 }
 
@@ -963,6 +973,7 @@ pub fn list_recoverable_branch_refs(
 pub fn restore_deleted_branch_ref(
     repo_path: &Path,
     branch_name: &str,
+    retention_ms: u64,
 ) -> Result<DeletedBranch, RepoError> {
     validate_branch_name(branch_name)?;
     let live = repo_path
@@ -985,10 +996,26 @@ pub fn restore_deleted_branch_ref(
         )));
     }
 
-    let entry = list_deleted_branch_refs(repo_path)?
+    // Filtered here rather than only in the caller: retention is part of the
+    // guarantee, and a library consumer that skipped the check would silently
+    // restore branches the window says are gone.
+    let entry = list_recoverable_branch_refs(repo_path, retention_ms)?
         .into_iter()
         .find(|d| d.name == branch_name)
         .ok_or_else(|| RepoError::RevisionNotFound(branch_name.to_string()))?;
+
+    // A tombstone should name a commit. Restoring an unparseable one would
+    // produce a live ref that no command can resolve, and `checkout` would
+    // report a missing *repository* rather than a missing commit.
+    let looks_like_commit = entry.commit_hash == "0"
+        || (entry.commit_hash.len() == 64
+            && entry.commit_hash.chars().all(|c| c.is_ascii_hexdigit()));
+    if !looks_like_commit {
+        return Err(RepoError::invalid_layout(format!(
+            "the stored entry for '{branch_name}' does not name a commit, so restoring it \
+             would create a branch nothing can resolve"
+        )));
+    }
 
     let base = deleted_refs_dir(repo_path);
     let stored = base.join(entry.deleted_at_ms.to_string()).join(branch_name);
@@ -1597,7 +1624,7 @@ mod tests {
         assert_eq!(listed[0].name, "feature");
         assert_eq!(listed[0].commit_hash, "a".repeat(64));
 
-        let restored = restore_deleted_branch_ref(repo, "feature").unwrap();
+        let restored = restore_deleted_branch_ref(repo, "feature", u64::MAX).unwrap();
         assert_eq!(restored.commit_hash, "a".repeat(64));
         assert!(branch_exists(repo, "feature"));
         assert_eq!(
@@ -1626,7 +1653,7 @@ mod tests {
         soft_delete_branch_ref(repo, "feature").unwrap();
         write_branch(repo, "feature", "b".repeat(64).as_str());
 
-        assert!(restore_deleted_branch_ref(repo, "feature").is_err());
+        assert!(restore_deleted_branch_ref(repo, "feature", u64::MAX).is_err());
         assert_eq!(
             fs::read_to_string(
                 repo.join(GFS_DIR)
@@ -1668,7 +1695,7 @@ mod tests {
         names.sort_unstable();
         assert_eq!(names, vec!["a", "a/b"], "both deletions must survive");
 
-        let restored = restore_deleted_branch_ref(repo, "a/b").unwrap();
+        let restored = restore_deleted_branch_ref(repo, "a/b", u64::MAX).unwrap();
         assert_eq!(restored.commit_hash, "b".repeat(64));
         assert!(branch_exists(repo, "a/b"));
         assert!(
@@ -1693,7 +1720,7 @@ mod tests {
         );
 
         assert_eq!(list_deleted_branch_refs(repo).unwrap().len(), 2);
-        let restored = restore_deleted_branch_ref(repo, "feature").unwrap();
+        let restored = restore_deleted_branch_ref(repo, "feature", u64::MAX).unwrap();
         assert_eq!(
             restored.commit_hash,
             "b".repeat(64),

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -796,6 +796,43 @@ pub struct DeletedBranch {
     pub deleted_at_ms: u64,
 }
 
+/// Rejects branch names that would escape `refs/heads` when joined onto a path.
+///
+/// A branch name is used as a path segment, so `..`, `.` and absolute paths let
+/// it address files outside the directory it is supposed to live in. Without
+/// this, `branch -d ../heads/main` deletes `main` while the current-branch guard
+/// — which compares the raw string — sees a name that is not the current branch.
+pub fn validate_branch_name(name: &str) -> Result<(), RepoError> {
+    if name.is_empty() {
+        return Err(RepoError::invalid_layout(
+            "branch name is empty".to_string(),
+        ));
+    }
+    if Path::new(name).is_absolute() {
+        return Err(RepoError::invalid_layout(format!(
+            "branch name '{name}' must be relative, not an absolute path"
+        )));
+    }
+    for segment in name.split('/') {
+        if segment.is_empty() {
+            return Err(RepoError::invalid_layout(format!(
+                "branch name '{name}' has an empty path segment"
+            )));
+        }
+        if segment == "." || segment == ".." {
+            return Err(RepoError::invalid_layout(format!(
+                "branch name '{name}' must not contain '.' or '..' segments"
+            )));
+        }
+    }
+    if name.contains('\\') {
+        return Err(RepoError::invalid_layout(format!(
+            "branch name '{name}' must not contain a backslash"
+        )));
+    }
+    Ok(())
+}
+
 /// `<repo>/.gfs/refs/deleted`.
 pub fn deleted_refs_dir(repo_path: &Path) -> PathBuf {
     repo_path
@@ -828,6 +865,7 @@ pub fn soft_delete_branch_ref(
     repo_path: &Path,
     branch_name: &str,
 ) -> Result<DeletedBranch, RepoError> {
+    validate_branch_name(branch_name)?;
     let ref_path = repo_path
         .join(GFS_DIR)
         .join(REFS_DIR)
@@ -901,6 +939,22 @@ pub fn list_deleted_branch_refs(repo_path: &Path) -> Result<Vec<DeletedBranch>, 
     Ok(out)
 }
 
+/// Deleted branches still inside `retention_ms`, newest first.
+///
+/// Filtered on read rather than relying on pruning: expiry has to hold even when
+/// nothing has triggered a prune, otherwise the window is advisory and a branch
+/// stays restorable long after it was documented to stop being so.
+pub fn list_recoverable_branch_refs(
+    repo_path: &Path,
+    retention_ms: u64,
+) -> Result<Vec<DeletedBranch>, RepoError> {
+    let cutoff = now_ms().saturating_sub(retention_ms);
+    Ok(list_deleted_branch_refs(repo_path)?
+        .into_iter()
+        .filter(|d| d.deleted_at_ms > cutoff)
+        .collect())
+}
+
 /// Restores the most recent deletion of `branch_name` back to `refs/heads/`.
 ///
 /// Refuses when a live branch of that name already exists: the caller asked to
@@ -910,6 +964,7 @@ pub fn restore_deleted_branch_ref(
     repo_path: &Path,
     branch_name: &str,
 ) -> Result<DeletedBranch, RepoError> {
+    validate_branch_name(branch_name)?;
     let live = repo_path
         .join(GFS_DIR)
         .join(REFS_DIR)
@@ -941,7 +996,12 @@ pub fn restore_deleted_branch_ref(
         fs::create_dir_all(parent).map_err(RepoError::from)?;
     }
     fs::rename(&stored, &live).map_err(RepoError::from)?;
-    prune_empty_dirs_under(&base.join(entry.deleted_at_ms.to_string()), &base);
+    // Start at the directory the ref actually sat in, not the timestamp root:
+    // for `a/b` the newly empty directory is `<ts>/a`, and `<ts>` still contains
+    // it, so starting there would find a non-empty directory and stop.
+    if let Some(from) = stored.parent() {
+        prune_empty_dirs_under(from, &base);
+    }
 
     Ok(entry)
 }
@@ -1676,6 +1736,76 @@ mod tests {
             .map(|d| d.name)
             .collect();
         assert_eq!(names, vec!["fresh".to_string()]);
+    }
+
+    /// A branch name becomes a path segment, so a traversing name addresses
+    /// files outside `refs/heads`. `branch -d ../heads/main` otherwise deletes
+    /// `main` while the current-branch guard, which compares raw strings, sees a
+    /// name that is not the current branch.
+    #[test]
+    fn validate_branch_name_rejects_names_that_escape_refs_heads() {
+        for good in ["main", "feature", "team/alpha", "a.b", "release-1.2"] {
+            assert!(validate_branch_name(good).is_ok(), "{good} should be valid");
+        }
+        for bad in [
+            "",
+            ".",
+            "..",
+            "./main",
+            "../heads/main",
+            "../../../../pwned",
+            "team//alpha",
+            "team/../../escape",
+            "/absolute",
+            "back\\slash",
+        ] {
+            assert!(
+                validate_branch_name(bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn soft_delete_refuses_a_traversing_name_instead_of_moving_another_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+        write_branch(repo, "main", "a".repeat(64).as_str());
+
+        assert!(soft_delete_branch_ref(repo, "../heads/main").is_err());
+        assert!(soft_delete_branch_ref(repo, "./main").is_err());
+        assert!(
+            branch_exists(repo, "main"),
+            "a refused delete must not touch the ref it would have resolved to"
+        );
+    }
+
+    /// Expiry has to hold on read. Pruning alone runs only during `branch -d`,
+    /// so a repo where nothing is being deleted would keep entries restorable
+    /// long after the window they were documented to have.
+    #[test]
+    fn recoverable_listing_excludes_entries_past_the_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+        write_branch(repo, "fresh", "a".repeat(64).as_str());
+        soft_delete_branch_ref(repo, "fresh").unwrap();
+
+        assert_eq!(
+            list_recoverable_branch_refs(repo, 60_000).unwrap().len(),
+            1,
+            "an entry inside the window is recoverable"
+        );
+        assert!(
+            list_recoverable_branch_refs(repo, 0).unwrap().is_empty(),
+            "a zero window makes it immediately unrecoverable"
+        );
+        assert_eq!(
+            list_deleted_branch_refs(repo).unwrap().len(),
+            1,
+            "filtering must not delete anything; the entry is still on disk"
+        );
     }
 
     #[test]

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -1035,6 +1035,53 @@ pub fn get_current_commit_id(repo_path: &Path) -> Result<String, RepoError> {
 
 /// Short commit id used for workspace directory path segment (avoids long paths on disk).
 /// If `commit_id` is longer than `SHORT_COMMIT_ID_LEN`, returns the prefix; otherwise returns as-is (e.g. `"0"`).
+/// Where a checkout of `revision` would land: its commit, and the workspace
+/// directory that would be rebuilt.
+///
+/// Extracted so the caller can ask what a checkout is about to overwrite BEFORE
+/// it overwrites it. `GfsRepository::checkout` uses the same function, because
+/// two copies of this rule that disagree is exactly how a guard ends up
+/// protecting a different directory from the one being destroyed.
+pub fn checkout_target(
+    repo: &Path,
+    revision: &str,
+) -> Result<(String, std::path::PathBuf), RepoError> {
+    let commit_hash = rev_parse(repo, revision)?;
+
+    // A branch name only keeps its own workspace while it still points at the
+    // commit being asked for; otherwise the checkout detaches.
+    let branch_segment = if is_branch(repo, revision) {
+        let tip = fs::read_to_string(
+            repo.join(GFS_DIR)
+                .join(REFS_DIR)
+                .join(HEADS_DIR)
+                .join(revision),
+        )
+        .map_err(RepoError::from)?;
+        if tip.trim() == commit_hash {
+            revision.to_string()
+        } else {
+            "detached".to_string()
+        }
+    } else {
+        "detached".to_string()
+    };
+
+    let workspace_segment = if branch_segment == "detached" {
+        short_commit_id_for_workspace(&commit_hash)
+    } else {
+        BRANCH_WORKSPACE_SEGMENT.to_string()
+    };
+
+    let path = repo
+        .join(GFS_DIR)
+        .join(WORKSPACES_DIR)
+        .join(&branch_segment)
+        .join(&workspace_segment)
+        .join(WORKSPACE_DATA_DIR);
+    Ok((commit_hash, path))
+}
+
 /// The directory holding a branch's working copy.
 pub fn branch_workspace_dir(repo_path: &Path, branch: &str) -> std::path::PathBuf {
     repo_path.join(GFS_DIR).join(WORKSPACES_DIR).join(branch)

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -1035,6 +1035,60 @@ pub fn get_current_commit_id(repo_path: &Path) -> Result<String, RepoError> {
 
 /// Short commit id used for workspace directory path segment (avoids long paths on disk).
 /// If `commit_id` is longer than `SHORT_COMMIT_ID_LEN`, returns the prefix; otherwise returns as-is (e.g. `"0"`).
+/// The directory holding a branch's working copy.
+pub fn branch_workspace_dir(repo_path: &Path, branch: &str) -> std::path::PathBuf {
+    repo_path.join(GFS_DIR).join(WORKSPACES_DIR).join(branch)
+}
+
+/// Paths in `workspace` that differ from `baseline`, i.e. uncommitted work.
+///
+/// Checkout restores the workspace from a snapshot, which overwrites whatever is
+/// there. Callers use this to refuse rather than overwrite silently.
+///
+/// WHAT IS COMPARED, and why it is only this. `FileEntry` records path, size,
+/// owner, group and mode; there is no content hash, so this is git's cheap tier
+/// (stat) without git's second tier (hash on suspicion).
+///
+/// * SIZE, for files present in both. A write to a SQLite database grows the
+///   database or its write-ahead log, so real work shows up here.
+/// * PRESENCE, for files in the workspace that the baseline does not have.
+/// * NOT permissions. A live workspace is 0700 and a snapshot is read-only, so
+///   they always differ and comparing them would report every workspace dirty.
+/// * NOT absences. SQLite deletes its `-wal` and `-shm` sidecars when the last
+///   connection closes, so a file that has gone away is the normal aftermath of
+///   reading the database, not uncommitted work.
+///
+/// The gap this leaves, stated rather than hidden: an edit that changes no
+/// file's size — an in-place UPDATE whose pages are checkpointed back to the
+/// same length — is not detected. The direction of the remaining error is the
+/// safe one for a false positive (a needless refusal, which `--force` clears)
+/// and the unsafe one for a false negative, so it is worth revisiting with a
+/// content hash if the commit object ever grows one.
+pub fn workspace_changes(
+    workspace: &Path,
+    baseline: &[FileEntry],
+) -> Result<Vec<String>, RepoError> {
+    if !workspace.exists() {
+        return Ok(Vec::new());
+    }
+    let current = collect_file_entries(workspace, "")?;
+    let sizes: std::collections::HashMap<&str, u64> = baseline
+        .iter()
+        .map(|e| (e.relative_path.as_str(), e.file_size))
+        .collect();
+
+    let mut changed: Vec<String> = current
+        .iter()
+        .filter(|entry| match sizes.get(entry.relative_path.as_str()) {
+            Some(&size) => size != entry.file_size,
+            None => true,
+        })
+        .map(|entry| entry.relative_path.clone())
+        .collect();
+    changed.sort();
+    Ok(changed)
+}
+
 pub fn short_commit_id_for_workspace(commit_id: &str) -> String {
     if commit_id.len() <= SHORT_COMMIT_ID_LEN {
         commit_id.to_string()
@@ -1104,6 +1158,76 @@ mod tests {
     use std::fs;
     use std::io;
     use tempfile::TempDir;
+
+    /// The dirty check reports work, and only work.
+    #[test]
+    fn workspace_changes_reports_writes_and_additions() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        fs::write(ws.join("db"), "aaaa").unwrap();
+        fs::write(ws.join("keep"), "same").unwrap();
+        let baseline = collect_file_entries(ws, "").unwrap();
+
+        // Untouched.
+        assert!(workspace_changes(ws, &baseline).unwrap().is_empty());
+
+        // A write that changes the size.
+        fs::write(ws.join("db"), "aaaaaaaa").unwrap();
+        assert_eq!(workspace_changes(ws, &baseline).unwrap(), vec!["db"]);
+
+        // A new file.
+        fs::write(ws.join("db"), "aaaa").unwrap();
+        fs::write(ws.join("new"), "x").unwrap();
+        assert_eq!(workspace_changes(ws, &baseline).unwrap(), vec!["new"]);
+    }
+
+    /// A file that has GONE is not uncommitted work.
+    ///
+    /// SQLite deletes its `-wal` and `-shm` sidecars when the last connection
+    /// closes, so treating an absence as a change would report every workspace
+    /// dirty after a plain read.
+    #[test]
+    fn workspace_changes_ignores_files_that_disappeared() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        fs::write(ws.join("db"), "aaaa").unwrap();
+        fs::write(ws.join("db-wal"), "").unwrap();
+        fs::write(ws.join("db-shm"), "x".repeat(32)).unwrap();
+        let baseline = collect_file_entries(ws, "").unwrap();
+
+        fs::remove_file(ws.join("db-wal")).unwrap();
+        fs::remove_file(ws.join("db-shm")).unwrap();
+        assert!(
+            workspace_changes(ws, &baseline).unwrap().is_empty(),
+            "closing the database is not uncommitted work"
+        );
+    }
+
+    /// Permissions are deliberately not compared.
+    ///
+    /// A live workspace is 0700 and the snapshot it came from is read-only, so
+    /// comparing modes would report every workspace dirty.
+    #[test]
+    fn workspace_changes_ignores_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let file = ws.join("db");
+        fs::write(&file, "aaaa").unwrap();
+        let mut baseline = collect_file_entries(ws, "").unwrap();
+        baseline[0].permissions = Some("0400".to_string());
+        assert!(workspace_changes(ws, &baseline).unwrap().is_empty());
+    }
+
+    /// A workspace that is not there yet has nothing to lose.
+    #[test]
+    fn workspace_changes_on_a_missing_workspace_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            workspace_changes(&dir.path().join("gone"), &[])
+                .unwrap()
+                .is_empty()
+        );
+    }
 
     #[test]
     fn short_commit_id_for_workspace_keeps_short_and_truncates_long() {

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -2,14 +2,15 @@ use crate::model::commit::{Commit, FileEntry};
 use crate::model::config::{EnvironmentConfig, GfsConfig, RuntimeConfig, UserConfig};
 use crate::model::errors::RepoError;
 use crate::model::layout::{
-    BRANCH_WORKSPACE_SEGMENT, CONFIG_FILE, DEFAULT_SHORT_HASH_LEN, GFS_DIR, HEAD_FILE, HEADS_DIR,
-    MAIN_BRANCH, MIN_SHORT_HASH_LEN, OBJECTS_DIR, REFS_DIR, SHORT_COMMIT_ID_LEN, SNAPSHOTS_DIR,
-    WORKSPACE_DATA_DIR, WORKSPACE_FILE, WORKSPACES_DIR,
+    BRANCH_WORKSPACE_SEGMENT, CONFIG_FILE, DEFAULT_SHORT_HASH_LEN, DELETED_REFS_DIR, GFS_DIR,
+    HEAD_FILE, HEADS_DIR, MAIN_BRANCH, MIN_SHORT_HASH_LEN, OBJECTS_DIR, REFS_DIR,
+    SHORT_COMMIT_ID_LEN, SNAPSHOTS_DIR, WORKSPACE_DATA_DIR, WORKSPACE_FILE, WORKSPACES_DIR,
 };
 use anyhow::Result;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn validate_repo_layout(gfs_dir: &Path) -> Result<(), RepoError> {
     // Check HEAD file
@@ -133,6 +134,7 @@ pub fn init_repo_layout(working_dir: &Path, mount_point: Option<String>) -> Resu
         runtime: None,
         storage: None,
         compute: None,
+        deleted_branch_retention_days: None,
     };
 
     let config_path = gfs_dir.join(CONFIG_FILE);
@@ -778,6 +780,219 @@ pub fn update_branch_ref(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Soft-deleted branch refs
+// ---------------------------------------------------------------------------
+
+/// A branch ref that `gfs branch -d` moved aside instead of unlinking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeletedBranch {
+    /// The branch's original name, including any `/` segments.
+    pub name: String,
+    /// The tip the branch pointed at when it was deleted.
+    pub commit_hash: String,
+    /// Deletion time in milliseconds since the Unix epoch. This is also the
+    /// directory segment the entry lives under.
+    pub deleted_at_ms: u64,
+}
+
+/// `<repo>/.gfs/refs/deleted`.
+pub fn deleted_refs_dir(repo_path: &Path) -> PathBuf {
+    repo_path
+        .join(GFS_DIR)
+        .join(REFS_DIR)
+        .join(DELETED_REFS_DIR)
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Moves `refs/heads/<branch_name>` aside so the branch can be restored later,
+/// instead of unlinking it.
+///
+/// The ref file holds the only record of which commit a branch pointed at: a
+/// commit object stores its parents but not the name of any branch, so an
+/// unlinked ref makes the name → tip binding unrecoverable even though every
+/// commit survives on disk.
+///
+/// Entries are stored at `refs/deleted/<unix_millis>/<branch path>`, with the
+/// timestamp as the *outer* segment. Putting the name first would break on
+/// nested branches: deleting `a` and then `a/b` would need `a` to be both a
+/// file and a directory. A directory per deletion also lets the same name be
+/// deleted, recreated and deleted again without entries colliding.
+pub fn soft_delete_branch_ref(
+    repo_path: &Path,
+    branch_name: &str,
+) -> Result<DeletedBranch, RepoError> {
+    let ref_path = repo_path
+        .join(GFS_DIR)
+        .join(REFS_DIR)
+        .join(HEADS_DIR)
+        .join(branch_name);
+    let commit_hash = fs::read_to_string(&ref_path)
+        .map_err(RepoError::from)?
+        .trim()
+        .to_string();
+
+    // Two deletions within the same millisecond would otherwise share a
+    // directory; step forward until the slot is free rather than merging them.
+    let mut deleted_at_ms = now_ms();
+    let base = deleted_refs_dir(repo_path);
+    while base
+        .join(deleted_at_ms.to_string())
+        .join(branch_name)
+        .exists()
+    {
+        deleted_at_ms += 1;
+    }
+
+    let target = base.join(deleted_at_ms.to_string()).join(branch_name);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(RepoError::from)?;
+    }
+    fs::rename(&ref_path, &target).map_err(RepoError::from)?;
+
+    Ok(DeletedBranch {
+        name: branch_name.to_string(),
+        commit_hash,
+        deleted_at_ms,
+    })
+}
+
+/// Every recoverable branch, newest deletion first.
+pub fn list_deleted_branch_refs(repo_path: &Path) -> Result<Vec<DeletedBranch>, RepoError> {
+    let base = deleted_refs_dir(repo_path);
+    if !base.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&base).map_err(RepoError::from)? {
+        let entry = entry.map_err(RepoError::from)?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        // A directory whose name is not a timestamp was not written by us; skip
+        // it rather than failing the whole listing.
+        let Some(deleted_at_ms) = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        for (name, commit_hash) in collect_branch_refs(&path, "")? {
+            out.push(DeletedBranch {
+                name,
+                commit_hash,
+                deleted_at_ms,
+            });
+        }
+    }
+    out.sort_by(|a, b| {
+        b.deleted_at_ms
+            .cmp(&a.deleted_at_ms)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Ok(out)
+}
+
+/// Restores the most recent deletion of `branch_name` back to `refs/heads/`.
+///
+/// Refuses when a live branch of that name already exists: the caller asked to
+/// recover a name that is now in use, and silently overwriting the live ref
+/// would trade one lost branch for another.
+pub fn restore_deleted_branch_ref(
+    repo_path: &Path,
+    branch_name: &str,
+) -> Result<DeletedBranch, RepoError> {
+    let live = repo_path
+        .join(GFS_DIR)
+        .join(REFS_DIR)
+        .join(HEADS_DIR)
+        .join(branch_name);
+    // `is_file`, not `exists`: after restoring `a/b`, `refs/heads/a` exists as a
+    // directory holding `b`. Treating that as a live branch would report the
+    // wrong reason, and the two cases need different advice.
+    if live.is_file() {
+        return Err(RepoError::invalid_layout(format!(
+            "branch '{branch_name}' already exists; rename or delete it before restoring the deleted one"
+        )));
+    }
+    if live.is_dir() {
+        return Err(RepoError::invalid_layout(format!(
+            "'{branch_name}' cannot be a branch while branches nested under it exist; \
+             a ref is a file, so it cannot also be a directory"
+        )));
+    }
+
+    let entry = list_deleted_branch_refs(repo_path)?
+        .into_iter()
+        .find(|d| d.name == branch_name)
+        .ok_or_else(|| RepoError::RevisionNotFound(branch_name.to_string()))?;
+
+    let base = deleted_refs_dir(repo_path);
+    let stored = base.join(entry.deleted_at_ms.to_string()).join(branch_name);
+    if let Some(parent) = live.parent() {
+        fs::create_dir_all(parent).map_err(RepoError::from)?;
+    }
+    fs::rename(&stored, &live).map_err(RepoError::from)?;
+    prune_empty_dirs_under(&base.join(entry.deleted_at_ms.to_string()), &base);
+
+    Ok(entry)
+}
+
+/// Drops deleted-ref entries older than `retention_ms`, returning how many went.
+///
+/// There is no background process and no garbage collector yet, so this is
+/// called opportunistically from `gfs branch -d`. Note that it frees only the
+/// ref files: the commit objects and snapshot trees an expired branch pointed at
+/// stay on disk until a reachability collector exists.
+pub fn prune_expired_deleted_refs(repo_path: &Path, retention_ms: u64) -> Result<usize, RepoError> {
+    let base = deleted_refs_dir(repo_path);
+    if !base.exists() {
+        return Ok(0);
+    }
+    let cutoff = now_ms().saturating_sub(retention_ms);
+    let mut pruned = 0;
+    for entry in fs::read_dir(&base).map_err(RepoError::from)? {
+        let entry = entry.map_err(RepoError::from)?;
+        let path = entry.path();
+        let Some(deleted_at_ms) = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        if path.is_dir() && deleted_at_ms < cutoff {
+            pruned += collect_branch_refs(&path, "")?.len();
+            fs::remove_dir_all(&path).map_err(RepoError::from)?;
+        }
+    }
+    Ok(pruned)
+}
+
+/// Removes `dir` and its now-empty parents, stopping at `stop_at` exclusive.
+fn prune_empty_dirs_under(dir: &Path, stop_at: &Path) {
+    let mut current = Some(dir);
+    while let Some(d) = current {
+        if d == stop_at || !d.starts_with(stop_at) {
+            break;
+        }
+        if d.read_dir().is_ok_and(|mut it| it.next().is_none()) {
+            let _ = fs::remove_dir(d);
+        } else {
+            break;
+        }
+        current = d.parent();
+    }
+}
+
 /// Resolves a human-readable revision to a commit id.
 ///
 /// Supported formats:
@@ -1282,6 +1497,194 @@ mod tests {
         assert_eq!(short_commit_id_for_workspace("abc"), "abc");
         let long = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
         assert_eq!(short_commit_id_for_workspace(long), "0123456789ab");
+    }
+
+    // -----------------------------------------------------------------------
+    // Soft-deleted branch refs
+    // -----------------------------------------------------------------------
+
+    /// Creates `refs/heads/<name>` holding `tip`, creating parent dirs.
+    fn write_branch(repo: &Path, name: &str, tip: &str) {
+        let p = repo.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR).join(name);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(p, tip).unwrap();
+    }
+
+    /// A branch ref is a *file*. `refs/heads/a` can also exist as a directory
+    /// when `a/b` is live, which is not the same thing as branch `a` existing.
+    fn branch_exists(repo: &Path, name: &str) -> bool {
+        repo.join(GFS_DIR)
+            .join(REFS_DIR)
+            .join(HEADS_DIR)
+            .join(name)
+            .is_file()
+    }
+
+    #[test]
+    fn soft_delete_then_restore_round_trips_name_and_tip() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+        write_branch(repo, "feature", "a".repeat(64).as_str());
+
+        let deleted = soft_delete_branch_ref(repo, "feature").unwrap();
+        assert_eq!(deleted.name, "feature");
+        assert_eq!(deleted.commit_hash, "a".repeat(64));
+        assert!(!branch_exists(repo, "feature"), "ref should have moved");
+
+        let listed = list_deleted_branch_refs(repo).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "feature");
+        assert_eq!(listed[0].commit_hash, "a".repeat(64));
+
+        let restored = restore_deleted_branch_ref(repo, "feature").unwrap();
+        assert_eq!(restored.commit_hash, "a".repeat(64));
+        assert!(branch_exists(repo, "feature"));
+        assert_eq!(
+            fs::read_to_string(
+                repo.join(GFS_DIR)
+                    .join(REFS_DIR)
+                    .join(HEADS_DIR)
+                    .join("feature")
+            )
+            .unwrap()
+            .trim(),
+            "a".repeat(64)
+        );
+        assert!(
+            list_deleted_branch_refs(repo).unwrap().is_empty(),
+            "a restored entry should leave the deleted area"
+        );
+    }
+
+    #[test]
+    fn restore_refuses_when_the_name_is_live_again() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+        write_branch(repo, "feature", "a".repeat(64).as_str());
+        soft_delete_branch_ref(repo, "feature").unwrap();
+        write_branch(repo, "feature", "b".repeat(64).as_str());
+
+        assert!(restore_deleted_branch_ref(repo, "feature").is_err());
+        assert_eq!(
+            fs::read_to_string(
+                repo.join(GFS_DIR)
+                    .join(REFS_DIR)
+                    .join(HEADS_DIR)
+                    .join("feature")
+            )
+            .unwrap()
+            .trim(),
+            "b".repeat(64),
+            "the live branch must not be clobbered by a refused restore"
+        );
+    }
+
+    /// The reason the timestamp is the outer path segment.
+    ///
+    /// `a` and `a/b` can never be live at the same time — a ref is a file, so
+    /// `refs/heads/a` being a file blocks `refs/heads/a/b`, the same
+    /// directory/file conflict git has. But *deleted* entries have no such
+    /// mutual exclusion: delete `a`, then later create and delete `a/b`, and
+    /// both are recoverable at once. Keying the deleted area by name first
+    /// would need `a` to be a file and a directory simultaneously; keying it by
+    /// deletion time makes the collision unreachable.
+    #[test]
+    fn a_deleted_branch_and_a_deleted_nested_branch_sharing_its_name_coexist() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+
+        write_branch(repo, "a", "a".repeat(64).as_str());
+        soft_delete_branch_ref(repo, "a").unwrap();
+
+        // Only possible now that `a` is no longer a live ref.
+        write_branch(repo, "a/b", "b".repeat(64).as_str());
+        soft_delete_branch_ref(repo, "a/b").unwrap();
+
+        let listed = list_deleted_branch_refs(repo).unwrap();
+        let mut names: Vec<&str> = listed.iter().map(|d| d.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["a", "a/b"], "both deletions must survive");
+
+        let restored = restore_deleted_branch_ref(repo, "a/b").unwrap();
+        assert_eq!(restored.commit_hash, "b".repeat(64));
+        assert!(branch_exists(repo, "a/b"));
+        assert!(
+            !branch_exists(repo, "a"),
+            "restoring one must not restore the other"
+        );
+    }
+
+    #[test]
+    fn deleting_the_same_name_twice_keeps_both_and_restores_the_newest() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+
+        write_branch(repo, "feature", "a".repeat(64).as_str());
+        let first = soft_delete_branch_ref(repo, "feature").unwrap();
+        write_branch(repo, "feature", "b".repeat(64).as_str());
+        let second = soft_delete_branch_ref(repo, "feature").unwrap();
+        assert_ne!(
+            first.deleted_at_ms, second.deleted_at_ms,
+            "two deletions must not share a slot"
+        );
+
+        assert_eq!(list_deleted_branch_refs(repo).unwrap().len(), 2);
+        let restored = restore_deleted_branch_ref(repo, "feature").unwrap();
+        assert_eq!(
+            restored.commit_hash,
+            "b".repeat(64),
+            "restore should take the most recent deletion"
+        );
+        assert_eq!(
+            list_deleted_branch_refs(repo).unwrap().len(),
+            1,
+            "the older deletion should still be recoverable"
+        );
+    }
+
+    #[test]
+    fn prune_drops_expired_entries_and_keeps_in_window_ones() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+        write_branch(repo, "fresh", "a".repeat(64).as_str());
+        soft_delete_branch_ref(repo, "fresh").unwrap();
+
+        // Backdate one entry by relocating it to an older timestamp directory,
+        // which is the same thing the passage of time would do.
+        write_branch(repo, "stale", "b".repeat(64).as_str());
+        let stale = soft_delete_branch_ref(repo, "stale").unwrap();
+        let base = deleted_refs_dir(repo);
+        let old_ms = stale.deleted_at_ms - 10_000;
+        fs::create_dir_all(base.join(old_ms.to_string())).unwrap();
+        fs::rename(
+            base.join(stale.deleted_at_ms.to_string()).join("stale"),
+            base.join(old_ms.to_string()).join("stale"),
+        )
+        .unwrap();
+        fs::remove_dir(base.join(stale.deleted_at_ms.to_string())).unwrap();
+
+        let pruned = prune_expired_deleted_refs(repo, 5_000).unwrap();
+        assert_eq!(pruned, 1);
+        let names: Vec<String> = list_deleted_branch_refs(repo)
+            .unwrap()
+            .into_iter()
+            .map(|d| d.name)
+            .collect();
+        assert_eq!(names, vec!["fresh".to_string()]);
+    }
+
+    #[test]
+    fn listing_is_empty_and_pruning_is_a_no_op_before_any_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        create_valid_repo_layout(repo).unwrap();
+        assert!(list_deleted_branch_refs(repo).unwrap().is_empty());
+        assert_eq!(prune_expired_deleted_refs(repo, 1).unwrap(), 0);
     }
 
     fn create_valid_repo_layout(path: &Path) -> io::Result<()> {

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -82,30 +82,43 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         self
     }
 
-    /// The uncommitted changes checkout would overwrite, as a short description.
+    /// The uncommitted changes this checkout would overwrite, as a short
+    /// description.
     ///
-    /// Compared against the file list recorded on the CURRENT commit, which is
-    /// the right baseline because a commit snapshots the workspace: immediately
-    /// after one, the two agree, and everything written since is uncommitted.
-    /// `None` when there is nothing recorded to compare against — a repository
-    /// with no commits yet, or one whose commit predates file lists — in which
-    /// case checkout proceeds as before rather than refusing on a fact it does
-    /// not have.
+    /// Asks about the TARGET workspace, not the one being left, because that is
+    /// the directory the restore rebuilds. Getting this backwards is a live
+    /// hazard rather than a nicety: checking the workspace you leave both
+    /// refuses switches that would overwrite nothing — each branch has its own
+    /// directory, so leaving a dirty branch destroys nothing — and, worse, lets
+    /// you walk away from dirty work on one branch and come back to it from a
+    /// clean one, at which point the restore deletes it with no refusal at all.
+    ///
+    /// The baseline is the file list recorded on the commit being checked out,
+    /// which is the right one for that directory: committing on a branch
+    /// snapshots its workspace, so the two agree immediately afterwards and
+    /// everything written since is uncommitted.
+    ///
+    /// `None` whenever the question cannot be answered — an unresolvable
+    /// revision (a branch about to be created), no commits yet, or a commit
+    /// that predates file lists. Checkout then proceeds and reports its own
+    /// error, rather than refusing on a fact this does not have.
     async fn uncommitted_changes(
         &self,
         path: &Path,
+        revision: &str,
     ) -> std::result::Result<Option<String>, CheckoutRepoError> {
-        let current = self.repository.get_current_commit_id(path).await?;
-        if current == "0" {
+        let Ok((commit_hash, workspace)) = repo_layout::checkout_target(path, revision) else {
+            return Ok(None);
+        };
+        if commit_hash == "0" {
             return Ok(None);
         }
-        let Ok(commit) = repo_layout::get_commit_from_hash(path, &current) else {
+        let Ok(commit) = repo_layout::get_commit_from_hash(path, &commit_hash) else {
             return Ok(None);
         };
         let Ok(Some(baseline)) = repo_layout::get_file_entries_for_commit(path, &commit) else {
             return Ok(None);
         };
-        let workspace = self.repository.get_active_workspace_data_dir(path).await?;
         let changed = repo_layout::workspace_changes(&workspace, &baseline)
             .map_err(|e| CheckoutRepoError::Repository(RepositoryError::Internal(e.to_string())))?;
         if changed.is_empty() {
@@ -138,13 +151,22 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         // unrecoverable. Neither silent option is acceptable: discarding loses
         // data the user cannot get back, and preserving it across a switch
         // leaves state that no command in GFS displays.
+        let revision = revision.trim().to_string();
+
+        // Refuse before anything is touched. The restore rebuilds the target
+        // workspace, so work that was never committed THERE is overwritten and
+        // unrecoverable. Neither silent option is acceptable: discarding loses
+        // data the user cannot get back, and keeping a stale directory means
+        // `Switched to X` does not give you X.
+        //
+        // Skipped when a branch is being created, since its workspace does not
+        // exist yet and there is nothing to lose.
         if !self.force
-            && let Some(changed) = self.uncommitted_changes(&path).await?
+            && create_branch.is_none()
+            && let Some(changed) = self.uncommitted_changes(&path, &revision).await?
         {
             return Err(CheckoutRepoError::WorkspaceDirty(changed));
         }
-
-        let revision = revision.trim().to_string();
 
         // Validate the target ref BEFORE stopping compute — a bad revision must
         // not leave the database offline (mirrors the k8s checkout path).

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -32,6 +32,12 @@ pub enum CheckoutRepoError {
 
     #[error("compute: {0}")]
     Compute(#[from] ComputeError),
+
+    #[error(
+        "the workspace has uncommitted changes that checkout would overwrite ({0}). \
+         Commit them first, or pass --force to discard them"
+    )]
+    WorkspaceDirty(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -47,6 +53,8 @@ pub struct CheckoutRepoUseCase<R: DatabaseProviderRegistry> {
     repository: Arc<dyn Repository>,
     compute: Arc<dyn Compute>,
     registry: Arc<R>,
+    /// Discard uncommitted work instead of refusing. Off by default.
+    force: bool,
 }
 
 impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
@@ -59,7 +67,60 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
             repository,
             compute,
             registry,
+            force: false,
         }
+    }
+
+    /// Overwrite a workspace that has uncommitted changes rather than refusing.
+    ///
+    /// A builder rather than a `run` parameter on purpose: `run`'s signature is
+    /// part of this crate's public surface and the data-plane calls it directly,
+    /// so adding an argument would break a caller that has no opinion about
+    /// forcing.
+    pub fn with_force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+
+    /// The uncommitted changes checkout would overwrite, as a short description.
+    ///
+    /// Compared against the file list recorded on the CURRENT commit, which is
+    /// the right baseline because a commit snapshots the workspace: immediately
+    /// after one, the two agree, and everything written since is uncommitted.
+    /// `None` when there is nothing recorded to compare against — a repository
+    /// with no commits yet, or one whose commit predates file lists — in which
+    /// case checkout proceeds as before rather than refusing on a fact it does
+    /// not have.
+    async fn uncommitted_changes(
+        &self,
+        path: &Path,
+    ) -> std::result::Result<Option<String>, CheckoutRepoError> {
+        let current = self.repository.get_current_commit_id(path).await?;
+        if current == "0" {
+            return Ok(None);
+        }
+        let Ok(commit) = repo_layout::get_commit_from_hash(path, &current) else {
+            return Ok(None);
+        };
+        let Ok(Some(baseline)) = repo_layout::get_file_entries_for_commit(path, &commit) else {
+            return Ok(None);
+        };
+        let workspace = self.repository.get_active_workspace_data_dir(path).await?;
+        let changed = repo_layout::workspace_changes(&workspace, &baseline)
+            .map_err(|e| CheckoutRepoError::Repository(RepositoryError::Internal(e.to_string())))?;
+        if changed.is_empty() {
+            return Ok(None);
+        }
+        let shown: Vec<&str> = changed.iter().take(3).map(String::as_str).collect();
+        Ok(Some(if changed.len() > shown.len() {
+            format!(
+                "{} and {} more",
+                shown.join(", "),
+                changed.len() - shown.len()
+            )
+        } else {
+            shown.join(", ")
+        }))
     }
 
     /// Check out `revision` (branch name or full 64-char commit hash) at `path`.
@@ -72,6 +133,17 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         revision: String,
         create_branch: Option<String>,
     ) -> std::result::Result<String, CheckoutRepoError> {
+        // Refuse before anything is touched. Checkout restores the workspace
+        // from a snapshot, so work that was never committed is overwritten and
+        // unrecoverable. Neither silent option is acceptable: discarding loses
+        // data the user cannot get back, and preserving it across a switch
+        // leaves state that no command in GFS displays.
+        if !self.force
+            && let Some(changed) = self.uncommitted_changes(&path).await?
+        {
+            return Err(CheckoutRepoError::WorkspaceDirty(changed));
+        }
+
         let revision = revision.trim().to_string();
 
         // Validate the target ref BEFORE stopping compute — a bad revision must

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -2615,6 +2615,7 @@ mod tests {
                 runtime: Some(runtime.clone()),
                 storage: None,
                 compute: None,
+                deleted_branch_retention_days: None,
             };
             config.save(&path).expect("save .gfs/config.toml");
             // MockRepository getters: the source the snapshot arm reads.

--- a/crates/domain/src/usecases/repository/execute_query_usecase.rs
+++ b/crates/domain/src/usecases/repository/execute_query_usecase.rs
@@ -383,6 +383,7 @@ mod tests {
             }),
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(&path).expect("save config");
         (temp, path)

--- a/crates/domain/src/usecases/repository/export_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/export_repo_usecase.rs
@@ -485,6 +485,7 @@ mod tests {
             runtime: Some(runtime.clone()),
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(dir).unwrap();
     }
@@ -561,6 +562,7 @@ mod tests {
             }),
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(dir.path()).unwrap();
 
@@ -596,6 +598,7 @@ mod tests {
             }),
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(dir.path()).unwrap();
 

--- a/crates/domain/src/usecases/repository/extract_schema_usecase.rs
+++ b/crates/domain/src/usecases/repository/extract_schema_usecase.rs
@@ -367,6 +367,7 @@ mod tests {
             runtime,
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(path).expect("save config");
     }

--- a/crates/domain/src/usecases/repository/import_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/import_repo_usecase.rs
@@ -587,6 +587,7 @@ mod tests {
             runtime: Some(runtime.clone()),
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(dir).unwrap();
     }

--- a/crates/domain/src/usecases/repository/manage_users_usecase.rs
+++ b/crates/domain/src/usecases/repository/manage_users_usecase.rs
@@ -630,6 +630,7 @@ mod tests {
             }),
             storage: None,
             compute: None,
+            deleted_branch_retention_days: None,
         };
         config.save(&path).expect("save config");
         (temp, path)


### PR DESCRIPTION
> ### ⚠️ Stacked on #76 — read this first
>
> This branch is built on top of **#76** (`fix/workspace-snapshot-restore`), so the diff below currently contains **5 commits, of which the bottom 2 belong to #76**:
>
> | | commit | belongs to |
> |---|---|---|
> | 5 | `af8e4c0` enforce retention in the domain, repair five audit findings | **this PR** |
> | 4 | `0da072b` validate branch names, enforce retention on read | **this PR** |
> | 3 | `1dcd571` make `branch -d` recoverable | **this PR** |
> | 2 | `58ebbc6` guard the workspace being rebuilt, not the one being left | #76 |
> | 1 | `1f3404e` restore the workspace from the snapshot, refuse to overwrite | #76 |
>
> **Recommended merge order: #76 first, then this.** Once #76 lands, I will rebase and the diff here collapses to the top 3 commits only. Reviewing the isolated diff before then: https://github.com/medazizktata25/gfs/pull/14, which is the same three commits based directly on #76's branch.
>
> GitHub's native stacked PRs cannot be used here — they require every branch to live in one repository and [do not support cross-fork stacks](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs), which is why this is stacked by hand.

## Why #76 must go first

Both change `cmd_branch::delete_branch`, and #76 fixes the half this depends on. #76 removes the branch's workspace on delete and makes checkout always restore from the snapshot — which is precisely what makes recovery cheap here: a restored branch rebuilds its working copy from the snapshot, so there is no workspace to preserve. Landing this first would conflict and would leave the restored branch inheriting a stale working copy.

Independent confirmation from a blind audit of this work: on current `main`, `gfs branch -d ../heads/main` **deletes the checked-out branch and bricks the repo** — `.gfs/refs` ends up empty and `branch`, `log` and `commit` all then fail with "not a GFS repository". That is a pre-existing critical bug, and the validation in this PR closes it.

## Problem

`gfs branch -d` unlinked the ref and did nothing else. Measured on a real repo, everything else stays: commit objects 6 → 6, snapshot trees 2 → 2, `.gfs` 76K → 72K. Only the ref file goes.

So the commits survive, and scanning `.gfs/objects/` for tips nothing points at finds them — what `git fsck --lost-found` does. What the unlink destroys is the **branch name**. A stored commit records its parents but no branch (the `refs` list lives on `CommitWithRefs`, a display wrapper built by scanning live refs at read time, not persisted), so the name → tip binding exists in exactly one file. You can recover the commits; you cannot learn that any of them was called `feature`.

That matters more once there is a collector. Today an unlinked branch survives *by accident*, because nothing reclaims unreachable objects. The moment a reachability GC exists, those commits are collected for real — so the ref has to be moved somewhere a collector can see, not removed.

## Fix

```console
$ gfs branch -d feature
✓ Deleted branch 'feature'
  restore with: gfs branch --restore feature  (restores committed work)

$ gfs branch --deleted
Recoverable for 30 days after deletion:
  feature  bdbc78a  2m ago

$ gfs branch --restore feature
✓ Restored branch 'feature' at bdbc78a
```

Entries live at `refs/deleted/<unix_millis>/<name>`. Retention defaults to 30 days — the window Neon and lakeFS settled on — and is set with `gfs config branch.deletedRetentionDays`.

**Why the timestamp is the outer segment.** `a` and `a/b` can never be live at once: a ref is a file, so `refs/heads/a` blocks `refs/heads/a/b` — git's own directory/file conflict. Deleted entries have no such exclusion: delete `a`, then later create and delete `a/b`, and both are recoverable simultaneously. Keying by name would need `a` to be a file and a directory at the same time. A directory per deletion also lets one name be deleted, recreated and deleted again without collision; `--restore` takes the most recent and the listing marks the rest.

The same file/directory distinction is why the refusal checks use `is_file`, not `exists`: after restoring `a/b`, `refs/heads/a` exists as a *directory*, and treating that as a live branch reports the wrong reason.

## Branch name validation

A name becomes a path segment, so `..` and `.` address files outside `refs/heads`, and the current-branch guard compares raw strings so a traversal walks straight past it. Soft-delete initially turned that silent loss into a dishonest one: the ref landed at `refs/deleted/heads/main`, invisible to the listing because `heads` does not parse as a timestamp, while `--json` still reported `"recoverable": true`.

`validate_branch_name` now rejects empty names, empty segments, `.`, `..`, absolute paths and backslashes, and `branch -d` validates *before* the current-branch guard. Creating such names is still possible and still pre-existing; this closes the path that destroys data.

## Audit

Two blind audits, the second against a verified binary. No regressions, and the mechanism held: **236 SIGKILL runs straddling the delete produced zero lost branches and zero orphans** (`fs::rename` is atomic), 8 parallel deletes of one branch gave exactly one winner, 12 parallel deletes of different branches all succeeded, prune reach was exact. Name handling is clean for nested, unicode, space, tab, newline and 250-character names.

Fixed in the follow-up commits:

- retention was enforced only in the CLI — `restore_deleted_branch_ref` looked entries up unfiltered. That matters because the data-platform daemon links `gfs_domain` and reimplements CLI orchestration, so it would have had no window at all. The filter now lives in the domain.
- a zero window was racy (`cutoff == now`); now special-cased, and the list (`>=`) and prune (`<`) comparisons are complementary so nothing lands in a gap.
- `gfs branch --deleted -d feat` listed and **exited 0 without deleting**; `-c` slipped through the same conflict set. Both now refused.
- restoring a live branch never deleted blamed an overwrite of a deleted branch that did not exist.
- a stored entry not naming a commit restored into an unresolvable ref.
- retention arithmetic overflowed, so the largest "keep forever" values gave the shortest windows.

## Known limits

**Retention bounds visibility, not data.** After expiry the CLI reports a branch unrecoverable while its content is still in `.gfs/snapshots/`, one `checkout <hash>` away. That needs a reachability collector; the comment on `prune_expired_deleted_refs` says so. Worth knowing before anyone describes the window as a data-lifecycle control.

**`branch -d` does not take the repo lock.** There is no shared lock primitive on `main` — the flock on `.gfs/commit.lock` is private to `commit_repo_usecase.rs` — and extracting it here would collide with other in-flight work. It belongs with a ref-update choke point, which is the natural follow-up to this.

## Verification

267 domain lib tests (9 new), `e2e_checkout` 10/10 (2 new), `json_output` 9/9, `cargo fmt` clean, `cargo clippy --all-targets -- -D warnings` clean on both touched crates.

Postgres e2e tests fail locally on Colima's socket path — verified pre-existing by stashing and rerunning on the unmodified base.