### PR TITLE
fix: a concurrent commit and checkout could lose a commit

### DIFF
--- a/crates/domain/src/repo_utils/mod.rs
+++ b/crates/domain/src/repo_utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod helpers;
 pub mod repo_layout;
+pub mod repo_lock;

--- a/crates/domain/src/repo_utils/repo_lock.rs
+++ b/crates/domain/src/repo_utils/repo_lock.rs
@@ -1,0 +1,179 @@
+//! Exclusive advisory lock serialising the operations that mutate a repository.
+//!
+//! Commit and checkout both read repository state, act on it, and then write it
+//! back, and neither is atomic. Interleaving them loses data. Demonstrated on
+//! two branches with a workspace large enough to make the snapshot copy take
+//! about half a second, launching `gfs checkout other` 50 ms into a
+//! `gfs commit` on `main`:
+//!
+//! 1. commit reads HEAD's commit as the new commit's PARENT — `main`'s tip;
+//! 2. commit copies the workspace, which takes as long as the data is large;
+//! 3. checkout moves HEAD to `other`;
+//! 4. commit finishes and advances *the current branch* — now `other` — to a
+//!    commit whose parent is `main`'s tip.
+//!
+//! `other`'s previous tip is then unreachable from any ref. Four runs of ten
+//! rounds each produced the lost commit every time. Nothing warns: both
+//! commands report success.
+//!
+//! An embedded provider was accidentally partly protected, which is why this
+//! took a database-less workspace to show. Checkout quiesces the database
+//! before restoring, and that `BEGIN IMMEDIATE` blocks on the write lock the
+//! commit's snapshot guard already holds — measured at 550 ms against 34 ms
+//! unobstructed. It is not a fix: it does not exist before the first write, it
+//! does not cover container-backed providers, and it leaves the window between
+//! the commit reading its parent and acquiring the guard.
+
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crate::model::layout::GFS_DIR;
+
+/// Name of the lock file, kept from when only commit took it. Renaming it would
+/// mean an old `gfs commit` and a new `gfs checkout` locking different files,
+/// which is worse than an inaccurate name.
+const LOCK_FILE: &str = "commit.lock";
+
+/// The lock is held by another process.
+#[derive(Debug)]
+pub struct Busy {
+    pub lock_path: std::path::PathBuf,
+}
+
+#[derive(Debug)]
+pub enum LockError {
+    Busy(Busy),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for LockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LockError::Busy(busy) => write!(
+                f,
+                "another operation is already running on this repository \
+                 (lock held at {}); retry once it finishes",
+                busy.lock_path.display()
+            ),
+            LockError::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+/// Held for the duration of one repository-mutating operation.
+///
+/// Released on drop via explicit `unlock`; if the process is killed the kernel
+/// releases the `flock` when the descriptor closes, so a crash never wedges the
+/// repository.
+#[derive(Debug)]
+pub struct RepoLock {
+    file: File,
+}
+
+impl RepoLock {
+    fn open(repo_path: &Path) -> Result<(File, std::path::PathBuf), LockError> {
+        let gfs_dir = repo_path.join(GFS_DIR);
+        std::fs::create_dir_all(&gfs_dir).map_err(LockError::Io)?;
+        let lock_path = gfs_dir.join(LOCK_FILE);
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(LockError::Io)?;
+        Ok((file, lock_path))
+    }
+
+    /// Take the lock, or fail immediately if someone else holds it.
+    ///
+    /// What commit does. Queueing a commit behind another commit is not useful:
+    /// by the time the first finishes, the second would snapshot a state the
+    /// first already captured, so failing loudly is the more honest answer.
+    pub fn try_acquire(repo_path: &Path) -> Result<Self, LockError> {
+        let (file, lock_path) = Self::open(repo_path)?;
+        match file.try_lock() {
+            Ok(()) => Ok(Self { file }),
+            Err(std::fs::TryLockError::WouldBlock) => Err(LockError::Busy(Busy { lock_path })),
+            Err(std::fs::TryLockError::Error(e)) => Err(LockError::Io(e)),
+        }
+    }
+
+    /// Take the lock, waiting up to `timeout` for whoever holds it.
+    ///
+    /// What checkout does, and the difference from `try_acquire` is deliberate.
+    /// A commit is the long operation, and a user who asks to switch branches
+    /// while one is running wants the switch, not an error telling them to run
+    /// it again in a minute. The wait is bounded rather than indefinite so a
+    /// long-lived daemon cannot be parked forever by a stuck commit.
+    pub fn acquire_waiting(repo_path: &Path, timeout: Duration) -> Result<Self, LockError> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match Self::try_acquire(repo_path) {
+                Err(LockError::Busy(busy)) if Instant::now() < deadline => {
+                    let _ = busy;
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                other => return other,
+            }
+        }
+    }
+}
+
+impl Drop for RepoLock {
+    fn drop(&mut self) {
+        // Best-effort: the kernel releases it on close regardless.
+        let _ = self.file.unlock();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_second_holder_is_refused_while_the_first_lives() {
+        let dir = tempfile::tempdir().unwrap();
+        let _first = RepoLock::try_acquire(dir.path()).expect("first acquire");
+        assert!(
+            matches!(RepoLock::try_acquire(dir.path()), Err(LockError::Busy(_))),
+            "a second holder must not get in"
+        );
+    }
+
+    #[test]
+    fn the_lock_is_available_again_after_the_holder_drops() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _first = RepoLock::try_acquire(dir.path()).unwrap();
+        }
+        RepoLock::try_acquire(dir.path()).expect("released on drop");
+    }
+
+    #[test]
+    fn waiting_gives_up_rather_than_hanging() {
+        let dir = tempfile::tempdir().unwrap();
+        let _held = RepoLock::try_acquire(dir.path()).unwrap();
+        let started = Instant::now();
+        let result = RepoLock::acquire_waiting(dir.path(), Duration::from_millis(120));
+        assert!(matches!(result, Err(LockError::Busy(_))));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the wait must be bounded: took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn waiting_succeeds_once_the_holder_lets_go() {
+        let dir = tempfile::tempdir().unwrap();
+        let held = RepoLock::try_acquire(dir.path()).unwrap();
+        let path = dir.path().to_path_buf();
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(80));
+            drop(held);
+        });
+        RepoLock::acquire_waiting(&path, Duration::from_secs(5)).expect("should get it");
+        releaser.join().unwrap();
+    }
+}

