### PR TITLE
fix(cli): announce an error once, not twice

### DIFF
--- a/crates/applications/cli/src/main.rs
+++ b/crates/applications/cli/src/main.rs
@@ -60,6 +60,25 @@ async fn main() {
                     }))
                     .unwrap_or_else(|_| "{\"error\":{\"message\":\"serialization failed\"}}".into())
                 );
+            } else if let Some(parse) = err.downcast_ref::<clap::Error>().filter(|p| {
+                p.kind() != clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            }) {
+                // A parse failure already carries clap's own "error:", so
+                // prefixing it again printed "error: error: ...".
+                //
+                // `lib.rs` returns early for DisplayHelp and DisplayVersion, so
+                // every other kind arrives here -- including
+                // DisplayHelpOnMissingArgumentOrSubcommand (`gfs storage` with no
+                // subcommand), which renders bare help and carries no prefix at
+                // all. Deferring unconditionally would drop the "error:" line
+                // those commands owe.
+                //
+                // Match on the kind, not on the rendered text. `ErrorKind` is
+                // `#[non_exhaustive]` and grows additively, so a new kind costs
+                // one doubled prefix; clap's formatting carries no such guarantee,
+                // and a change to it would silently restore the doubling on every
+                // command at once.
+                let _ = parse.print();
             } else {
                 eprintln!("{} {err}", red("error:"));
             }

