### PR TITLE
fix(refs): refuse an existing ref at the write, not with a predicate

### DIFF
--- a/crates/applications/cli/src/commands/cmd_branch.rs
+++ b/crates/applications/cli/src/commands/cmd_branch.rs
@@ -167,10 +167,10 @@ async fn create_branch(
                 .map_err(|e| anyhow::anyhow!("failed to get HEAD: {e}"))?
         };
 
-        // Check if branch already exists.
-        if repo_layout::is_branch(repo_path, name) {
-            anyhow::bail!("branch '{}' already exists", name);
-        }
+        // No pre-check here. `create_branch` refuses an existing ref at the open
+        // itself, so asking first only adds a second answer to the same question
+        // -- two different messages for one condition, and a window between the
+        // question and the write in which the answer can stop being true.
 
         // Write the ref file.
         let repository: Arc<dyn Repository> = Arc::new(GfsRepository::new());
@@ -218,9 +218,14 @@ fn delete_branch(repo_path: &std::path::Path, name: &str, json_output: bool) -> 
     }
 
     let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
-    let ref_path = refs_dir.join(name);
+    let ref_path =
+        repo_layout::branch_ref_path(repo_path, name).map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    if !ref_path.exists() {
+    // `symlink_metadata`, not `exists()`: the latter follows the link, so a ref
+    // that is a dangling symlink reported "not found" and could not be deleted --
+    // while `create_branch` refused the same name as taken. Uncreatable and
+    // undeletable at once.
+    if std::fs::symlink_metadata(&ref_path).is_err() {
         anyhow::bail!("branch '{}' not found", name);
     }
 

--- a/crates/domain/src/adapters/gfs_repository.rs
+++ b/crates/domain/src/adapters/gfs_repository.rs
@@ -664,14 +664,28 @@ impl Repository for GfsRepository {
                 "(empty branch name)".to_string(),
             ));
         }
-        if repo_layout::is_branch(repo, name) {
-            return Err(RepositoryError::BranchAlreadyExists(name.to_string()));
-        }
-        let ref_path = repo.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR).join(name);
+        let ref_path = repo_layout::branch_ref_path(repo, name).map_err(map_err)?;
         if let Some(parent) = ref_path.parent() {
             fs::create_dir_all(parent).map_err(RepositoryError::Io)?;
         }
-        fs::write(&ref_path, commit_hash).map_err(RepositoryError::Io)?;
+        // `create_new`, not a predicate then a write: `exists()` is false both for
+        // "no such ref" and for "could not stat it", so an unreadable ref read as a
+        // free name and its tip was replaced. Losing a ref costs the branch *name* --
+        // the commits stay findable via `find_commits_by_prefix`.
+        use std::io::Write;
+        let mut f = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&ref_path)
+        {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(RepositoryError::BranchAlreadyExists(name.to_string()));
+            }
+            Err(e) => return Err(RepositoryError::Io(e)),
+        };
+        f.write_all(commit_hash.as_bytes())
+            .map_err(RepositoryError::Io)?;
         Ok(())
     }
 
@@ -914,6 +928,63 @@ description = "test"
         assert_eq!(commit.snapshot_hash, "snap-json");
         assert_eq!(commit.author, "alice");
         assert_eq!(commit.hash, Some(hash));