--- a/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/checkout_repo_usecase.rs
@@ -17,6 +17,7 @@ use crate::ports::compute::{
 use crate::ports::database_provider::DatabaseProviderRegistry;
 use crate::ports::repository::{Repository, RepositoryError};
 use crate::repo_utils::repo_layout;
+use crate::repo_utils::repo_lock::{LockError, RepoLock};
 #[cfg(unix)]
 use crate::utils::current_user;
 use crate::utils::data_dir;
@@ -32,7 +33,16 @@ pub enum CheckoutRepoError {
 
     #[error("compute: {0}")]
     Compute(#[from] ComputeError),
+
+    #[error("{0}")]
+    Busy(String),
 }
+
+/// How long a checkout waits for a running commit before giving up.
+///
+/// Long enough for a snapshot of a realistic database, short enough that a
+/// daemon is not parked indefinitely by a commit that has wedged.
+const LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(120);
 
 // ---------------------------------------------------------------------------
 // Use case
@@ -73,6 +83,25 @@ impl<R: DatabaseProviderRegistry> CheckoutRepoUseCase<R> {
         create_branch: Option<String>,
     ) -> std::result::Result<String, CheckoutRepoError> {
         let revision = revision.trim().to_string();
+
+        // Serialised against commit. A commit reads HEAD's commit as its parent
+        // BEFORE the snapshot and reads HEAD's branch AFTER it, so a checkout
+        // landing in between makes the commit advance the branch it moved TO,
+        // with a parent from the branch it moved FROM — and that branch's
+        // previous tip becomes unreachable from any ref. Reproduced four times
+        // out of four; see repo_utils::repo_lock.
+        //
+        // Waits rather than fails: the commit is the long operation, and a user
+        // switching branches during one wants the switch, not an error.
+        let _repo_lock = RepoLock::acquire_waiting(&path, LOCK_WAIT).map_err(|e| match e {
+            LockError::Busy(_) => CheckoutRepoError::Busy(format!(
+                "a `gfs commit` has been running on this repository for over {} seconds; \
+                 checkout would interleave with it and lose a commit, so it is not started. \
+                 Retry once the commit finishes",
+                LOCK_WAIT.as_secs()
+            )),
+            LockError::Io(e) => CheckoutRepoError::Repository(RepositoryError::Io(e)),
+        })?;
 
         // Validate the target ref BEFORE stopping compute — a bad revision must
         // not leave the database offline (mirrors the k8s checkout path).

--- a/crates/domain/src/usecases/repository/commit_repo_usecase.rs
+++ b/crates/domain/src/usecases/repository/commit_repo_usecase.rs
@@ -1,4 +1,3 @@
-use std::fs::{File, OpenOptions, TryLockError};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -8,12 +7,12 @@ use thiserror::Error;
 
 use crate::model::commit::NewCommit;
 use crate::model::config::{EnvironmentConfig, GlobalSettings, RuntimeConfig};
-use crate::model::layout::GFS_DIR;
 use crate::ports::compute::{Compute, ComputeError, InstanceId, InstanceState};
 use crate::ports::database_provider::{ConnectionParams, DatabaseProviderRegistry};
 use crate::ports::repository::{Repository, RepositoryError};
 use crate::ports::storage::{SnapshotOptions, StorageError, StoragePort, VolumeId};
 use crate::repo_utils::repo_layout;
+use crate::repo_utils::repo_lock::{LockError, RepoLock};
 use crate::usecases::repository::extract_schema_usecase::ExtractSchemaUseCase;
 use crate::utils::hash::hash_snapshot;
 
@@ -93,61 +92,6 @@ impl Drop for UnpauseGuard {
                 }
             });
         }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Per-repo commit lock