--- a/crates/applications/cli/tests/json_output.rs
+++ b/crates/applications/cli/tests/json_output.rs
@@ -14,6 +14,10 @@ fn run_gfs(cwd: &Path, args: &[&str]) -> (i32, String, String) {
         .args(args)
         // Keep stderr clean for --json contract assertions.
         .env("RUST_LOG", "off")
+        // And keep it uncoloured: clap writes ANSI when colour is forced, which
+        // would otherwise make an assertion on the start of a line pass or fail
+        // depending on the environment the suite is run from.
+        .env("NO_COLOR", "1")
         .output()
         .expect("failed to run gfs");
 
@@ -154,4 +158,48 @@ fn json_error_compute_logs_without_config_is_json() {
     assert_stderr_empty(&stderr);
     let v = assert_stdout_json(&stdout);
     assert!(v.get("error").is_some(), "expected error envelope");
+}
+
+/// Covers both error paths, which are not interchangeable: a parse failure is
+/// formatted by clap, a runtime failure keeps the prefix `main` adds, and neither
+/// may double it.
+#[test]
+fn an_error_is_announced_once() {
+    let tmp = TempDir::new().unwrap();
+
+    // Parse failure: `init` takes its path positionally, so `--path` is unknown.
+    let (code, _, stderr) = run_gfs(tmp.path(), &["init", "--path", "somewhere"]);
+    assert_eq!(code, 1, "a usage error still exits 1");
+    // Counting the substring would be wrong: a message like "internal error: ..."
+    // legitimately contains it. Only the prefix is under test.
+    let first = stderr.lines().next().unwrap_or_default();
+    assert!(
+        first.starts_with("error: ") && !first.starts_with("error: error:"),
+        "clap already says 'error:' once: {first}"
+    );
+    assert!(
+        stderr.contains("Usage:"),
+        "clap's usage block must survive: {stderr}"
+    );
+
+    // clap renders bare help for these and prefixes nothing, so a test covering
+    // only a mistyped flag would not notice the line going missing.
+    for bare in [vec![], vec!["storage"], vec!["schema"], vec!["user"]] {
+        let (code, _, stderr) = run_gfs(tmp.path(), &bare);
+        assert_eq!(code, 1, "`gfs {}` exits 1", bare.join(" "));
+        assert!(
+            stderr.lines().any(|l| l.starts_with("error: ")),
+            "`gfs {}` must still announce an error: {stderr}",
+            bare.join(" ")
+        );
+    }
+
+    // Runtime failure: a valid command against a directory that is not a repo.
+    let (code, _, stderr) = run_gfs(tmp.path(), &["status"]);
+    assert_eq!(code, 1);
+    let first = stderr.lines().next().unwrap_or_default();
+    assert!(
+        first.starts_with("error: ") && !first.starts_with("error: error:"),
+        "and main's own prefix is still applied exactly once: {first}"
+    );
 }


### PR DESCRIPTION
## The problem

Every mistyped command printed the prefix twice:

```
$ gfs init --path somewhere
error: error: unexpected argument '--path' found
```

For a parse failure clap renders its own `error:` prefix, a usage block and a did-you-mean tip. `lib.rs` converts that error into `anyhow` and `main.rs` then prefixed it a second time, so the doubling appeared on every subcommand and clap's formatting of the rest was flattened into a single `Display` string.

## The change

Parse failures print through clap, which is what already happens for `--help` and `--version`.

The filter on that arm is not decoration. `lib.rs` returns early only for `DisplayHelp` and `DisplayVersion`, so every other kind arrives here — including `DisplayHelpOnMissingArgumentOrSubcommand`, which `gfs`, `gfs storage`, `gfs schema`, `gfs compute`, `gfs proxy` and `gfs user` produce when given no subcommand, and which renders bare help carrying no prefix at all. Deferring unconditionally would drop the `error:` line from all six.

It matches on the **kind**, not on the rendered text. `ErrorKind` is `#[non_exhaustive]` and grows additively, so an unfamiliar kind costs one doubled prefix; clap's formatting carries no such guarantee, and a change to it would silently restore the doubling everywhere at once.

Runtime errors are untouched and keep the prefix `main` adds. `--json` is checked first, so a machine-readable caller still gets its error object rather than clap's text; that path is byte-identical to before.

One visible consequence beyond the prefix: clap honours a forced colour setting even when stderr is a pipe, where the previous path did not. That is what `CLICOLOR_FORCE` asks for, but it is a change.

## Verification

Every subcommand `--help` lists, run against a build of the base commit and against this branch:

| | base `f6f3eac` | this branch |
|---|---|---|
| doubled prefix on a bad flag | **29 / 29 subcommands** | 0 / 29 |
| bare subcommands byte-identical to base | — | 6 / 6 |
| bare subcommands missing `error:` | 0 | 0 |
| runtime errors byte-identical | — | 4 / 4 |
| `--json` paths byte-identical | — | 3 / 3 |
| usage block on a missing required arg | `Usage: gfs` | `Usage: gfs schema show <CO…` |

That last row is the second half of the fix: flattening clap's error into a `Display` string also truncated the usage line.

### Also verified on Linux (Ubuntu 24.04, ext4, aarch64)

The doubling reproduces on the base build there and is gone here; runtime errors
and the `--json` paths stay byte-identical. One further script-visible difference
shows up only on Linux, where `/dev/full` exists: stderr loses a trailing blank
line, so it goes from 8 lines to 7 and `2>&1 | tail -1` changes from empty to
`For more information, try '--help'.`

### Behavioural changes beyond the prefix

With stderr closed, a parse failure now exits **1** where the base exited **101** — the base panicked because `eprintln!` fails on a broken pipe, and clap's own writer does not. Arguably better, but it is a change and worth knowing.

Also: clap honours a forced colour setting even when stderr is a pipe, where the previous path did not. That is what `CLICOLOR_FORCE` asks for, but it too is a change.

### Gates


Compared against a build of the base commit: the doubling is gone from every subcommand, the six bare-subcommand cases are byte-identical to the base, and runtime errors and every `--json` path are byte-identical.

The test asserts the prefix rather than counting occurrences of `error:`, since a message like `internal error: ...` legitimately contains one. It covers the bare-subcommand cases, which are what the filter exists for, and fails both without the clap arm and with an unfiltered version of it. The shared test runner sets `NO_COLOR` so an assertion on the start of a line does not depend on the environment the suite is run from.

`cargo test -p gfs-cli --test json_output` 10 pass · `clippy --all-targets -- -D warnings` clean · `fmt --check` clean.