+    }
+
+    /// Needs a ref whose `stat` fails but whose bytes are writable -- the state a
+    /// predicate cannot see. macOS `deny readattr` gives it; there is no portable
+    /// equivalent, since removing +x from the parent blocks the write too and both
+    /// shapes then error alike. Skips rather than reporting a pass it did not earn.
+    ///
+    /// A healthy repository does not work here: a predicate also refuses there.
+    #[tokio::test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "needs macOS ACLs")]
+    async fn a_ref_whose_stat_fails_is_not_overwritten() {
+        let temp = setup_repo();
+        let repo = temp.path();
+        let repository = GfsRepository::new();
+
+        let tip = "a".repeat(64);
+        repository.create_branch(repo, "feat", &tip).await.unwrap();
+        let ref_path = repo
+            .join(GFS_DIR)
+            .join(REFS_DIR)
+            .join(HEADS_DIR)
+            .join("feat");
+
+        let user = String::from_utf8(
+            std::process::Command::new("/usr/bin/id")
+                .arg("-un")
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap();
+        let acl = std::process::Command::new("/bin/chmod")
+            .args(["+a", &format!("{} deny readattr", user.trim())])
+            .arg(&ref_path)
+            .status();
+        if !matches!(acl, Ok(st) if st.success()) || std::fs::metadata(&ref_path).is_ok() {
+            eprintln!("SKIP: could not make the ref unstat-able; nothing exercised");
+            return;
+        }
+
+        let err = repository
+            .create_branch(repo, "feat", &"b".repeat(64))
+            .await;
+        let _ = std::process::Command::new("/bin/chmod")
+            .arg("-N")
+            .arg(&ref_path)
+            .status();
+
+        assert!(
+            err.is_err(),
+            "an existing ref must not be replaced: {err:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&ref_path).unwrap(),
+            tip,
+            "the tip must be exactly as it was"
+        );
     }
 
     #[tokio::test]

--- a/crates/domain/src/repo_utils/repo_layout.rs
+++ b/crates/domain/src/repo_utils/repo_layout.rs
@@ -101,7 +101,6 @@ pub fn init_repo_layout(working_dir: &Path, mount_point: Option<String>) -> Resu
     let snapshots_dir = gfs_dir.join(SNAPSHOTS_DIR);
     fs::create_dir_all(&snapshots_dir).map_err(RepoError::from)?;
 
-    // Create HEAD file
     let head_content = format!("ref: {}/{}/{}", REFS_DIR, HEADS_DIR, MAIN_BRANCH);
     fs::write(gfs_dir.join(HEAD_FILE), head_content).map_err(RepoError::from)?;
 
@@ -526,6 +525,14 @@ pub fn get_commit_from_hash(repo_path: &Path, commit_hash: &str) -> Result<Commi
     tracing::trace!("Getting commit from hash {}", commit_hash);
 
     let objects_dir = repo_path.join(GFS_DIR).join(OBJECTS_DIR);
+    // Reached with whatever a ref file holds, and a one-byte ref is what a crash
+    // during a ref write leaves, so this panicked on a damaged repository.
+    if !commit_hash.is_char_boundary(2) {
+        return Err(RepoError::invalid_layout(format!(
+            "'{}' is not a commit hash",
+            commit_hash.escape_debug()
+        )));
+    }
     let (dir_part, file_part) = commit_hash.split_at(2);
     let object_path = objects_dir.join(dir_part).join(file_part);
     let commit_json = fs::read_to_string(object_path).map_err(RepoError::from)?;
@@ -724,13 +731,87 @@ pub fn get_snapshot_from_commit(repo_path: &Path, commit_hash: &str) -> Result<S
     Ok(commit.snapshot_hash)
 }
 