-// ---------------------------------------------------------------------------
-
-/// Exclusive advisory lock on `<repo>/.gfs/commit.lock`, held for the duration
-/// of a single `CommitRepoUseCase::run` invocation.
-///
-/// Prevents two concurrent `gfs commit` processes on the same repository from
-/// racing pause/unpause, writing overlapping snapshot directories, or
-/// advancing the branch ref with the same parent — any of which can produce
-/// orphan snapshots or lost commits.
-///
-/// Uses `std::fs::File::try_lock` (stable since Rust 1.89) for a non-blocking
-/// POSIX `flock`. Lock is released on Drop via explicit `unlock`; if the
-/// process is killed, the kernel releases the flock on FD close so a crashed
-/// commit never wedges future commits.
-struct CommitLock {
-    file: File,
-}
-
-impl CommitLock {
-    fn acquire(repo_path: &Path) -> std::result::Result<Self, CommitRepoError> {
-        let gfs_dir = repo_path.join(GFS_DIR);
-        std::fs::create_dir_all(&gfs_dir)
-            .map_err(|e| CommitRepoError::Repository(RepositoryError::Io(e)))?;
-        let lock_path = gfs_dir.join("commit.lock");
-
-        let file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&lock_path)
-            .map_err(|e| CommitRepoError::Repository(RepositoryError::Io(e)))?;
-
-        match file.try_lock() {
-            Ok(()) => Ok(Self { file }),
-            Err(TryLockError::WouldBlock) => Err(CommitRepoError::Repository(
-                RepositoryError::Internal(format!(
-                    "another `gfs commit` is already running on this repository \
-                     (lock held at {}); retry once it finishes",
-                    lock_path.display()
-                )),
-            )),
-            Err(TryLockError::Error(e)) => Err(CommitRepoError::Repository(RepositoryError::Io(e))),
-        }
-    }
-}
-
-impl Drop for CommitLock {
-    fn drop(&mut self) {
-        // Best-effort: kernel will release on FD close regardless.
-        let _ = self.file.unlock();
     }
 }
 
@@ -236,39 +180,6 @@ mod unfrozen_snapshot_flag_tests {
     }
 }
 
-#[cfg(test)]
-mod commit_lock_tests {
-    use super::{CommitLock, CommitRepoError};
-    use crate::ports::repository::RepositoryError;
-
-    #[test]
-    fn second_acquire_reports_contention() {
-        let dir = tempfile::tempdir().unwrap();
-        let _first = CommitLock::acquire(dir.path()).expect("first acquire should succeed");
-
-        let second = CommitLock::acquire(dir.path());
-        match second {
-            Err(CommitRepoError::Repository(RepositoryError::Internal(msg))) => {
-                assert!(
-                    msg.contains("another `gfs commit` is already running"),
-                    "unexpected message: {msg}"
-                );
-            }
-            Err(e) => panic!("expected Internal contention error, got {e:?}"),
-            Ok(_) => panic!("expected contention error, but second acquire succeeded"),
-        }
-    }
-
-    #[test]
-    fn acquire_succeeds_after_drop() {
-        let dir = tempfile::tempdir().unwrap();
-        {
-            let _first = CommitLock::acquire(dir.path()).unwrap();
-        }
-        let _second = CommitLock::acquire(dir.path()).expect("lock should be released after drop");
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Use case
 // ---------------------------------------------------------------------------
@@ -330,7 +241,19 @@ impl<R: DatabaseProviderRegistry> CommitRepoUseCase<R> {
 
         // Serialize commits per repository. Held until this function returns,
         // covering pause, snapshot, finalize, and ref advance.
-        let _commit_lock = CommitLock::acquire(&path)?;
+        // Fail fast rather than wait: a second commit would snapshot a state the
+        // first has already captured, so queueing it produces a redundant commit
+        // rather than a useful one. Checkout waits instead — see repo_lock.
+        let _repo_lock = RepoLock::try_acquire(&path).map_err(|e| match e {
+            LockError::Busy(busy) => {
+                CommitRepoError::Repository(RepositoryError::Internal(format!(
+                    "another `gfs commit` is already running on this repository \
+                     (lock held at {}); retry once it finishes",
+                    busy.lock_path.display()
+                )))
+            }
+            LockError::Io(e) => CommitRepoError::Repository(RepositoryError::Io(e)),
+        })?;
 
         // 1. Resolve commit context from the repository.
         let parent_commit_id = self.repository.get_current_commit_id(&path).await?;

--- a/scripts/gfs-commit-checkout-race.py
+++ b/scripts/gfs-commit-checkout-race.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Try to make a concurrent commit and checkout lose a commit.
+
+Usage: gfs-commit-checkout-race.py <repo> <gfs-binary> <rounds> [delay-seconds]
+
+`<repo>` must be an initialised GFS repo with two branches, `main` and `other`,
+each with at least one commit. `delay-seconds` (default 0.05) is how long after
+the commit starts the checkout is launched.
+
+WHAT IT LOOKS FOR. A commit reads HEAD's commit as its new commit's PARENT
+before taking the snapshot, and reads HEAD's BRANCH after, when it advances the
+ref. Checkout writes HEAD in between. The result is a commit parented on the
+branch checkout moved away FROM, written onto the branch it moved TO — so that
+branch's previous tip stops being reachable from any ref. Both commands report
+success.
+
+Three checks run each round:
+
+  lost         a branch tip no longer reaches a commit it reached before;
+  mismatch     a commit's snapshot holds the other branch's data, read from a
+               `marker(branch TEXT)` table when the workspace has one;
+  inconsistent HEAD names one branch while .gfs/WORKSPACE points into another.
+
+MAKING IT REPRODUCE. The window is the snapshot copy, so the workspace has to
+be big enough for that to take real time — a few thousand files is enough; with
+a 0.5-second commit this reproduced four times out of four.
+
+A workspace holding a live SQLite database is partly protected by accident:
+checkout quiesces the database first, and that `BEGIN IMMEDIATE` blocks on the
+write lock the commit's snapshot guard holds (measured at 550 ms against 34 ms
+unobstructed). That protection is not a fix — it does not exist before the
+first write, does not cover container-backed providers, and does not cover the
+window before the guard is taken — so to see the race, use a workspace with
+files but no database.
+
+Exits 0 when nothing went wrong, and reports how many rounds actually ran the
+two commands concurrently to success: a run where they never overlapped proves
+nothing.
+"""
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+
+if len(sys.argv) < 4:
+    sys.exit(__doc__)
+repo, gfs, rounds = sys.argv[1], sys.argv[2], int(sys.argv[3])
+DELAY = float(sys.argv[4]) if len(sys.argv) > 4 else 0.05
+
+OBJ = os.path.join(repo, ".gfs", "objects")
+HEADS = os.path.join(repo, ".gfs", "refs", "heads")
+
+
+def run(*args):
+    return subprocess.run([gfs, *args], cwd=repo, capture_output=True, text=True)
+
+
+def load(commit_hash):
+    try:
+        with open(os.path.join(OBJ, commit_hash[:2], commit_hash[2:])) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return None
+
+
+def commits():
+    found = {}
+    for prefix in os.listdir(OBJ):
+        directory = os.path.join(OBJ, prefix)
+        if not os.path.isdir(directory):
+            continue
+        for rest in os.listdir(directory):
+            obj = load(prefix + rest)
+            if obj and "snapshot_hash" in obj:
+                found[prefix + rest] = obj
+    return found
+
+
+def reachable(tip):
+    seen, stack = set(), [tip]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        obj = load(current)
+        if obj:
+            stack.extend(obj.get("parents") or [])
+    return seen
+
+
+def marker(directory):
+    """Which branch's data is here, per the optional `marker` table."""
+    db = os.path.join(directory, "db.sqlite")
+    if not os.path.exists(db):
+        return None
+    conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    try:
+        return conn.execute("SELECT branch FROM marker LIMIT 1").fetchone()[0]
+    except Exception:
+        return None
+    finally:
+        conn.close()
+
+
+def snapshot_dir(obj):
+    h = obj["snapshot_hash"]
+    return os.path.join(repo, ".gfs", "snapshots", h[:2], h[2:])
+
+
+def head_name():
+    head = open(os.path.join(repo, ".gfs", "HEAD")).read().strip()
+    return head.rsplit("/", 1)[-1] if head.startswith("ref:") else "detached"
+
+
+def workspace_branch():
+    parts = open(os.path.join(repo, ".gfs", "WORKSPACE")).read().strip().split(os.sep)
+    return parts[parts.index("workspaces") + 1] if "workspaces" in parts else None
+
+
+def tips():
+    return {n: open(os.path.join(HEADS, n)).read().strip() for n in os.listdir(HEADS)}
+
+
+known = set(commits())
+before = {name: reachable(tip) for name, tip in tips().items()}
+lost, mismatched, inconsistent, concurrent = [], [], [], 0
+
+for i in range(rounds):
+    source, target = ("main", "other") if i % 2 == 0 else ("other", "main")
+    run("checkout", source)
+    results = {}
+
+    def do_commit():
+        results["commit"] = run("commit", "-m", f"race{i}")
+
+    def do_checkout():
+        time.sleep(DELAY)
+        results["checkout"] = run("checkout", target)
+
+    threads = [threading.Thread(target=do_commit), threading.Thread(target=do_checkout)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    if results["commit"].returncode == 0 and results["checkout"].returncode == 0:
+        concurrent += 1
+
+    head, workspace = head_name(), workspace_branch()
+    if head != "detached" and workspace and head != workspace:
+        inconsistent.append(i)
+        print(f"  INCONSISTENT round {i}: HEAD is '{head}' but WORKSPACE is in '{workspace}'")
+
+    now = {name: reachable(tip) for name, tip in tips().items()}
+    for name, was in before.items():
+        dropped = was - now.get(name, set())
+        if dropped:
+            lost.append((i, name, sorted(dropped)[0]))
+            print(f"  LOST round {i}: branch '{name}' no longer reaches {sorted(dropped)[0][:8]}")
+    before = now
+
+    for commit_hash, obj in commits().items():
+        if commit_hash in known:
+            continue
+        known.add(commit_hash)
+        owners = [n for n, reach in now.items() if commit_hash in reach]
+        if len(owners) != 1:
+            continue
+        held = marker(snapshot_dir(obj))
+        if held and held != owners[0]:
+            mismatched.append((commit_hash, owners[0], held))
+            print(f"  MISMATCH commit {commit_hash[:8]} on '{owners[0]}' holds '{held}' data")
+
+print(f"  {concurrent}/{rounds} rounds ran commit and checkout concurrently to success")
+print(f"  RESULT: {len(lost)} lost, {len(mismatched)} mismatched, {len(inconsistent)} inconsistent")
+if lost or mismatched or inconsistent:
+    sys.exit(1)
+if concurrent == 0:
+    print("  INCONCLUSIVE: the two commands never overlapped")
+    sys.exit(2)


### PR DESCRIPTION
## The race

`commit` reads HEAD twice and does different things with each read:

```
1. reads HEAD's commit  -> becomes the new commit's PARENT   (before the snapshot)
2. copies the workspace -> takes as long as the data is large
3. reads HEAD's branch  -> the ref it advances               (after the snapshot)
```

`checkout` writes HEAD, and takes no lock at all. Land it between steps 1 and 3 and the result is a commit parented on the branch checkout moved away *from*, written onto the branch it moved *to* — so that branch's previous tip stops being reachable from any ref. Both commands report success and nothing warns.

`commit` does hold a lock today, but it is a **private struct inside `commit_repo_usecase.rs`**, so it only ever protects one commit from another. On `main`, `CommitLock` appears in exactly one file, and `checkout`, `clone`, `import` and `export` reference no lock at all.

## Reproduced, not argued

A workspace of 2500 × 30 KB files makes the snapshot copy take about 450 ms; the checkout is launched partway in. **Fresh repository per run**, six rounds each:

| delay | before | after |
|---|---|---|
| 0.05s | **1 lost** | 0 lost |
| 0.15s | **1 lost** | 0 lost |
| 0.25s | **1 lost** | 0 lost |

After the fix, 6/6 rounds at every delay still ran commit and checkout **concurrently to success** — they are serialised, not refused.

**The reproduction needs a fresh repository each run.** My first attempt reused one: run 1 lost a commit, runs 2 and 3 lost nothing, which reads exactly like an intermittent bug that the fix cured. It was not — runs 2 and 3 did not reproduce on the *unfixed* build either, because run 1 had already destroyed the topology the check compares against. Two runs were discarded to that before the protocol was corrected. `scripts/gfs-commit-checkout-race.py` and the commit message both say so, so the next person does not lose the same two runs.

## The fix

`CommitLock` becomes `repo_utils::repo_lock::RepoLock`, taken by both commands:

- **commit** uses `try_acquire` and fails fast. A second commit would snapshot a state the first has already captured, so queueing it produces a redundant commit rather than a useful one.
- **checkout** uses `acquire_waiting` with a two-minute cap. The commit is the long operation, and a user switching branches during one wants the switch, not an error. The cap stops a daemon being parked by a commit that has wedged.

The lock file keeps its `commit.lock` name. Renaming it would let an old `gfs commit` and a new `gfs checkout` lock different files, which is worse than an inaccurate name.

## Why this is its own PR

It was written inside the SQLite branch (#148), where it sits behind +6499/−1412 of unrelated work and would be reviewed last. Three separate things need this primitive: a ref-update choke point, a future `gfs gc` (which must not run while a commit is between "snapshot written" and "object written"), and #148's own concurrency half.

**#148 has been rebased to drop its copy**, so the two no longer collide and #148 depends on this landing to regain protection against a checkout interleaving with a commit.

## An accidental partial protection, which is not a fix

An embedded provider is partly protected by luck, which is why this needs a database-less workspace to demonstrate. Checkout quiesces the database first, and that `BEGIN IMMEDIATE` blocks on the write lock the commit's snapshot guard already holds — measured at 550 ms against 34 ms unobstructed. It is not a fix: absent before the first write, absent for container-backed providers, and it leaves the window between the commit reading its parent and acquiring the guard.

## Scope

`clone`, `import` and `export` still take no lock. Extending the same primitive to them, and to a collector, is now a matter of calling it.

## Verification

Rebased onto current `main` (`f6f3eac`) with no conflicts. 255 domain tests including 4 new for the lock itself, `cargo fmt` clean, `cargo clippy --all-targets -- -D warnings` clean.