+/// The path of a branch ref, or an error if the name would not stay inside
+/// `refs/heads`.
+///
+/// `Path::join` discards the prefix when the argument is absolute, so
+/// `refs_dir.join("/tmp/x")` is `/tmp/x`: a branch name could name any writable
+/// path on the machine, and `gfs branch /tmp/x` created a file there and reported
+/// success. `..` walks out the same way, landing in `.gfs/` itself.
+///
+/// Every caller that turns a branch name into a path goes through here, so the
+/// check cannot be bypassed by adding another one.
+pub fn branch_ref_path(repo_path: &Path, name: &str) -> Result<PathBuf, RepoError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(RepoError::invalid_layout(
+            "branch name is empty".to_string(),
+        ));
+    }
+    let bad = Path::new(trimmed)
+        .components()
+        .any(|c| !matches!(c, std::path::Component::Normal(_)));
+    if bad {
+        return Err(RepoError::invalid_layout(format!(
+            "branch name '{}' must not be absolute or contain '..'",
+            trimmed.escape_debug()
+        )));
+    }
+    let heads = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
+    let candidate = heads.join(trimmed);
+
+    // Rejecting `..` and absolute names is not enough on its own: a symlink
+    // *already inside* refs/heads walks out just as well, and `sub/x` with
+    // `sub -> /tmp` wrote /tmp/x and reported success. Component checks cannot
+    // see that, because the escape is on disk rather than in the name.
+    //
+    // So resolve the nearest existing ancestor and require it to be under a
+    // resolved refs/heads. Canonicalising follows symlinks, which is the point:
+    // if the answer lands outside, the name is refused whatever it looked like.
+    let anchor = heads.canonicalize().unwrap_or_else(|_| heads.clone());
+    let mut existing = candidate.as_path();
+    let resolved = loop {
+        match existing.parent() {
+            Some(parent) => {
+                if let Ok(c) = parent.canonicalize() {
+                    break c;
+                }
+                existing = parent;
+            }
+            None => break anchor.clone(),
+        }
+    };
+    if !resolved.starts_with(&anchor) {
+        return Err(RepoError::invalid_layout(format!(
+            "branch name '{}' resolves outside refs/heads",
+            trimmed.escape_debug()
+        )));
+    }
+    Ok(candidate)
+}
+
+/// Whether `branch_name` names an existing ref.
+///
+/// Plain, deliberately: `rev_parse` and the error messages read this too, so
+/// resolving an unstat-able ref as "taken" would make a 300-character name report
+/// "already exists" rather than "File name too long", and would break `checkout
+/// <full-hash>` on a damaged `refs/heads` -- when recovery by hash is what you
+/// need. `create_branch` guards the overwrite at the write instead.
 pub fn is_branch(repo_path: &Path, branch_name: &str) -> bool {
     let refs_dir = repo_path.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
     let branch_path = refs_dir.join(branch_name);
     branch_path.exists()
 }
 
+/// Whether `commit_hash` names a stored object.
+///
+/// Plain, for the same reason as [`is_branch`]. The guard is against a panic, not
+/// a policy: `split_at(2)` panics below two bytes and when byte 2 falls inside a
+/// character (`"€"` is three bytes), and this is `pub`.
 pub fn is_commit(repo_path: &Path, commit_hash: &str) -> bool {
+    if !commit_hash.is_char_boundary(2) {
+        return false;
+    }
     let objects_dir = repo_path.join(GFS_DIR).join(OBJECTS_DIR);
     let (dir_part, file_part) = commit_hash.split_at(2);
     let object_path = objects_dir.join(dir_part).join(file_part);
@@ -1389,6 +1470,90 @@ name = "test-repo"
         // Now "develop" should exist
         let now_exists = is_branch(&repo_dir, "develop");
         assert!(now_exists);
+    }
+
+    /// `split_at(2)` panics below two bytes and also when byte 2 lands inside a
+    /// character -- `"€"` is three bytes and splits in the middle of one, so a
+    /// byte-length check alone does not cover it. `is_commit` is `pub`.
+    #[test]
+    fn is_commit_does_not_panic_on_a_hash_that_cannot_be_sharded() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        init_repo_layout(&repo_dir, None).unwrap();
+
+        for bad in ["", "a", "\u{20ac}", "\u{20ac}abc"] {
+            assert!(!is_commit(&repo_dir, bad), "{bad:?} must not shard");
+        }
+        assert!(
+            !is_commit(&repo_dir, &"c".repeat(64)),
+            "well-formed but absent"
+        );
+    }
+
+    /// `Path::join` discards the prefix when the argument is absolute, so a branch
+    /// name could name any writable path on the machine: `gfs branch /tmp/x` wrote
+    /// a file there and reported success. `..` walks out the same way.
+    #[test]
+    fn a_branch_name_cannot_escape_refs_heads() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        init_repo_layout(&repo_dir, None).unwrap();
+
+        for bad in ["/tmp/escaped", "../../traversed", "..", "a/../../b", ""] {
+            assert!(
+                branch_ref_path(&repo_dir, bad).is_err(),
+                "{bad:?} must be refused"
+            );
+        }
+        for good in ["feat", "team/alpha", "a.b", "1234"] {
+            let p = branch_ref_path(&repo_dir, good).unwrap();
+            assert!(
+                p.starts_with(repo_dir.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR)),
+                "{good:?} must stay inside refs/heads, got {p:?}"
+            );
+        }
+    }
+
+    /// Rejecting `..` and absolute names is not enough: a symlink already inside
+    /// `refs/heads` escapes just as well, and the name that does it looks
+    /// entirely ordinary. `sub/x` with `sub -> /tmp` wrote `/tmp/x` and reported
+    /// success -- on both platforms, and on the base build too.
+    #[test]
+    fn a_symlinked_component_inside_refs_heads_cannot_escape() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        init_repo_layout(&repo_dir, None).unwrap();
+
+        let outside = TempDir::new().unwrap();
+        let heads = repo_dir.join(GFS_DIR).join(REFS_DIR).join(HEADS_DIR);
+        std::os::unix::fs::symlink(outside.path(), heads.join("sub")).unwrap();
+
+        assert!(
+            branch_ref_path(&repo_dir, "sub/x").is_err(),
+            "a name whose parent resolves outside refs/heads must be refused"
+        );
+        // A real nested branch must still work, or the check is just a ban on '/'.
+        std::fs::create_dir_all(heads.join("team")).unwrap();
+        assert!(branch_ref_path(&repo_dir, "team/alpha").is_ok());
+    }
+
+    /// `get_commit_from_hash` shards with `split_at(2)`, which panics below two
+    /// bytes and when byte 2 falls inside a character. It is reached with whatever
+    /// a ref file holds, and a one-byte ref is what a crash during a ref write
+    /// leaves, so `gfs log` panicked on a damaged repository rather than reporting
+    /// it.
+    #[test]
+    fn a_ref_too_short_to_shard_is_an_error_not_a_panic() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        init_repo_layout(&repo_dir, None).unwrap();
+
+        for bad in ["x", "", "\u{20ac}"] {
+            assert!(
+                get_commit_from_hash(&repo_dir, bad).is_err(),
+                "{bad:?} must error rather than panic"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The problem

`create_branch` asked `is_branch` whether a name was free and then wrote the ref:

```rust
if repo_layout::is_branch(repo, name) {
    return Err(RepositoryError::BranchAlreadyExists(name.to_string()));
}
fs::write(&ref_path, commit_hash)?;
```

Two faults, and the mundane one is worse.

**Concurrency.** Every racing caller sees "free", every one writes, the last lands. Twelve concurrent creators of one name, ten rounds, against a build of the base commit: 28 successes, with lost writes in nine rounds out of ten. With this change, exactly one wins per round.

**Unreadable refs.** `Path::exists` returns false both for "no such ref" and for "could not stat it", so a ref the process cannot read is treated as a free name and its tip is replaced:

```
# blocks stat while leaving the bytes writable
chmod +a "$(id -un) deny readattr" .gfs/refs/heads/feat
gfs branch feat <some-other-commit>

# base: exits 0, "Created branch 'feat'", feat's tip is gone
# here: exits 1, "branch already exists: 'feat'", tip untouched
```

`checkout -b` on such a ref was worse: it destroyed the tip and *then* reported `revision not found`. A dangling-symlink ref was written through, creating a file outside `refs/heads` and reporting success.

## The change

The decision moves into the `open`. `create_new` has the kernel refuse an existing file, which closes the window between the question and the write and leaves every other failure its own errno — a name that is too long now says so instead of "already exists".

**A branch name could also name any writable path on the machine.** `Path::join` discards the prefix when the argument is absolute, so `gfs branch /tmp/x` created a file there and reported success; `..` walked out the same way into `.gfs/` itself. Both are pre-existing. `branch_ref_path` is now the single place a name becomes a path and refuses anything that would not stay inside `refs/heads`; the delete path shares it, and asks `symlink_metadata` rather than `exists`, so a dangling-symlink ref is no longer both uncreatable and undeletable.

`get_commit_from_hash` panicked when sharding a value that will not split at byte 2. It is reached with whatever a ref file holds, and a one-byte ref is what a crash during a ref write leaves — so `gfs log` panicked on a damaged repository instead of reporting it.

`cmd_branch` asked the same "does it exist" question a second time and answered it with a different string. Removed.

`is_branch` and `is_commit` stay plain predicates deliberately. They are read by `rev_parse` and by the error messages, not only by the write, so resolving an unreadable path as "present" would misreport more than it protects — a 300-character name would report "already exists" rather than "File name too long", and `checkout <full-hash>` would stop working on a repository whose `refs/heads` is damaged, which is when recovery by hash is what you need.

## Verification

Each claim run against a build of the base commit and against this branch, same harness, same machine:

| | base `f6f3eac` | this branch |
|---|---|---|
| unreadable ref: is the tip preserved? | **TIP LOST** | preserved |
| `checkout -b` onto an unreadable ref | **TIP LOST** | preserved |
| absolute branch name | **wrote outside the repo** | refused |
| `../..` traversal name | **escaped `refs/heads`** | refused |
| dangling-symlink ref: written through? | **wrote through the link** | refused |
| dangling-symlink ref: deletable? | **undeletable** | deleted |
| 1-byte ref: `gfs log` | **panic, rc=101** | clean error |
| symlinked component inside `refs/heads` | **wrote outside the repo** | refused |
| control: normal branch / checkout / delete | all ok | all ok |

### Also verified on Linux (Ubuntu 24.04, ext4, aarch64)

The macOS ACL that the unreadable-ref rows rely on has no Linux equivalent, so
that test skips there — and CI is ubuntu. The behaviour it protects is reachable
two other ways on Linux, and both were checked:

- **Concurrency**, which is the stronger case: 20 rounds x 25 processes creating
  one name gave the base **43 successes where 20 is ideal**, with multiple winners
  in 3 rounds; this branch gave exactly 20, none. With two distinct start points
  the base double-succeeded in 5 of 25 rounds — a silent lost update.
- **A dangling-symlink ref**, where `exists()` is false while `File::create`
  follows the link: the base wrote a ref outside the repository.

A barrier-synced "exactly one `rc=0`" check would be a portable stand-in for the
ACL test, and is worth adding if that matters to you.

Rejecting `..` and absolute names turned out not to be enough on its own: a
symlink *already inside* `refs/heads` escapes just as well, and the name that does
it (`sub/x`) looks entirely ordinary. That is now caught by resolving the nearest
existing ancestor rather than by inspecting the name — verified on both platforms.

The unreadable-ref rows need a ref whose `stat` fails while its bytes stay writable (`chmod +a "<user> deny readattr"`). Two earlier versions of that check silently proved nothing — `checkout -b feat` creates `feat` at main's commit, so overwriting it *with main's hash* is a no-op the comparison cannot see. The branch under test must point somewhere main does not, and the harness now asserts that precondition rather than assuming it.

Each new unit test also fails when the change it guards is reverted.

### Gates


Every failure mode above was reproduced against a build of the base commit and re-checked here. Each new test fails when the change it guards is reverted. The ACL test needs a ref whose `stat` fails but whose bytes are writable; there is no portable equivalent, since removing `+x` from the parent blocks the write too and both shapes then error alike, so it announces a skip where unavailable rather than reporting a pass it did not earn.

`cargo test -p gfs-domain` 257 pass · `clippy --all-targets -- -D warnings` clean · `fmt --check` clean.


